### PR TITLE
chore(docs): enforce LF + normalize line endings

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+docs/**/*.md text eol=lf

--- a/docs/handbooks/templater-commands.md
+++ b/docs/handbooks/templater-commands.md
@@ -1,4 +1,4 @@
-﻿---
+---
 id: templater-commands
 title: Templater Commands (Canon v2)
 doc_type: handbook


### PR DESCRIPTION
## Summary
Enforces LF line endings for all documentation and normalizes existing files to UTF-8 (no BOM) + LF.

## Changes
1. **Added `.gitattributes`** with rule: `docs/**/*.md text eol=lf`
   - Ensures Git always uses LF for docs markdown files, regardless of platform
   - Prevents future CRLF/LF混 mixing issues

2. **Normalized 36 existing files** under `docs/`:
   - Converted all CRLF → LF
   - Stripped UTF-8 BOM (U+FEFF) where present
   - Removed leading whitespace before front-matter
   - All files now UTF-8 (no BOM) with LF endings

## Impact
- **No content changes** - only line ending normalization
- Validator passes: `validate_docs: OK`
- Files already on LF: 1 (docs/docs-readme.md)
- Files normalized: 36

## Rationale
Consistent line endings prevent spurious diffs, simplify cross-platform collaboration, and ensure the validator's front-matter parser works reliably (it already strips BOM/whitespace, but this prevents the issue at source).

🤖 Generated with [Claude Code](https://claude.com/claude-code)