### PR TITLE
docs: add spec-kitty template and pre-implementation prompt

### DIFF
--- a/docs/func-spec/_TEMPLATE_spec_kitty_input.md
+++ b/docs/func-spec/_TEMPLATE_spec_kitty_input.md
@@ -1,3 +1,9 @@
+---
+title: "TEMPLATE: Spec-Kitty Feature Specification Input"
+doc_type: reference
+status: approved
+---
+
 # TEMPLATE: Spec-Kitty Feature Specification Input
 
 **Version**: 1.0

--- a/docs/func-spec/claude-pre-implementation-prompt.md
+++ b/docs/func-spec/claude-pre-implementation-prompt.md
@@ -1,3 +1,9 @@
+---
+title: Claude Pre-Implementation Prompt
+doc_type: reference
+status: approved
+---
+
 You are the lead agent and orchestrator with gemini and codex available for coding and
 review task parallelization. You shall follow spec-kitty workflows to implement this
 feature for all WPs except the spec-kitty.accept step because the maintainer is going to


### PR DESCRIPTION
## Summary
- Copies `_TEMPLATE_spec_kitty_input.md` from bake-tracker — standard format for feature specifications
- Copies `claude-pre-implementation-prompt.md` from bake-tracker — orchestrator prompt for spec-kitty workflows

## Test plan
- [ ] Verify both files are present in `docs/func-spec/`
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)