### PR TITLE
feat(#688): stamp felix-deployer rebaseline outcome onto the applied deploy record

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -308,11 +308,12 @@ change deploys.
 automatically and silently — no operator action needed. The deployer uses
 a deferred-confirm flow: it observes the committed audited-surface change,
 sets a pending token, then rebaselines once the expected drift is confirmed
-by a read-only audit run. Outcomes are recorded on the felix-deployer **tick
-log** (`/data/services/felix-deployer/logs/<date>.jsonl`), via the
-`rebaseline_reconcile` / `rebaseline_stamped` events correlated to the applied
-manifest name (`completed / not_required / failed`) — NOT as a field on the
-applied YAML record. The operator is NOT the load-bearing component on the
+by a read-only audit run. Outcomes are recorded in two places (#688): the
+real-time felix-deployer **tick log** (`/data/services/felix-deployer/logs/<date>.jsonl`,
+`rebaseline_reconcile` / `rebaseline_stamped` events), AND — as the durable
+per-deploy annotation — a `rebaseline:` field stamped onto the **applied YAML
+record** (`deploys/applied/<NNNN>-<name>.yaml`) after reconcile (`outcome` +
+`at_utc` + details). The operator is NOT the load-bearing component on the
 happy path.
 
 The observe range is driven by a **persisted last-observed-head watermark**

--- a/deploys/schema/manifest-v1.schema.json
+++ b/deploys/schema/manifest-v1.schema.json
@@ -93,6 +93,45 @@
       "type": "string",
       "format": "date-time",
       "description": "When the applier (or bootstrap wrapper) recorded success. Only valid in deploys/applied/."
+    },
+    "rebaseline": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["outcome", "at_utc"],
+      "description": "Security-rebaseline disposition felix-deployer stamped onto this applied record after the tick's deferred-confirm reconcile (#688). The felix-deployer tick log remains the real-time stream; this is the durable per-deploy annotation. Only valid in deploys/applied/.",
+      "properties": {
+        "outcome": {
+          "type": "string",
+          "enum": [
+            "completed",
+            "cleared_clean",
+            "pending_clean",
+            "not_required",
+            "unexpected_drift",
+            "inconclusive",
+            "failed"
+          ],
+          "description": "The reconcile outcome for the tick that applied this manifest."
+        },
+        "at_utc": {
+          "type": "string",
+          "format": "date-time",
+          "description": "When the outcome was stamped (UTC). Makes staleness of a non-terminal outcome visible."
+        },
+        "baseline_count": {
+          "type": "integer",
+          "description": "Regenerated baseline file count (outcome=completed)."
+        },
+        "error_summary": {
+          "type": "string",
+          "description": "Failure detail (outcome=failed)."
+        },
+        "unexpected": {
+          "type": "array",
+          "items": { "type": "string" },
+          "description": "Baselines that drifted beyond the expected set (outcome=unexpected_drift)."
+        }
+      }
     }
   },
   "oneOf": [
@@ -114,6 +153,15 @@
       "comment": "Applied manifests MUST include apply_mode and applied_at; queued manifests MUST NOT.",
       "if": {
         "required": ["applied_at"]
+      },
+      "then": {
+        "required": ["apply_mode", "applied_at"]
+      }
+    },
+    {
+      "comment": "The rebaseline outcome is applied-record-only (deployer-stamped); it cannot appear on a queued manifest.",
+      "if": {
+        "required": ["rebaseline"]
       },
       "then": {
         "required": ["apply_mode", "applied_at"]

--- a/docs/runbooks/deployment.md
+++ b/docs/runbooks/deployment.md
@@ -9,7 +9,7 @@ last_updated: '2026-06-12'
 # Deployment Runbook
 
 **This page has moved.** The canonical deploy discipline is now documented
-at [`docs/runbooks/deploy/discipline.md`](deploy/discipline.md). All
+at [`docs/runbooks/deploy/discipline.md`](<./deploy/discipline.md>). All
 conceptual questions about how a deploy reaches office2 — manifest shape,
 applier behavior, tier policy, failure handling, rebaseline obligation —
 are answered there.
@@ -26,7 +26,7 @@ This page is preserved for two reasons:
    redirects to the canonical discipline runbook.
 
 For **any new deploy after the pull-based-deploy-pipeline mission merges**,
-read [`docs/runbooks/deploy/discipline.md`](deploy/discipline.md). Do not
+read [`docs/runbooks/deploy/discipline.md`](<./deploy/discipline.md>). Do not
 author new deploys against the patterns below.
 
 ---
@@ -94,7 +94,7 @@ documentation-sync standing requirement; it is not optional.
 
 After deploying new services or modifying existing audited surfaces, reset
 the security audit baselines on office2. See
-[`docs/runbooks/security-baseline-ops.md`](security-baseline-ops.md) for
+[`docs/runbooks/security-baseline-ops.md`](<./security-baseline-ops.md>) for
 the canonical procedure. The rebaseline obligation applies regardless of
 whether the deploy goes through the manifest discipline or a grandfathered
 script.
@@ -107,7 +107,7 @@ On the happy path, felix-deployer resets the security-monitor baselines
 automatically after a pipeline deploy that touches an audited surface, so
 the operator is not the load-bearing component (see the "Rebaseline
 obligation" section in `CLAUDE.md` and the deferred-confirm flow in
-[`security-baseline-ops.md`](security-baseline-ops.md#automatic-rebaseline-felix-deployer)).
+[`security-baseline-ops.md`](<./security-baseline-ops.md#automatic-rebaseline-felix-deployer>)).
 Three behaviors of that flow are load-bearing for anyone authoring or
 debugging a deploy:
 
@@ -175,12 +175,42 @@ until a subsequent tick (once the token has aged past the grace window,
 currently ~330s / roughly one tick). Only then, on a still-clean audit, is the
 token `cleared_clean`.
 
+### Rebaseline outcome on the applied record
+
+After reconcile, the deployer stamps the tick's rebaseline outcome onto the
+applied YAML record(s) written that tick (#688) — the durable per-deploy
+artefact — in addition to the real-time tick-log events:
+
+```yaml
+rebaseline:
+  outcome: completed        # completed / cleared_clean / pending_clean /
+                            #   not_required / unexpected_drift / inconclusive / failed
+  at_utc: '2026-07-09T03:22:55Z'
+  baseline_count: 14        # on completed
+  # error_summary: ...      # on failed
+  # unexpected: [...]        # on unexpected_drift
+```
+
+Only **audited** deploys are stamped. A `not_required` reconcile means no pending
+token existed (a non-audited deploy — the common case), so the record carries **no**
+`rebaseline` field; its absence means "no rebaseline was in play" and avoids a
+second commit on every routine deploy.
+
+The applied record is committed early in the queue loop (so a crash never
+re-runs a non-idempotent entrypoint); the outcome is known only after reconcile,
+so it is written in a **second** `deploy(rebaseline): …` commit whose SHA feeds
+the watermark advance (the stamp commit is never re-observed). **Limitation
+(same-tick MVP):** the field holds the outcome as of the applying tick — a deploy
+whose drift lands in the grace window is stamped `pending_clean` and is not
+re-stamped by the later tick that resolves it; the tick log carries the terminal
+outcome. Tracked for a future enhancement.
+
 ---
 
 ## Troubleshooting (legacy scripts only)
 
 For new deploys (manifest discipline), failure handling is documented in
-[`docs/runbooks/deploy/discipline.md`](deploy/discipline.md) under the
+[`docs/runbooks/deploy/discipline.md`](<./deploy/discipline.md>) under the
 **Failure handling** section.
 
 For legacy scripts:
@@ -207,7 +237,7 @@ For legacy scripts:
 
 ## Related documents
 
-- [`docs/runbooks/deploy/discipline.md`](deploy/discipline.md) — **canonical** deploy discipline
+- [`docs/runbooks/deploy/discipline.md`](<./deploy/discipline.md>) — **canonical** deploy discipline
 - `docs/runbooks/openclaw-ops.md` — OpenClaw service management
 - `docs/runbooks/security-baseline-ops.md` — rebaseline obligation procedure
 - `docs/runbooks/maintenance.md` — branch and CI conventions

--- a/docs/runbooks/security-baseline-ops.md
+++ b/docs/runbooks/security-baseline-ops.md
@@ -82,8 +82,8 @@ audited surface. **No operator action is needed on the happy path.**
      (`rm baselines/* && sg docker -c audit.sh`), verifies that the
      baseline count equals `expected_baseline_count` from the registry
      and that the audit reports clear, records the `completed` outcome on
-     the tick log (`rebaseline_reconcile` / `rebaseline_stamped`), and clears
-     the token.
+     the tick log (`rebaseline_reconcile` / `rebaseline_stamped`) and on the
+     applied record's `rebaseline:` field (#688), and clears the token.
 
    - **Audit clean (no drift)** — the committed change did not alter
      the hashed content of any monitored surface (e.g. a comment-only
@@ -102,11 +102,15 @@ audited surface. **No operator action is needed on the happy path.**
 
 ### Observability outcomes
 
-The outcome is recorded on the felix-deployer tick log
-(`/data/services/felix-deployer/logs/<date>.jsonl`), via the
-`rebaseline_reconcile` and (when ≥1 manifest was applied this tick)
-`rebaseline_stamped` events correlated to the applied manifest name. It is NOT
-written as a field on the `deploys/applied/` YAML entry:
+The outcome is recorded in two places (#688): the real-time felix-deployer tick
+log (`/data/services/felix-deployer/logs/<date>.jsonl`, `rebaseline_reconcile` /
+`rebaseline_stamped` events correlated to the applied manifest name) AND, as the
+durable per-deploy annotation, a `rebaseline:` field stamped onto the
+`deploys/applied/<NNNN>-<name>.yaml` entry after reconcile (`outcome` + `at_utc`
++ details), in a follow-up `deploy(rebaseline): …` commit. Note: the field holds
+the outcome as of the applying tick — a deploy whose drift lands in the grace
+window is stamped `pending_clean` and is not re-stamped by the later tick that
+resolves it (same-tick MVP; the tick log carries the terminal outcome).
 
 | Outcome | Meaning |
 |---|---|
@@ -246,11 +250,11 @@ To exercise the failure path without a real failure, the operator can:
 3. Observe the tick log for `failed` outcome.
 4. Confirm exactly one ntfy alert with topic `rebaseline_failed` was
    emitted.
-5. Confirm the tick log carries the `failed` outcome (the
+5. Confirm the `failed` outcome is recorded both on the tick log (the
    `rebaseline_reconcile` / `rebaseline_stamped` events in
    `/data/services/felix-deployer/logs/<date>.jsonl`, correlated to the applied
-   manifest name — the outcome is recorded on the tick log, not on the applied
-   YAML record).
+   manifest name) and as the `rebaseline:` field on the applied YAML record
+   (`deploys/applied/<NNNN>-<name>.yaml`, with `outcome: failed` + `error_summary`).
 6. Confirm the applied code is still in place (no rollback).
 7. Restore the correct `expected_baseline_count` and reset manually.
 

--- a/scripts/deploy/felix-deployer/_tick.py
+++ b/scripts/deploy/felix-deployer/_tick.py
@@ -369,6 +369,9 @@ def run_tick(
     # the deploy record (FR-003).  Populated inside the queue loop below;
     # consumed after reconcile.
     applied_this_tick: list[str] = []
+    # Applied-record paths written this tick — the durable YAML artefacts the
+    # reconcile outcome is stamped onto after reconcile (#688).
+    applied_record_paths: list[str] = []
     # Baselines declared by manifests applied this tick — folded into the
     # pending token AFTER observe, BEFORE reconcile (T006 / FR-005/006).
     declared_baselines: set[str] = set()
@@ -449,6 +452,12 @@ def run_tick(
             # or push then fails; otherwise a push failure silently drops the
             # manifest-declared drift → NFR-001 / undetected drift.
             applied_this_tick.append(manifest_name)
+            # Record the applied YAML path (when write_applied produced one) so
+            # the reconcile outcome can be stamped onto it after reconcile
+            # (#688). Present even when push failed, since the record file was
+            # already written on disk.
+            if rec.applied_path:
+                applied_record_paths.append(rec.applied_path)
             for b in manifest_data.get("expected_baselines", []) or []:
                 if b:
                     declared_baselines.add(b)
@@ -622,6 +631,100 @@ def run_tick(
                 stamp["stale"] = True
             _log(log_path, stamp)
 
+        # #688 — stamp the reconcile outcome onto the applied deploy record(s)
+        # written this tick, so a deploy's rebaseline disposition is legible
+        # from the durable YAML artefact (not only the tick-log stream). The
+        # record was committed early in the queue loop (idempotency: a crash
+        # must never re-run a non-idempotent entrypoint), so the outcome —
+        # known only now, after reconcile — is written in a SECOND commit whose
+        # SHA is appended to ``own_commit_shas`` BEFORE the watermark advance, so
+        # the advance still lands on the deployer's last own commit (C4) and the
+        # stamp commit is never re-observed next tick. Crash-safe: any failure is
+        # logged and the tick proceeds (NFR-001).
+        #
+        # Gated on an outcome OTHER than ``not_required``: a ``not_required``
+        # reconcile means no pending token existed (a non-audited deploy — the
+        # common case), so there is no rebaseline disposition worth a second
+        # commit. The applied record simply carries no ``rebaseline`` field then;
+        # its absence means "no rebaseline was in play". Only audited deploys
+        # (completed / cleared_clean / pending_clean / unexpected_drift /
+        # failed / inconclusive) are stamped.
+        if applied_record_paths and rec_outcome != _rebaseline.OUTCOME_NOT_REQUIRED:
+            try:
+                annotation = _build_rebaseline_annotation(rec_outcome, rec_result)
+                stamped_rel: list[str] = []
+                for rec_path in applied_record_paths:
+                    if not pathlib.Path(rec_path).exists():
+                        continue
+                    res = _applied.stamp_rebaseline(rec_path, annotation)
+                    if res.ok:
+                        stamped_rel.append(
+                            str(pathlib.Path(rec_path).relative_to(repo_root))
+                        )
+                    else:
+                        _log(
+                            log_path,
+                            {
+                                "event": "rebaseline_record_stamp_error",
+                                "path": rec_path,
+                                "reason": res.summary,
+                            },
+                        )
+                if stamped_rel:
+                    # On ANY git failure below, restore the stamped paths to HEAD
+                    # (`git checkout HEAD -- <paths>` resets both index and
+                    # working tree) so no dirty/staged record write leaks into
+                    # the next tick's `deploy(applied)` commit or a later pull
+                    # (Codex #688 MED-2).
+                    add = _git(["add", *stamped_rel], cwd=repo_root)
+                    if add.returncode != 0:
+                        _git(["checkout", "HEAD", "--", *stamped_rel], cwd=repo_root)
+                        _log(
+                            log_path,
+                            {
+                                "event": "rebaseline_record_stamp_error",
+                                "reason": f"git add failed: {add.stderr[:200]}",
+                            },
+                        )
+                    else:
+                        commit_msg = (
+                            f"deploy(rebaseline): {rec_outcome} for "
+                            f"{', '.join(applied_this_tick)}"
+                        )
+                        commit = _git(["commit", "-m", commit_msg], cwd=repo_root)
+                        if commit.returncode != 0:
+                            _git(["checkout", "HEAD", "--", *stamped_rel], cwd=repo_root)
+                            _log(
+                                log_path,
+                                {
+                                    "event": "rebaseline_record_stamp_error",
+                                    "reason": f"git commit failed: {commit.stderr[:200]}",
+                                },
+                            )
+                        else:
+                            stamp_sha = _resolve_head_sha(repo_root)
+                            if stamp_sha:
+                                own_commit_shas.append(stamp_sha)
+                            push = _git(["push"], cwd=repo_root)
+                            _log(
+                                log_path,
+                                {
+                                    "event": "rebaseline_record_stamped",
+                                    "applied_records": stamped_rel,
+                                    "outcome": rec_outcome,
+                                    "commit_sha": stamp_sha,
+                                    "pushed": push.returncode == 0,
+                                },
+                            )
+            except Exception as exc:  # noqa: BLE001 - never crash the tick
+                _log(
+                    log_path,
+                    {
+                        "event": "rebaseline_record_stamp_error",
+                        "error": str(exc)[:200],
+                    },
+                )
+
         # Dispatch ntfy alerts for off-happy-path events (C5).
         # Alert dispatch is best-effort: errors must NEVER propagate.
         _maybe_dispatch_rebaseline_alert(rec_outcome, rec_result, head_sha, log_path)
@@ -666,6 +769,34 @@ def run_tick(
 
     _log(log_path, {"event": "tick_complete"})
     return 0
+
+
+def _build_rebaseline_annotation(
+    rec_outcome: str, rec_result: dict[str, Any]
+) -> dict[str, Any]:
+    """Build the ``rebaseline`` annotation stamped onto an applied record (#688).
+
+    Mirrors the fields in the ``rebaseline_stamped`` tick-log event so the
+    durable record and the real-time log agree. ``at_utc`` timestamps the stamp
+    so a non-terminal outcome's staleness is visible (a deploy whose drift lands
+    in the grace window may be stamped ``pending_clean`` and is not re-stamped by
+    a later tick in this MVP — see docs/runbooks/deployment.md).
+    """
+    annotation: dict[str, Any] = {
+        "outcome": rec_outcome,
+        "at_utc": _utc_now_iso(),
+    }
+    if rec_outcome == _rebaseline.OUTCOME_COMPLETED:
+        bc = rec_result.get("baseline_count")
+        if isinstance(bc, int):
+            annotation["baseline_count"] = bc
+    elif rec_outcome == _rebaseline.OUTCOME_FAILED:
+        annotation["error_summary"] = (rec_result.get("error_summary") or "")[:500]
+    elif rec_outcome == _rebaseline.OUTCOME_UNEXPECTED_DRIFT:
+        unexpected = rec_result.get("unexpected") or []
+        if unexpected:
+            annotation["unexpected"] = list(unexpected)
+    return annotation
 
 
 def _select_watermark_advance(

--- a/scripts/deploy/lib/applied.py
+++ b/scripts/deploy/lib/applied.py
@@ -64,6 +64,10 @@ def write_applied(
         )
 
     augmented = dict(manifest)
+    # ``rebaseline`` is a deployer-owned field stamped post-hoc by
+    # stamp_rebaseline (#688) — never author-supplied. Strip any value carried in
+    # from the queued manifest so an operator cannot pre-seed a false outcome.
+    augmented.pop("rebaseline", None)
     augmented["apply_mode"] = apply_mode
     augmented["applied_at"] = applied_at or _utc_now_iso()
 
@@ -128,6 +132,68 @@ def write_applied(
             "apply_mode": apply_mode,
             "applied_at": augmented["applied_at"],
         },
+    )
+
+
+def stamp_rebaseline(
+    applied_path: str | os.PathLike[str],
+    annotation: dict[str, Any],
+    schema_path: str | os.PathLike[str] | None = None,
+) -> LibResult:
+    """Write the ``rebaseline`` annotation onto an existing applied record (#688).
+
+    Reads the applied YAML at *applied_path*, sets its ``rebaseline`` field to
+    *annotation*, re-validates against the v1 schema (so a malformed annotation
+    is refused, never silently written), and writes the file back.
+
+    Idempotent: re-stamping overwrites the field. Never raises — all failures
+    are returned as a non-ok ``LibResult`` so the felix-deployer tick can log
+    and continue (NFR-001).
+    """
+    path = Path(applied_path)
+    try:
+        record = yaml.safe_load(path.read_text(encoding="utf-8"))
+    except (OSError, yaml.YAMLError) as exc:
+        return LibResult(
+            ok=False,
+            summary=f"failed to read applied record {path}: {exc}",
+            details={"error_code": "READ_FAILED", "error": str(exc)},
+        )
+    if not isinstance(record, dict):
+        return LibResult(
+            ok=False,
+            summary=f"applied record {path} is not a mapping",
+            details={"error_code": "INVALID_RECORD"},
+        )
+
+    augmented = dict(record)
+    augmented["rebaseline"] = annotation
+
+    validation = validate_manifest(augmented, schema_path=schema_path)
+    if not validation.ok:
+        return LibResult(
+            ok=False,
+            summary=f"refusing to stamp invalid rebaseline annotation: {validation.summary}",
+            details={
+                "error_code": validation.details.get("error_code", "SCHEMA_VIOLATION"),
+                "errors": validation.details.get("errors"),
+            },
+        )
+
+    try:
+        serialised = yaml.safe_dump(augmented, sort_keys=False, default_flow_style=False)
+        path.write_text(serialised, encoding="utf-8")
+    except (OSError, yaml.YAMLError) as exc:
+        return LibResult(
+            ok=False,
+            summary=f"failed to write stamped applied record {path}: {exc}",
+            details={"error_code": "WRITE_FAILED", "error": str(exc)},
+        )
+
+    return LibResult(
+        ok=True,
+        summary=f"stamped rebaseline outcome {annotation.get('outcome')!r} onto {path.name}",
+        details={"path": str(path), "outcome": annotation.get("outcome")},
     )
 
 
@@ -214,4 +280,4 @@ if __name__ == "__main__":  # pragma: no cover - CLI entrypoint
     sys.exit(_main())
 
 
-__all__ = ["write_applied"]
+__all__ = ["write_applied", "stamp_rebaseline"]

--- a/tests/deploy/test_applied.py
+++ b/tests/deploy/test_applied.py
@@ -235,3 +235,93 @@ def test_write_applied_round_trip_passes_schema(tmp_path):
     round_trip = manifest.load_manifest(result.details["path"])
     revalidate = manifest.validate_manifest(round_trip, schema_path=SCHEMA_PATH)
     assert revalidate.ok is True
+
+
+# ---------------------------------------------------------------------------
+# stamp_rebaseline (#688)
+# ---------------------------------------------------------------------------
+
+
+def _write_applied_record(tmp_path):
+    base = _load_valid_tier3()
+    result = applied.write_applied(
+        base,
+        apply_mode="manifest",
+        applied_at="2026-07-09T12:00:00Z",
+        applied_dir=tmp_path,
+        schema_path=SCHEMA_PATH,
+    )
+    assert result.ok is True
+    return pathlib.Path(result.details["path"])
+
+
+def test_stamp_rebaseline_writes_field_and_revalidates(tmp_path):
+    rec = _write_applied_record(tmp_path)
+    ann = {"outcome": "completed", "at_utc": "2026-07-09T12:05:00Z", "baseline_count": 14}
+
+    result = applied.stamp_rebaseline(rec, ann, schema_path=SCHEMA_PATH)
+
+    assert result.ok is True
+    written = yaml.safe_load(rec.read_text(encoding="utf-8"))
+    assert written["rebaseline"] == ann
+    # Record still validates against the v1 schema with the new field.
+    assert manifest.validate_manifest(written, schema_path=SCHEMA_PATH).ok is True
+
+
+def test_stamp_rebaseline_is_idempotent(tmp_path):
+    rec = _write_applied_record(tmp_path)
+    applied.stamp_rebaseline(
+        rec, {"outcome": "pending_clean", "at_utc": "2026-07-09T12:05:00Z"},
+        schema_path=SCHEMA_PATH,
+    )
+    result = applied.stamp_rebaseline(
+        rec, {"outcome": "completed", "at_utc": "2026-07-09T12:11:00Z", "baseline_count": 14},
+        schema_path=SCHEMA_PATH,
+    )
+    assert result.ok is True
+    written = yaml.safe_load(rec.read_text(encoding="utf-8"))
+    assert written["rebaseline"]["outcome"] == "completed"
+
+
+def test_stamp_rebaseline_rejects_invalid_annotation(tmp_path):
+    rec = _write_applied_record(tmp_path)
+    # Unknown outcome + missing at_utc are schema violations.
+    result = applied.stamp_rebaseline(
+        rec, {"outcome": "bogus-outcome"}, schema_path=SCHEMA_PATH,
+    )
+    assert result.ok is False
+    # The record on disk is untouched (no rebaseline field written).
+    written = yaml.safe_load(rec.read_text(encoding="utf-8"))
+    assert "rebaseline" not in written
+
+
+def test_stamp_rebaseline_missing_file_returns_not_ok(tmp_path):
+    result = applied.stamp_rebaseline(
+        tmp_path / "0009-nope.yaml",
+        {"outcome": "completed", "at_utc": "2026-07-09T12:05:00Z"},
+        schema_path=SCHEMA_PATH,
+    )
+    assert result.ok is False
+    assert result.details.get("error_code") == "READ_FAILED"
+
+
+def test_write_applied_strips_smuggled_rebaseline(tmp_path):
+    """A queued manifest cannot pre-seed the deployer-owned rebaseline field."""
+    base = _load_valid_tier3()
+    base["rebaseline"] = {"outcome": "completed", "at_utc": "2026-07-09T00:00:00Z"}
+
+    result = applied.write_applied(
+        base, apply_mode="manifest", applied_at="2026-07-09T12:00:00Z",
+        applied_dir=tmp_path, schema_path=SCHEMA_PATH,
+    )
+    assert result.ok is True
+    written = yaml.safe_load(pathlib.Path(result.details["path"]).read_text(encoding="utf-8"))
+    assert "rebaseline" not in written
+
+
+def test_schema_rejects_rebaseline_on_queued_manifest():
+    """A queued manifest (no applied_at/apply_mode) with a rebaseline field is invalid."""
+    base = _load_valid_tier3()
+    base["rebaseline"] = {"outcome": "completed", "at_utc": "2026-07-09T00:00:00Z"}
+    result = manifest.validate_manifest(base, schema_path=SCHEMA_PATH)
+    assert result.ok is False

--- a/tests/deploy/test_tick_rebaseline.py
+++ b/tests/deploy/test_tick_rebaseline.py
@@ -1492,3 +1492,258 @@ def test_malformed_registry_degrades_and_tick_returns_zero(
     monkeypatch.setattr(tick, "_git", _git_mock(pre_sha=PRE, post_sha=POST))
     rc = tick.run_tick(repo_root=fake_repo, log_dir=log_dir)
     assert rc == 0
+
+
+# ---------------------------------------------------------------------------
+# #688 — stamp the reconcile outcome onto the applied deploy record
+# ---------------------------------------------------------------------------
+
+
+def test_build_rebaseline_annotation_per_outcome():
+    a = tick._build_rebaseline_annotation("completed", {"baseline_count": 14})
+    assert a["outcome"] == "completed" and a["baseline_count"] == 14 and a["at_utc"]
+
+    f = tick._build_rebaseline_annotation("failed", {"error_summary": "boom"})
+    assert f["outcome"] == "failed" and f["error_summary"] == "boom"
+
+    u = tick._build_rebaseline_annotation(
+        "unexpected_drift", {"unexpected": ["openclaw-cron.txt"]}
+    )
+    assert u["unexpected"] == ["openclaw-cron.txt"]
+
+    n = tick._build_rebaseline_annotation("not_required", {})
+    assert n["outcome"] == "not_required" and set(n) == {"outcome", "at_utc"}
+
+
+def _write_valid_applied_record(path: pathlib.Path) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+        "\n".join(
+            [
+                "schema_version: v1",
+                "name: test-deploy",
+                "mission_slug: felix-deployer-rebaseline-detection-01KX26DS",
+                "tier: 3",
+                "entrypoint: scripts/deploy/deploy-test.py",
+                "audited_surface: false",
+                "created_at: '2026-07-09T12:00:00Z'",
+                "created_by: felix-deployer",
+                "apply_mode: manifest",
+                "applied_at: '2026-07-09T12:00:00Z'",
+                "",
+            ]
+        ),
+        encoding="utf-8",
+    )
+
+
+def test_reconcile_outcome_stamped_onto_applied_record(
+    monkeypatch, fake_repo_with_manifest, log_dir
+):
+    """A deploy applied this tick has the reconcile outcome written onto its
+    applied YAML in a second commit, and that commit becomes the watermark."""
+    import yaml
+
+    from scripts.deploy.lib import apply as _apply_lib
+
+    STAMP = "5ada5ada" * 5
+    applied_path = fake_repo_with_manifest / "deploys" / "applied" / "0099-test-deploy.yaml"
+    _write_valid_applied_record(applied_path)
+
+    def _fake_git(args, cwd):
+        cmd = args[0] if args else ""
+        if cmd == "rev-parse":
+            if not getattr(_fake_git, "_pre", False):
+                _fake_git._pre = True
+                return _FakeProc(returncode=0, stdout=PRE + "\n")
+            if not getattr(_fake_git, "_post", False):
+                _fake_git._post = True
+                return _FakeProc(returncode=0, stdout=POST + "\n")
+            return _FakeProc(returncode=0, stdout=STAMP + "\n")  # post-stamp-commit HEAD
+        return _FakeProc(returncode=0)  # pull/add/commit/push/merge-base/cat-file ok
+
+    monkeypatch.setattr(tick, "_git", _fake_git)
+
+    wm_path = fake_repo_with_manifest / "rebaseline-observed-head.json"
+    monkeypatch.setattr(rebaseline, "DEFAULT_OBSERVED_HEAD_PATH", wm_path)
+    rebaseline.write_observed_head(WATERMARK, wm_path)
+
+    # _record_success succeeds and returns the real applied-record path.
+    monkeypatch.setattr(
+        tick,
+        "_record_success",
+        lambda repo_root, manifest_path, manifest_data, head_sha: tick._RecordResult(
+            ok=True, pushed=True, commit_sha="dep10000" * 5, applied_path=str(applied_path)
+        ),
+    )
+
+    class _OkResult:
+        ok = True
+        summary = "ok"
+        details: dict = {}
+
+    monkeypatch.setattr(_apply_lib, "dry_run_then_apply_gate", lambda *a, **kw: _OkResult())
+    monkeypatch.setattr(rebaseline, "observe", lambda *a, **kw: {"outcome": "not_required"})
+    monkeypatch.setattr(
+        rebaseline, "reconcile", lambda **kw: {"outcome": "completed", "baseline_count": 14}
+    )
+
+    rc = tick.run_tick(repo_root=fake_repo_with_manifest, log_dir=log_dir)
+    assert rc == 0
+
+    # The applied record on disk now carries the rebaseline outcome.
+    written = yaml.safe_load(applied_path.read_text(encoding="utf-8"))
+    assert written["rebaseline"]["outcome"] == "completed"
+    assert written["rebaseline"]["baseline_count"] == 14
+
+    entries = _read_log(log_dir)
+    stamped = next(e for e in entries if e.get("event") == "rebaseline_record_stamped")
+    assert stamped["outcome"] == "completed"
+    assert "deploys/applied/0099-test-deploy.yaml" in stamped["applied_records"]
+
+    # The stamp commit is the deployer's last own commit → the new watermark.
+    assert rebaseline.read_observed_head(wm_path) == STAMP
+
+
+def test_record_stamp_failure_never_crashes_tick(
+    monkeypatch, fake_repo_with_manifest, log_dir
+):
+    """If stamping raises, the tick logs the error and still returns 0 (NFR-001)."""
+    from scripts.deploy.lib import apply as _apply_lib
+    from scripts.deploy.lib import applied as _applied_lib
+
+    applied_path = fake_repo_with_manifest / "deploys" / "applied" / "0099-test-deploy.yaml"
+    _write_valid_applied_record(applied_path)
+
+    monkeypatch.setattr(tick, "_git", lambda args, cwd: _FakeProc(returncode=0, stdout=POST + "\n"))
+    wm_path = fake_repo_with_manifest / "rebaseline-observed-head.json"
+    monkeypatch.setattr(rebaseline, "DEFAULT_OBSERVED_HEAD_PATH", wm_path)
+
+    monkeypatch.setattr(
+        tick,
+        "_record_success",
+        lambda *a, **kw: tick._RecordResult(ok=True, pushed=True, applied_path=str(applied_path)),
+    )
+
+    class _OkResult:
+        ok = True
+        summary = "ok"
+        details: dict = {}
+
+    monkeypatch.setattr(_apply_lib, "dry_run_then_apply_gate", lambda *a, **kw: _OkResult())
+    monkeypatch.setattr(rebaseline, "observe", lambda *a, **kw: {"outcome": "not_required"})
+    monkeypatch.setattr(rebaseline, "reconcile", lambda **kw: {"outcome": "completed"})
+
+    def _boom(*a, **kw):
+        raise RuntimeError("stamp exploded")
+
+    monkeypatch.setattr(_applied_lib, "stamp_rebaseline", _boom)
+
+    rc = tick.run_tick(repo_root=fake_repo_with_manifest, log_dir=log_dir)
+    assert rc == 0
+    entries = _read_log(log_dir)
+    assert any(e.get("event") == "rebaseline_record_stamp_error" for e in entries)
+
+
+def test_not_required_does_not_stamp_applied_record(
+    monkeypatch, fake_repo_with_manifest, log_dir
+):
+    """A non-audited deploy (reconcile=not_required) leaves the applied record
+    unstamped — no rebaseline field, no second commit."""
+    import yaml
+
+    from scripts.deploy.lib import apply as _apply_lib
+
+    applied_path = fake_repo_with_manifest / "deploys" / "applied" / "0099-test-deploy.yaml"
+    _write_valid_applied_record(applied_path)
+
+    committed: list = []
+
+    def _fake_git(args, cwd):
+        if args and args[0] == "commit":
+            committed.append(args)
+        if args and args[0] == "rev-parse":
+            return _FakeProc(returncode=0, stdout=POST + "\n")
+        return _FakeProc(returncode=0)
+
+    monkeypatch.setattr(tick, "_git", _fake_git)
+    wm_path = fake_repo_with_manifest / "rebaseline-observed-head.json"
+    monkeypatch.setattr(rebaseline, "DEFAULT_OBSERVED_HEAD_PATH", wm_path)
+    monkeypatch.setattr(
+        tick,
+        "_record_success",
+        lambda *a, **kw: tick._RecordResult(ok=True, pushed=True, applied_path=str(applied_path)),
+    )
+
+    class _OkResult:
+        ok = True
+        summary = "ok"
+        details: dict = {}
+
+    monkeypatch.setattr(_apply_lib, "dry_run_then_apply_gate", lambda *a, **kw: _OkResult())
+    monkeypatch.setattr(rebaseline, "observe", lambda *a, **kw: {"outcome": "not_required"})
+    monkeypatch.setattr(rebaseline, "reconcile", lambda **kw: {"outcome": "not_required"})
+
+    rc = tick.run_tick(repo_root=fake_repo_with_manifest, log_dir=log_dir)
+    assert rc == 0
+
+    written = yaml.safe_load(applied_path.read_text(encoding="utf-8"))
+    assert "rebaseline" not in written
+    entries = _read_log(log_dir)
+    assert not any(e.get("event") == "rebaseline_record_stamped" for e in entries)
+    # No deploy(rebaseline) commit was made.
+    assert not any("deploy(rebaseline)" in " ".join(a) for a in committed)
+
+
+def test_stamp_commit_failure_restores_paths(
+    monkeypatch, fake_repo_with_manifest, log_dir
+):
+    """If the stamp git commit fails, the stamped paths are restored from HEAD
+    (git checkout HEAD -- <paths>) so no dirty state leaks to the next tick."""
+    from scripts.deploy.lib import apply as _apply_lib
+
+    applied_path = fake_repo_with_manifest / "deploys" / "applied" / "0099-test-deploy.yaml"
+    _write_valid_applied_record(applied_path)
+
+    calls: list = []
+
+    def _fake_git(args, cwd):
+        calls.append(list(args))
+        cmd = args[0] if args else ""
+        if cmd == "commit":
+            return _FakeProc(returncode=1, stderr="nothing to commit / hook failed")
+        if cmd == "rev-parse":
+            return _FakeProc(returncode=0, stdout=POST + "\n")
+        return _FakeProc(returncode=0)  # pull/add/checkout/merge-base/cat-file ok
+
+    monkeypatch.setattr(tick, "_git", _fake_git)
+    wm_path = fake_repo_with_manifest / "rebaseline-observed-head.json"
+    monkeypatch.setattr(rebaseline, "DEFAULT_OBSERVED_HEAD_PATH", wm_path)
+    monkeypatch.setattr(
+        tick,
+        "_record_success",
+        lambda *a, **kw: tick._RecordResult(ok=True, pushed=True, applied_path=str(applied_path)),
+    )
+
+    class _OkResult:
+        ok = True
+        summary = "ok"
+        details: dict = {}
+
+    monkeypatch.setattr(_apply_lib, "dry_run_then_apply_gate", lambda *a, **kw: _OkResult())
+    monkeypatch.setattr(rebaseline, "observe", lambda *a, **kw: {"outcome": "not_required"})
+    monkeypatch.setattr(rebaseline, "reconcile", lambda **kw: {"outcome": "completed"})
+
+    rc = tick.run_tick(repo_root=fake_repo_with_manifest, log_dir=log_dir)
+    assert rc == 0
+
+    # A restore (`git checkout HEAD -- <path>`) was issued after the failed commit.
+    assert any(
+        c[:3] == ["checkout", "HEAD", "--"] for c in calls
+    ), f"expected a checkout-HEAD restore in {calls}"
+    entries = _read_log(log_dir)
+    assert any(
+        e.get("event") == "rebaseline_record_stamp_error"
+        and "git commit failed" in (e.get("reason") or "")
+        for e in entries
+    )


### PR DESCRIPTION
Closes #688.

## What & why

felix-deployer recorded each deploy's rebaseline outcome **only** on the JSONL tick log, not on the durable per-deploy artifact (`deploys/applied/<NNNN>-<name>.yaml`). An operator inspecting a specific applied deploy couldn't see its security-rebaseline disposition without correlating the tick log by timestamp/manifest name. This adds an optional `rebaseline` field to the manifest/applied schema and has felix-deployer stamp the reconcile outcome onto the applied record.

## Design (the timing subtlety)

The applied record is committed **early** in the queue loop for idempotency — a crash must never re-run a non-idempotent entrypoint. The outcome isn't known until reconcile at end-of-tick. Rather than defer that commit (which would widen the re-apply crash window), the outcome is written in a **second** `deploy(rebaseline): …` commit whose SHA is appended to `own_commit_shas` before #685's watermark advance — so the watermark still lands on the deployer's last own commit and the stamp commit is never re-observed.

- **Gated to audited deploys** (`rec_outcome != not_required`): a non-audited deploy (the common case) gets no `rebaseline` field and no second commit — its absence means "no rebaseline was in play." Avoids doubling commits on routine deploys.
- **Crash-safe** (NFR-001): `stamp_rebaseline` never raises; the whole block is wrapped; on git failure the stamped paths are restored from HEAD so no dirty/staged state leaks to the next tick.
- **Known limitation (same-tick MVP):** the field holds the outcome as of the applying tick — a deploy whose drift lands in the grace window is stamped `pending_clean` and is not re-stamped by the later tick that resolves it; the tick log carries the terminal outcome. Documented in `deployment.md`.

## Review discipline (P3 direct action, not a mission)

Per our discussion this was handled as a direct branch + PR (P3, bounded, single-lane), keeping two SK safeguards: design-think up front, and one **adversarial Codex review** on the diff. Codex confirmed the watermark ordering + idempotency were sound and found **2 MEDIUM** issues, both fixed here:
- A queued manifest could pre-seed a false `rebaseline` field → `write_applied` now strips it + a schema rule forbids it on queued manifests.
- A failed stamp commit could leave dirty/staged record writes for the next tick → the stamped paths are now restored from HEAD on any git failure.

## Verification

- `tests/deploy/`: **371 passed** (+ new unit tests for `stamp_rebaseline`, `_build_rebaseline_annotation`, the smuggle-strip/schema guard, and integration tests proving the watermark lands on the stamp commit, `not_required` doesn't stamp, and commit-failure restores paths). Full-repo pre-push gate green.
- Deploys by the felix-deployer applier self-pulling `main` on its next tick (no manifest). Rebaseline **not required** (`scripts/deploy/**` surface has empty `affected_baselines`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YJQpKPHoBcRVoSWkGXwp96
