### PR TITLE
feat(#737): atomic fail-loud inbox→calendar finalize (#737; #738/#657 silent-loss core)

### DIFF
--- a/scripts/inbox/append_routing_entry.py
+++ b/scripts/inbox/append_routing_entry.py
@@ -29,12 +29,19 @@ def main(argv: list[str] | None = None) -> int:
     parser.add_argument("filename", help="Inbox note filename (basename only).")
     parser.add_argument(
         "issue_number",
+        nargs="?",
         type=int,
-        help="GitHub issue number filed for this note.",
+        default=None,
+        help=(
+            "GitHub issue number filed for this note (issue_task routes). "
+            "Omit for --kind calendar."
+        ),
     )
     parser.add_argument(
         "vikunja_task_id",
-        help="Vikunja task ID, or '-' if no task was created.",
+        nargs="?",
+        default=None,
+        help="Vikunja task ID, or '-' if no task was created (issue_task routes).",
     )
     parser.add_argument(
         "excerpt",
@@ -42,10 +49,73 @@ def main(argv: list[str] | None = None) -> int:
         default="",
         help="Short note excerpt (will be truncated to 120 chars).",
     )
+    parser.add_argument(
+        "--kind",
+        choices=("issue_task", "calendar"),
+        default="issue_task",
+        help=(
+            "Route class. 'calendar' records a Google Calendar event (#737) — "
+            "calendar routes have no GitHub issue or Vikunja task."
+        ),
+    )
+    parser.add_argument(
+        "--event-id",
+        default=None,
+        help="Calendar event id — required (and the destination) with --kind calendar.",
+    )
     args = parser.parse_args(argv)
 
-    task_id = None if args.vikunja_task_id == "-" else int(args.vikunja_task_id)
     writer = RoutingLogWriter()
+
+    if args.kind == "calendar":
+        if not args.event_id:
+            print(
+                "ERROR: --event-id is required with --kind calendar",
+                file=sys.stderr,
+            )
+            return 2
+        if args.issue_number is not None:
+            print(
+                "ERROR: positional issue_number is not allowed with --kind "
+                "calendar (use --event-id)",
+                file=sys.stderr,
+            )
+            return 2
+        try:
+            entry = writer.append(
+                filename=args.filename,
+                kind="calendar",
+                destination=args.event_id,
+                note_excerpt=args.excerpt,
+            )
+        except OSError as exc:
+            print(f"ERROR: could not write routing log: {exc}", file=sys.stderr)
+            return 1
+        print(
+            f"Appended routing log entry: {entry.filename} -> calendar "
+            f"({entry.destination})"
+        )
+        return 0
+
+    # issue_task route (original behavior).
+    if args.issue_number is None:
+        print(
+            "ERROR: issue_number is required with --kind issue_task",
+            file=sys.stderr,
+        )
+        return 2
+    if args.vikunja_task_id in (None, "-"):
+        task_id = None
+    else:
+        try:
+            task_id = int(args.vikunja_task_id)
+        except ValueError:
+            print(
+                "ERROR: vikunja_task_id must be an integer or '-' "
+                f"(got {args.vikunja_task_id!r})",
+                file=sys.stderr,
+            )
+            return 2
     try:
         entry = writer.append(
             filename=args.filename,

--- a/scripts/inbox/route_calendar_event.py
+++ b/scripts/inbox/route_calendar_event.py
@@ -86,6 +86,15 @@ DEFAULT_ACCOUNT = "personal"
 # constant so tests can monkeypatch the subprocess call site.
 CALENDAR_HELPER_MODULE = "scripts.google.calendar_helper"
 
+# Subprocess timeouts (seconds). --finalize is the SINGLE command the capture
+# agent relies on, so a blocked Google API call or a stuck mark_processed must
+# fail cleanly rather than hang until the 600s openclaw cron limit kills the
+# whole turn. On timeout we synthesize a non-zero result so the caller's
+# returncode-based branches surface it as a fail-loud error (note not finalized).
+CALENDAR_HELPER_TIMEOUT_SECONDS = 90
+MARK_PROCESSED_TIMEOUT_SECONDS = 30
+_TIMEOUT_RETURNCODE = 124  # conventional timeout exit code
+
 # The calendar helper's Google client libraries live ONLY in a dedicated venv on
 # office2 (system python3 has neither pip nor the google libs). The helper MUST be
 # invoked with that venv's interpreter — NOT ``sys.executable`` (capture runs this
@@ -251,24 +260,36 @@ def _invoke_calendar_helper(
     try:
         with open(fd, "w", encoding="utf-8") as fh:
             json.dump(envelope, fh)
-        return subprocess.run(
-            [
-                _calendar_helper_python(),
-                "-m",
-                CALENDAR_HELPER_MODULE,
-                "create",
-                "--payload-file",
-                tmp_name,
-                "--idempotency-key",
-                source_inbox_path,
-                "--account",
-                account,
-                "--json",
-            ],
-            capture_output=True,
-            text=True,
-            check=False,
-        )
+        try:
+            return subprocess.run(
+                [
+                    _calendar_helper_python(),
+                    "-m",
+                    CALENDAR_HELPER_MODULE,
+                    "create",
+                    "--payload-file",
+                    tmp_name,
+                    "--idempotency-key",
+                    source_inbox_path,
+                    "--account",
+                    account,
+                    "--json",
+                ],
+                capture_output=True,
+                text=True,
+                check=False,
+                timeout=CALENDAR_HELPER_TIMEOUT_SECONDS,
+            )
+        except subprocess.TimeoutExpired:
+            return subprocess.CompletedProcess(
+                args=["calendar_helper"],
+                returncode=_TIMEOUT_RETURNCODE,
+                stdout="",
+                stderr=(
+                    "ERROR: calendar helper timed out after "
+                    f"{CALENDAR_HELPER_TIMEOUT_SECONDS}s"
+                ),
+            )
     finally:
         try:
             Path(tmp_name).unlink()
@@ -346,6 +367,155 @@ def _run_create(
 
 
 # ---------------------------------------------------------------------------
+# --finalize mode (#737/#738/#657): atomic create -> verify -> mark -> log
+# ---------------------------------------------------------------------------
+
+
+def _invoke_mark_processed(source_path: str) -> "subprocess.CompletedProcess[str]":
+    """Run ``mark_processed`` as a subprocess and return the completed process.
+
+    Deliberately a subprocess, not an in-process import of ``mark_processed()``:
+    the C-001 private-path refusal, inbox-root validation, and — critically —
+    the symlink ``.resolve()`` guard all live in ``mark_processed.main()``, not
+    in the bare function. Calling the function directly would let a symlinked
+    vault note "mark" the symlink while the real target stays ``unprocessed``,
+    re-introducing the silent-loss class this mission closes. The subprocess
+    also isolates ``mark_processed``'s own stdout JSON from this helper's
+    single-result-JSON contract. ``mark_processed`` is stdlib-only, so the
+    system interpreter (``sys.executable``) is correct (unlike the calendar
+    helper, which needs the google venv).
+    """
+    try:
+        return subprocess.run(
+            [sys.executable, "-m", "scripts.inbox.mark_processed", "--path", source_path],
+            capture_output=True,
+            text=True,
+            check=False,
+            timeout=MARK_PROCESSED_TIMEOUT_SECONDS,
+        )
+    except subprocess.TimeoutExpired:
+        return subprocess.CompletedProcess(
+            args=["mark_processed"],
+            returncode=_TIMEOUT_RETURNCODE,
+            stdout="",
+            stderr=f"ERROR: mark_processed timed out after {MARK_PROCESSED_TIMEOUT_SECONDS}s",
+        )
+
+
+def _append_calendar_routing_log(
+    filename: str, event_id: str, note_excerpt: str
+) -> bool:
+    """Append a ``calendar`` routing-log entry — LAST, after the frontmatter mark.
+
+    ``prescan`` dedups on the routing-log filename, so writing this BEFORE the
+    frontmatter mark can strand a note (skipped forever, never processed) — so
+    the caller runs this only after ``mark_processed`` exits 0. Idempotent via
+    ``RoutingLogReader().has()`` so a reprocess never double-writes. Best-effort:
+    a write failure is non-fatal (the note is already marked processed, which is
+    the primary dedup) — returns ``False`` so the caller can warn.
+    """
+    from scripts.inbox.routing_log import RoutingLogReader, RoutingLogWriter
+
+    try:
+        if RoutingLogReader().has(filename):
+            return True
+        RoutingLogWriter().append(
+            filename=filename,
+            kind="calendar",
+            destination=event_id,
+            note_excerpt=note_excerpt,
+        )
+        return True
+    except OSError:
+        return False
+
+
+def _run_finalize(
+    payload: object, source_path: str, account: str
+) -> tuple[dict, int]:
+    """Atomic create-and-finalize for a calendar route. Returns ``(result, code)``.
+
+    The single deterministic operation the capture agent invokes for a calendar
+    route — it cannot half-complete. Order (verified against ``prescan`` dedup):
+    create -> verify (``status==created`` AND non-empty ``event_id``) ->
+    ``mark_processed`` (subprocess, exit 0) -> routing-log append (last). Any
+    failure leaves the note UNprocessed so the next tick retries; the calendar
+    helper's idempotency key (= source path) prevents a double-create.
+
+    The exit code is derived from the OUTCOME, never from ``_run_create`` (which
+    returns 0 for created / error / needs_clarification alike):
+
+    - invalid payload -> ``{status: needs_clarification, missing}``; exit 0.
+    - create error / missing event_id -> ``{status: error, ...}``; exit 1. Not finalized.
+    - ``mark_processed`` non-zero -> ``{status: error, stage: mark_processed, ...}``;
+      exit 1. Event exists but note not marked; retried next tick.
+    - success -> ``{status: finalized, event_id, html_link, marked_processed,
+      routing_logged}``; exit 0.
+    """
+    if not isinstance(payload, dict):
+        return {"status": "needs_clarification", "missing": ["payload_not_object"]}, 0
+
+    # Pass the RAW source_path as the idempotency key (identical to --create) so
+    # a note previously touched by --create and now --finalize resolves to the
+    # SAME key — canonicalizing here would risk a double-create.
+    result, _ = _run_create(payload, source_path, account)
+    status = result.get("status")
+    if status == "needs_clarification":
+        return result, 0
+    if status != "created" or not result.get("event_id"):
+        # Create failed (or, defensively, "created" without an id). Fail loud:
+        # preserve the helper's error detail, force a non-zero exit, finalize nothing.
+        err = dict(result)
+        err["status"] = "error"
+        return err, 1
+
+    event_id = result["event_id"]
+    html_link = result.get("html_link", "")
+    title = payload.get("title", "")
+    note_excerpt = title if isinstance(title, str) else ""
+
+    proc = _invoke_mark_processed(source_path)
+    if proc.returncode != 0:
+        return {
+            "status": "error",
+            "stage": "mark_processed",
+            "event_id": event_id,
+            "exit_code": proc.returncode,
+            "error": (proc.stderr or proc.stdout).strip(),
+        }, 1
+
+    routing_logged = _append_calendar_routing_log(
+        Path(source_path).name, event_id, note_excerpt
+    )
+    return {
+        "status": "finalized",
+        "event_id": event_id,
+        "html_link": html_link,
+        "marked_processed": True,
+        "routing_logged": routing_logged,
+    }, 0
+
+
+def _run_finalize_dry_run(payload: object, source_path: str, account: str) -> dict:
+    """Credential-free wiring check for ``--finalize --dry-run``.
+
+    Validates the payload and reports the envelope that WOULD be sent, without
+    invoking the calendar helper, ``mark_processed``, or the routing log. Lets an
+    operator confirm the command is wired correctly on office2 without creating a
+    real event or needing Google credentials.
+    """
+    if not isinstance(payload, dict):
+        return {"status": "needs_clarification", "missing": ["payload_not_object"]}
+    is_valid, missing = validate_payload(payload)
+    if not is_valid:
+        return {"status": "needs_clarification", "missing": missing}
+    normalized = normalize_payload(payload)
+    envelope = build_delegation_payload(normalized, source_path)
+    envelope["account"] = account
+    return {"status": "dry_run", "would_finalize": True, "envelope": envelope}
+
+
+# ---------------------------------------------------------------------------
 # CLI orchestrator
 # ---------------------------------------------------------------------------
 
@@ -414,6 +584,27 @@ def main(argv: Optional[list[str]] = None) -> int:
         ),
     )
     parser.add_argument(
+        "--finalize",
+        action="store_true",
+        help=(
+            "Atomic create-and-finalize (#737/#738/#657): create the event, "
+            "verify it, mark the source note processed, and append the calendar "
+            "routing-log entry — as ONE operation the agent cannot half-complete. "
+            "Emits a single result JSON {status: finalized|error|needs_clarification} "
+            "and a non-zero exit on error. Requires --source-path; mutually "
+            "exclusive with --create/--as-delegation-payload."
+        ),
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help=(
+            "Only valid with --finalize: validate the payload and report the "
+            "envelope that WOULD be sent, WITHOUT creating, marking, or logging "
+            "(credential-free wiring check)."
+        ),
+    )
+    parser.add_argument(
         "--account",
         default=DEFAULT_ACCOUNT,
         help=(
@@ -431,18 +622,41 @@ def main(argv: Optional[list[str]] = None) -> int:
     )
     args = parser.parse_args(argv)
 
-    if args.as_delegation_payload and args.create:
-        _emit_error("mutually_exclusive", detail="--create and --as-delegation-payload are mutually exclusive")
+    if sum(bool(f) for f in (args.as_delegation_payload, args.create, args.finalize)) > 1:
+        _emit_error(
+            "mutually_exclusive",
+            detail="--create, --finalize, and --as-delegation-payload are mutually exclusive",
+        )
         return 1
 
-    if (args.as_delegation_payload or args.create) and not args.source_path:
-        flag = "--create" if args.create else "--as-delegation-payload"
+    if (args.as_delegation_payload or args.create or args.finalize) and not args.source_path:
+        flag = (
+            "--finalize" if args.finalize
+            else "--create" if args.create
+            else "--as-delegation-payload"
+        )
         _emit_error("missing_source_path", detail=f"--source-path is required with {flag}")
+        return 1
+
+    if args.dry_run and not args.finalize:
+        _emit_error("invalid_flag", detail="--dry-run is only valid with --finalize")
         return 1
 
     payload, err_code = _load_payload(Path(args.payload_file))
     if err_code is not None:
         return err_code
+
+    if args.finalize:
+        # Atomic create-and-finalize. Result JSON on stdout; exit code reflects
+        # the outcome (non-zero on error) so a failed create/mark surfaces
+        # loudly and the note is never silently marked processed.
+        if args.dry_run:
+            result = _run_finalize_dry_run(payload, args.source_path, args.account)
+            sys.stdout.write(json.dumps(result) + "\n")
+            return 0
+        result, code = _run_finalize(payload, args.source_path, args.account)
+        sys.stdout.write(json.dumps(result) + "\n")
+        return code
 
     if args.create:
         # In --create mode an invalid payload is a needs_clarification RESULT

--- a/scripts/inbox/routing_log.py
+++ b/scripts/inbox/routing_log.py
@@ -23,13 +23,24 @@ DEFAULT_ROUTING_LOG_PATH = Path("/data/services/openclaw/state/inbox-routing.jso
 
 @dataclass(frozen=True)
 class RoutingEntry:
-    """One row in the routing log. Append-only; values never mutate after write."""
+    """One row in the routing log. Append-only; values never mutate after write.
+
+    ``kind`` records the route class (``issue_task`` for the original
+    GitHub-issue / Vikunja-task routes, ``calendar`` for Google Calendar
+    events, etc.) and ``destination`` carries a kind-specific identifier
+    (e.g. a calendar ``event_id``). Both were added in #737 so calendar
+    routes — which have neither a GitHub issue nor a Vikunja task — can be
+    represented. Old on-disk rows predate these fields; the reader only keys
+    on ``filename`` so their absence is harmless.
+    """
 
     filename: str
-    issue_number: int
+    issue_number: Optional[int]
     vikunja_task_id: Optional[int]
     routed_at: str  # ISO-8601 UTC, with trailing Z
     note_excerpt: str = ""
+    kind: str = "issue_task"
+    destination: str = ""
 
     def to_dict(self) -> dict:
         return asdict(self)
@@ -114,14 +125,19 @@ class RoutingLogWriter:
     def append(
         self,
         filename: str,
-        issue_number: int,
+        issue_number: Optional[int] = None,
         vikunja_task_id: Optional[int] = None,
         note_excerpt: str = "",
+        kind: str = "issue_task",
+        destination: str = "",
     ) -> RoutingEntry:
         """Append one entry. Creates the parent directory if absent.
 
         `routed_at` is set automatically to UTC now (ISO-8601 with trailing Z).
         `note_excerpt` is truncated to 120 characters per the contract.
+        `kind`/`destination` (#737) record the route class and a kind-specific
+        id (e.g. a calendar ``event_id``); ``issue_number`` defaults to ``None``
+        so calendar routes — which have no GitHub issue — need not supply it.
         """
         entry = RoutingEntry(
             filename=filename,
@@ -129,6 +145,8 @@ class RoutingLogWriter:
             vikunja_task_id=vikunja_task_id,
             routed_at=datetime.now(timezone.utc).isoformat().replace("+00:00", "Z"),
             note_excerpt=(note_excerpt or "")[:120],
+            kind=kind,
+            destination=destination,
         )
         self._path.parent.mkdir(parents=True, exist_ok=True, mode=0o750)
         new_file = not self._path.exists()

--- a/scripts/openclaw/agents/felix-admin-capture/AGENTS.md
+++ b/scripts/openclaw/agents/felix-admin-capture/AGENTS.md
@@ -99,10 +99,10 @@ For each successfully parsed file, invoke `cd /home/claude/kg-automation && pyth
 - Then route by kind:
   - `journal` → `cd /home/claude/kg-automation && python3 -m scripts.inbox.route_journal_entry --content-file <tmp> --datetime <iso>`. Pass the block content via a tempfile; pass the note's frontmatter `created` (or file mtime if absent) as the datetime.
   - `someday` → `cd /home/claude/kg-automation && python3 -m scripts.inbox.route_someday --title <title> --body <body> --note-filename <name>`. Title = first sentence (≤100 chars); body = full block content. Returns `task_id=<int>`.
-  - `calendar` → assemble a `CalendarPayload` (`title`, `start`, optional `end`/`location`/`description`) into a tempfile; run the **single** deterministic command `cd /home/claude/kg-automation && python3 -m scripts.inbox.route_calendar_event --create --payload-file <tmp> --source-path <abs-path-of-the-source-note>`. This one command validates, builds the envelope, and invokes the calendar helper in-process — **there is no agent-to-agent hop**. Do **NOT** run `openclaw agent`, `sessions_send`, or route through `main`; do **NOT** run `gog` (you have none). On exit 0 the command emits ONE result JSON on stdout — branch on its `status`:
-    - `"created"` → the event was created (`event_id` / `html_link` present). Continue to Step 5 (mark processed) and record `event_id` in the routing log.
-    - `"needs_clarification"` → the payload was incomplete (`missing` lists the fields). Do NOT mark the note processed — enter the clarification flow below.
-    - `"error"` → the helper failed (`exit_code` + verbatim `error`). Do NOT mark the note processed — send Kent ONE WhatsApp with the `error` text verbatim and leave the note unprocessed for retry. **Never treat an `error` as a created event (#683).**
+  - `calendar` → assemble a `CalendarPayload` (`title`, `start`, optional `end`/`location`/`description`) into a tempfile; run the **single atomic** command `cd /home/claude/kg-automation && python3 -m scripts.inbox.route_calendar_event --finalize --payload-file <tmp> --source-path <abs-path-of-the-source-note>`. This ONE command creates the event, verifies it, marks the note processed, AND writes the routing-log entry — so for a calendar route you do **NOT** run Step 5b/5c separately, and there is **no agent-to-agent hop**. Do **NOT** run `openclaw agent`, `sessions_send`, or route through `main`; do **NOT** run `gog` (you have none). It emits ONE result JSON on stdout — branch on its `status`:
+    - `"finalized"` → **done.** The event was created (`event_id` / `html_link`), the note is already marked processed, and the routing-log entry is written. **Skip Step 5 for this note** — do NOT run `mark_processed` or `append_routing_entry`.
+    - `"needs_clarification"` → the payload was incomplete (`missing` lists the fields). The note was NOT marked processed — enter the clarification flow below.
+    - `"error"` → the create or finalize failed (**non-zero exit**; `error` + optional `stage`). The note was NOT marked processed, so there is no silent loss — it retries next tick. Send Kent ONE WhatsApp with the `error` text verbatim. **Never treat an `error` as a created event (#683).**
   - `github_issue` → invoke `cd /home/claude/kg-automation && python3 scripts/openclaw/agents/main/felix-file-issue.py …` (existing surface). Title and body come from the block; labels per heuristic.
 
     **Available Labels** — apply at the `github_issue` route:
@@ -117,7 +117,7 @@ For each successfully parsed file, invoke `cd /home/claude/kg-automation && pyth
   - `vikunja_task` → fall back to the Task bridge (below).
   - `parse_failure` → continue to Step 6.
 
-**Calendar clarification flow** (when `route_calendar_event --create` returns `status: "needs_clarification"`):
+**Calendar clarification flow** (when `route_calendar_event --finalize` returns `status: "needs_clarification"`):
 
 1. `cd /home/claude/kg-automation && python3 -m scripts.inbox.handle_clarification_state add --note-filename <name> --partial-payload <json>` to record what's known (the JSON-array store at `/data/services/openclaw/state/pending-calendar-clarifications.json`).
 2. Compose ONE WhatsApp message asking Kent for the missing fields. Direct voice, single question. Example: `Sent by felix-admin-capture:haiku\n\nWhat time should "<title>" be on <date>?`
@@ -139,9 +139,13 @@ For each path in `marker_cleanup_needed` from prescan: `cd /home/claude/kg-autom
 
 For each fully-routed note (per Step 3): `cd /home/claude/kg-automation && python3 -m scripts.inbox.append_routing_entry <name> <issue-number-or-0> <vikunja-task-id-or-dash> <short-excerpt>` — **positional** args (matching the CLI + `AGENTS.md.tmpl`): note basename, GitHub issue number as an integer (`0` if none), Vikunja task id (or `-` if none), optional ≤120-char excerpt. This is the dedup substrate; future ticks consult it to skip re-routing the same file.
 
+**Exempt: `calendar` routes** — `route_calendar_event --finalize` already wrote their routing-log entry (`--kind calendar`). Do NOT append again for a note that returned `status: "finalized"`.
+
 #### Step 5c — Atomic frontmatter write
 
 For each fully-routed note: `cd /home/claude/kg-automation && python3 -m scripts.inbox.mark_processed --path <path>`. Writes `status: processed` + `processed_at: <ISO-8601 UTC>` atomically, preserves all other frontmatter, preserves the body verbatim, leaves the file at its original path. Idempotent on already-processed notes. This step is frontmatter-only, in place — the note stays in `01-Inbox/` indefinitely; `prescan.py` archives it after the 7-day window. Do NOT move or delete the file (see Step 5 INVARIANT above).
+
+**Exempt: `calendar` routes** — `route_calendar_event --finalize` already marked them processed. Do NOT mark again for a note that returned `status: "finalized"`.
 
 The helper prints a single-line JSON to stdout on exit 0 and `{"error": …, "detail": "…"}` to stderr on non-zero exits. Act on the exit code immediately:
 

--- a/tests/inbox/conftest.py
+++ b/tests/inbox/conftest.py
@@ -14,4 +14,17 @@ SCRIPTS_INBOX = REPO_ROOT / "scripts" / "inbox"
 if str(SCRIPTS_INBOX) not in sys.path:
     sys.path.insert(0, str(SCRIPTS_INBOX))
 
+# Unify the bare ``routing_log`` and packaged ``scripts.inbox.routing_log``
+# module identities. Inbox tests import the bare form (via the sys.path entry
+# above) and monkeypatch ``routing_log.DEFAULT_ROUTING_LOG_PATH``, while
+# ``prescan.py`` and ``route_calendar_event.py`` import the packaged form. Pin
+# them to ONE module object so a monkeypatch on either is seen by both,
+# regardless of which test imports which form first. Previously this identity
+# held only by luck of import order; a test importing the packaged form early
+# could split them and silently disable routing-log dedup in later tests.
+import importlib as _importlib  # noqa: E402
+
+_routing_log_mod = _importlib.import_module("routing_log")
+sys.modules["scripts.inbox.routing_log"] = _routing_log_mod
+
 FIXTURES_DIR = Path(__file__).resolve().parent / "fixtures"

--- a/tests/inbox/test_append_routing_entry.py
+++ b/tests/inbox/test_append_routing_entry.py
@@ -1,0 +1,80 @@
+"""Tests for the append_routing_entry CLI — issue_task + calendar routes (#737)."""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from scripts.inbox import append_routing_entry as cli
+from scripts.inbox import routing_log as _routing_log
+
+
+def _run(argv, capsys):
+    code = cli.main(argv)
+    cap = capsys.readouterr()
+    return code, cap.out, cap.err
+
+
+def _redirect(tmp_path, monkeypatch):
+    log = tmp_path / "routing.jsonl"
+    monkeypatch.setattr(_routing_log, "DEFAULT_ROUTING_LOG_PATH", log)
+    return log
+
+
+def test_issue_task_positional_form_unchanged(tmp_path, capsys, monkeypatch):
+    log = _redirect(tmp_path, monkeypatch)
+    code, out, err = _run(["n.md", "42", "7", "an excerpt"], capsys)
+    assert code == 0, err
+    row = json.loads(log.read_text().splitlines()[0])
+    assert row["filename"] == "n.md"
+    assert row["issue_number"] == 42
+    assert row["vikunja_task_id"] == 7
+    assert row["kind"] == "issue_task"
+
+
+def test_issue_task_dash_task_id(tmp_path, capsys, monkeypatch):
+    log = _redirect(tmp_path, monkeypatch)
+    code, out, err = _run(["n.md", "0", "-"], capsys)
+    assert code == 0, err
+    row = json.loads(log.read_text().splitlines()[0])
+    assert row["issue_number"] == 0
+    assert row["vikunja_task_id"] is None
+
+
+def test_calendar_route_records_event_id(tmp_path, capsys, monkeypatch):
+    log = _redirect(tmp_path, monkeypatch)
+    code, out, err = _run(["Note 1.md", "--kind", "calendar", "--event-id", "evt_xyz"], capsys)
+    assert code == 0, err
+    row = json.loads(log.read_text().splitlines()[0])
+    assert row["kind"] == "calendar"
+    assert row["destination"] == "evt_xyz"
+    assert row["filename"] == "Note 1.md"
+    assert row["issue_number"] is None
+
+
+def test_calendar_requires_event_id(tmp_path, capsys, monkeypatch):
+    _redirect(tmp_path, monkeypatch)
+    code, out, err = _run(["n.md", "--kind", "calendar"], capsys)
+    assert code == 2
+    assert "event-id" in err
+
+
+def test_calendar_rejects_positional_issue_number(tmp_path, capsys, monkeypatch):
+    _redirect(tmp_path, monkeypatch)
+    code, out, err = _run(["n.md", "42", "--kind", "calendar", "--event-id", "e"], capsys)
+    assert code == 2
+    assert "issue_number is not allowed" in err
+
+
+def test_issue_task_requires_issue_number(tmp_path, capsys, monkeypatch):
+    _redirect(tmp_path, monkeypatch)
+    code, out, err = _run(["n.md"], capsys)
+    assert code == 2
+    assert "issue_number is required" in err
+
+
+def test_issue_task_bad_vikunja_id_is_clean_error(tmp_path, capsys, monkeypatch):
+    _redirect(tmp_path, monkeypatch)
+    # A non-int, non-'-' task id must exit 2 cleanly (not raise ValueError).
+    code, out, err = _run(["n.md", "42", "not-an-int"], capsys)
+    assert code == 2
+    assert "must be an integer" in err

--- a/tests/inbox/test_route_calendar_event.py
+++ b/tests/inbox/test_route_calendar_event.py
@@ -537,3 +537,268 @@ class TestCreateMode:
         )
         monkeypatch.setenv("FELIX_CALENDAR_HELPER_PYTHON", "/tmp/venv/bin/python")
         assert helper._calendar_helper_python() == "/tmp/venv/bin/python"
+
+
+# ---------------------------------------------------------------------------
+# --finalize mode (#737/#738/#657): atomic create -> verify -> mark -> log
+#
+# _invoke_calendar_helper (create) and _invoke_mark_processed (subprocess) are
+# MOCKED; the routing log is redirected to a tmp file.
+# ---------------------------------------------------------------------------
+
+
+from scripts.inbox import routing_log as _routing_log  # noqa: E402
+
+
+def _created_stdout(event_id="evt_1", html="https://cal/evt_1", idempotent=False):
+    return (
+        f'{{"status": "created", "idempotent": {str(idempotent).lower()}, '
+        f'"event_id": "{event_id}", "html_link": "{html}"}}\n'
+        "SUMMARY: op=create status=created\n"
+    )
+
+
+class TestFinalizeMode:
+    def _redirect_log(self, tmp_path, monkeypatch):
+        log = tmp_path / "routing.jsonl"
+        monkeypatch.setattr(_routing_log, "DEFAULT_ROUTING_LOG_PATH", log)
+        return log
+
+    def test_finalize_success_marks_and_logs(self, tmp_path, capsys, monkeypatch):
+        log = self._redirect_log(tmp_path, monkeypatch)
+        monkeypatch.setattr(
+            helper, "_invoke_calendar_helper",
+            lambda *a, **k: _fake_completed(0, stdout=_created_stdout()),
+        )
+        marked = {"called_with": None}
+
+        def fake_mark(source_path):
+            marked["called_with"] = source_path
+            return _fake_completed(0, stdout='{"finalized": true, "status": "processed"}\n')
+
+        monkeypatch.setattr(helper, "_invoke_mark_processed", fake_mark)
+
+        pf = _write_payload(tmp_path, {"title": "Emanuel call", "start": "2026-07-16T12:00:00-04:00"})
+        code, out, err = _run(
+            ["--payload-file", str(pf), "--finalize", "--source-path", "/inbox/Note 1.md"],
+            capsys,
+        )
+        assert code == 0, err
+        result = json.loads(out)
+        assert result["status"] == "finalized"
+        assert result["event_id"] == "evt_1"
+        assert result["marked_processed"] is True
+        assert result["routing_logged"] is True
+        # mark_processed was invoked with the raw source path.
+        assert marked["called_with"] == "/inbox/Note 1.md"
+        # A calendar routing-log row was written (basename key, kind, destination).
+        rows = [json.loads(l) for l in log.read_text().splitlines() if l.strip()]
+        assert len(rows) == 1
+        assert rows[0]["filename"] == "Note 1.md"
+        assert rows[0]["kind"] == "calendar"
+        assert rows[0]["destination"] == "evt_1"
+
+    def test_finalize_idempotent_hit_still_finalizes(self, tmp_path, capsys, monkeypatch):
+        self._redirect_log(tmp_path, monkeypatch)
+        monkeypatch.setattr(
+            helper, "_invoke_calendar_helper",
+            lambda *a, **k: _fake_completed(0, stdout=_created_stdout(idempotent=True)),
+        )
+        monkeypatch.setattr(helper, "_invoke_mark_processed", lambda p: _fake_completed(0))
+        pf = _write_payload(tmp_path, {"title": "Sync", "start": "2026-07-16T12:00:00-04:00"})
+        code, out, err = _run(
+            ["--payload-file", str(pf), "--finalize", "--source-path", "/inbox/n.md"], capsys
+        )
+        assert code == 0, err
+        assert json.loads(out)["status"] == "finalized"
+
+    def test_finalize_create_error_does_not_mark_or_log(self, tmp_path, capsys, monkeypatch):
+        log = self._redirect_log(tmp_path, monkeypatch)
+        monkeypatch.setattr(
+            helper, "_invoke_calendar_helper",
+            lambda *a, **k: _fake_completed(3, stderr="ERROR: auth_failed invalid_grant\n"),
+        )
+
+        def fake_mark(source_path):  # pragma: no cover - must NOT be called
+            raise AssertionError("mark_processed must not run when create fails")
+
+        monkeypatch.setattr(helper, "_invoke_mark_processed", fake_mark)
+        pf = _write_payload(tmp_path, {"title": "Sync", "start": "2026-07-16T12:00:00-04:00"})
+        code, out, err = _run(
+            ["--payload-file", str(pf), "--finalize", "--source-path", "/inbox/n.md"], capsys
+        )
+        assert code == 1, "create failure must be a NON-zero exit (fail-loud)"
+        result = json.loads(out)
+        assert result["status"] == "error"
+        assert "auth_failed invalid_grant" in result["error"]
+        assert not log.exists() or log.read_text().strip() == ""
+
+    def test_finalize_needs_clarification_not_finalized(self, tmp_path, capsys, monkeypatch):
+        self._redirect_log(tmp_path, monkeypatch)
+
+        def fake_invoke(*a, **k):  # pragma: no cover - not called for invalid payload
+            raise AssertionError("helper must not be called for an invalid payload")
+
+        monkeypatch.setattr(helper, "_invoke_calendar_helper", fake_invoke)
+        monkeypatch.setattr(helper, "_invoke_mark_processed", lambda p: _fake_completed(0))
+        pf = _write_payload(tmp_path, {"title": "Sync"})  # missing start
+        code, out, err = _run(
+            ["--payload-file", str(pf), "--finalize", "--source-path", "/inbox/n.md"], capsys
+        )
+        assert code == 0, err
+        result = json.loads(out)
+        assert result["status"] == "needs_clarification"
+        assert "start" in result["missing"]
+
+    def test_finalize_mark_failure_is_error_not_logged(self, tmp_path, capsys, monkeypatch):
+        log = self._redirect_log(tmp_path, monkeypatch)
+        monkeypatch.setattr(
+            helper, "_invoke_calendar_helper",
+            lambda *a, **k: _fake_completed(0, stdout=_created_stdout()),
+        )
+        monkeypatch.setattr(
+            helper, "_invoke_mark_processed",
+            lambda p: _fake_completed(3, stderr='{"error": "refused"}'),
+        )
+        pf = _write_payload(tmp_path, {"title": "Sync", "start": "2026-07-16T12:00:00-04:00"})
+        code, out, err = _run(
+            ["--payload-file", str(pf), "--finalize", "--source-path", "/inbox/n.md"], capsys
+        )
+        assert code == 1, "mark_processed failure must be NON-zero (fail-loud)"
+        result = json.loads(out)
+        assert result["status"] == "error"
+        assert result["stage"] == "mark_processed"
+        assert result["event_id"] == "evt_1"  # the event DID get created — surface it
+        # routing log must NOT be written (mark did not succeed).
+        assert not log.exists() or log.read_text().strip() == ""
+
+    def test_finalize_routing_log_failure_still_finalized(self, tmp_path, capsys, monkeypatch):
+        self._redirect_log(tmp_path, monkeypatch)
+        monkeypatch.setattr(
+            helper, "_invoke_calendar_helper",
+            lambda *a, **k: _fake_completed(0, stdout=_created_stdout()),
+        )
+        monkeypatch.setattr(helper, "_invoke_mark_processed", lambda p: _fake_completed(0))
+        # Simulate a routing-log write failure (best-effort; non-fatal).
+        monkeypatch.setattr(helper, "_append_calendar_routing_log", lambda *a, **k: False)
+        pf = _write_payload(tmp_path, {"title": "Sync", "start": "2026-07-16T12:00:00-04:00"})
+        code, out, err = _run(
+            ["--payload-file", str(pf), "--finalize", "--source-path", "/inbox/n.md"], capsys
+        )
+        # The note IS processed and the event IS created → success, with a warning flag.
+        assert code == 0, err
+        result = json.loads(out)
+        assert result["status"] == "finalized"
+        assert result["routing_logged"] is False
+
+    def test_finalize_routing_log_is_idempotent(self, tmp_path, capsys, monkeypatch):
+        log = self._redirect_log(tmp_path, monkeypatch)
+        # Pre-seed an existing calendar row for this note.
+        log.write_text(json.dumps({"filename": "n.md", "kind": "calendar", "destination": "old"}) + "\n")
+        monkeypatch.setattr(
+            helper, "_invoke_calendar_helper",
+            lambda *a, **k: _fake_completed(0, stdout=_created_stdout()),
+        )
+        monkeypatch.setattr(helper, "_invoke_mark_processed", lambda p: _fake_completed(0))
+        pf = _write_payload(tmp_path, {"title": "Sync", "start": "2026-07-16T12:00:00-04:00"})
+        code, out, err = _run(
+            ["--payload-file", str(pf), "--finalize", "--source-path", "/inbox/n.md"], capsys
+        )
+        assert code == 0, err
+        assert json.loads(out)["routing_logged"] is True
+        # No duplicate row appended.
+        rows = [json.loads(l) for l in log.read_text().splitlines() if l.strip()]
+        assert len(rows) == 1
+
+    def test_finalize_dry_run_no_side_effects(self, tmp_path, capsys, monkeypatch):
+        log = self._redirect_log(tmp_path, monkeypatch)
+
+        def fake_invoke(*a, **k):  # pragma: no cover
+            raise AssertionError("dry-run must not call the calendar helper")
+
+        def fake_mark(p):  # pragma: no cover
+            raise AssertionError("dry-run must not mark processed")
+
+        monkeypatch.setattr(helper, "_invoke_calendar_helper", fake_invoke)
+        monkeypatch.setattr(helper, "_invoke_mark_processed", fake_mark)
+        pf = _write_payload(tmp_path, {"title": "Sync", "start": "2026-07-16T12:00:00-04:00"})
+        code, out, err = _run(
+            ["--payload-file", str(pf), "--finalize", "--dry-run", "--source-path", "/inbox/n.md"],
+            capsys,
+        )
+        assert code == 0, err
+        result = json.loads(out)
+        assert result["status"] == "dry_run"
+        assert result["would_finalize"] is True
+        assert result["envelope"]["summary"] == "Sync"
+        assert not log.exists() or log.read_text().strip() == ""
+
+    def test_finalize_dry_run_invalid_is_needs_clarification(self, tmp_path, capsys):
+        pf = _write_payload(tmp_path, {"title": "Sync"})  # missing start
+        code, out, err = _run(
+            ["--payload-file", str(pf), "--finalize", "--dry-run", "--source-path", "/inbox/n.md"],
+            capsys,
+        )
+        assert code == 0, err
+        assert json.loads(out)["status"] == "needs_clarification"
+
+    def test_finalize_requires_source_path(self, tmp_path, capsys):
+        pf = _write_payload(tmp_path, {"title": "Sync", "start": "2026-07-16T12:00:00-04:00"})
+        code, out, err = _run(["--payload-file", str(pf), "--finalize"], capsys)
+        assert code == 1
+        assert "missing_source_path" in err
+
+    def test_finalize_and_create_mutually_exclusive(self, tmp_path, capsys):
+        pf = _write_payload(tmp_path, {"title": "Sync", "start": "2026-07-16T12:00:00-04:00"})
+        code, out, err = _run(
+            ["--payload-file", str(pf), "--finalize", "--create", "--source-path", "/inbox/n.md"],
+            capsys,
+        )
+        assert code == 1
+        assert "mutually_exclusive" in err
+
+    def test_dry_run_without_finalize_rejected(self, tmp_path, capsys):
+        pf = _write_payload(tmp_path, {"title": "Sync", "start": "2026-07-16T12:00:00-04:00"})
+        code, out, err = _run(["--payload-file", str(pf), "--dry-run"], capsys)
+        assert code == 1
+        assert "invalid_flag" in err
+
+
+class TestSubprocessTimeouts:
+    def test_calendar_helper_timeout_returns_nonzero(self, monkeypatch):
+        import subprocess as _sp
+
+        def raise_timeout(*a, **k):
+            raise _sp.TimeoutExpired(cmd="calendar_helper", timeout=90)
+
+        monkeypatch.setattr(helper.subprocess, "run", raise_timeout)
+        proc = helper._invoke_calendar_helper({"a": 1}, "/inbox/n.md", "personal")
+        assert proc.returncode == helper._TIMEOUT_RETURNCODE
+        assert "timed out" in proc.stderr
+
+    def test_mark_processed_timeout_returns_nonzero(self, monkeypatch):
+        import subprocess as _sp
+
+        def raise_timeout(*a, **k):
+            raise _sp.TimeoutExpired(cmd="mark_processed", timeout=30)
+
+        monkeypatch.setattr(helper.subprocess, "run", raise_timeout)
+        proc = helper._invoke_mark_processed("/inbox/n.md")
+        assert proc.returncode == helper._TIMEOUT_RETURNCODE
+        assert "timed out" in proc.stderr
+
+    def test_finalize_surfaces_helper_timeout_as_error(self, tmp_path, capsys, monkeypatch):
+        import subprocess as _sp
+
+        # subprocess.run raises TimeoutExpired -> _invoke_calendar_helper catches
+        # it and returns rc=124 -> _run_create -> error -> _run_finalize exit 1.
+        monkeypatch.setattr(
+            helper.subprocess, "run",
+            lambda *a, **k: (_ for _ in ()).throw(_sp.TimeoutExpired("x", 90)),
+        )
+        pf = _write_payload(tmp_path, {"title": "Sync", "start": "2026-07-16T12:00:00-04:00"})
+        code, out, err = _run(
+            ["--payload-file", str(pf), "--finalize", "--source-path", "/inbox/n.md"], capsys
+        )
+        assert code == 1
+        assert json.loads(out)["status"] == "error"

--- a/tests/inbox/test_routing_log.py
+++ b/tests/inbox/test_routing_log.py
@@ -199,3 +199,44 @@ def test_default_routing_log_path_under_data_services():
     # /data/services/openclaw/state/ per #656 (persistent-state boundary fix).
     assert str(DEFAULT_ROUTING_LOG_PATH) == "/data/services/openclaw/state/inbox-routing.jsonl"
     assert DEFAULT_ROUTING_LOG_PATH.name == "inbox-routing.jsonl"
+
+
+# ---------------------------------------------------------------------------
+# #737 — calendar routes: kind / destination fields
+# ---------------------------------------------------------------------------
+
+
+def test_append_calendar_route_records_kind_and_destination(tmp_path: Path):
+    log = tmp_path / "log.jsonl"
+    writer = RoutingLogWriter(log)
+    entry = writer.append(
+        filename="Note 1.md", kind="calendar", destination="evt_abc", note_excerpt="Emanuel call"
+    )
+    assert entry.kind == "calendar"
+    assert entry.destination == "evt_abc"
+    assert entry.issue_number is None
+    assert entry.vikunja_task_id is None
+    row = json.loads(log.read_text().splitlines()[0])
+    assert row["kind"] == "calendar"
+    assert row["destination"] == "evt_abc"
+    assert row["filename"] == "Note 1.md"
+
+
+def test_append_issue_task_defaults_kind(tmp_path: Path):
+    log = tmp_path / "log.jsonl"
+    writer = RoutingLogWriter(log)
+    entry = writer.append(filename="n.md", issue_number=42, vikunja_task_id=7)
+    assert entry.kind == "issue_task"
+    assert entry.destination == ""
+    assert entry.issue_number == 42
+
+
+def test_reader_tolerates_old_rows_without_kind(tmp_path: Path):
+    # Rows written before #737 have no kind/destination — dedup still works.
+    log = tmp_path / "log.jsonl"
+    log.write_text(
+        json.dumps({"filename": "old.md", "issue_number": 5, "vikunja_task_id": None,
+                    "routed_at": "2026-01-01T00:00:00Z", "note_excerpt": ""}) + "\n"
+    )
+    reader = RoutingLogReader(log)
+    assert reader.has("old.md")


### PR DESCRIPTION
Closes #737.

## Problem
The #699 calendar helper is correct; every remaining inbox→calendar failure lived at the **agent-orchestration seam**. The haiku capture agent ran a brittle multi-step sequence and failed by dropping `--create` (a silent no-op it misread as success), by `append_routing_entry` structurally rejecting calendar routes (#737), or by marking a note `processed` with **no event created** (#657 silent loss). Per Constitution **Directive 6**, this collapses the deterministic orchestration into ONE atomic, fail-loud operation.

## Change
- **`route_calendar_event --finalize`**: create → verify (`status==created` AND non-empty `event_id`) → `mark_processed` (via **subprocess**, so its C-001 privacy / inbox-root / symlink-resolve guards run and its stdout stays isolated) → routing-log append **last** (prescan dedups on the routing-log filename, so log-before-mark can strand a note; append is idempotent via `has()`). Any failure leaves the note **unprocessed → retried next tick**; the raw-source-path idempotency key prevents a double-create. Exit code derives from the outcome (error → non-zero), never from `_run_create` (which returns 0 on every branch). Plus `--finalize --dry-run` (credential-free wiring check) and 90s/30s subprocess timeouts.
- **`routing_log`** schema gains `kind`/`destination` (backward-compatible). **`append_routing_entry`** accepts `--kind calendar --event-id` (#737); issue_task positional form unchanged; bad task id now exits 2 cleanly.
- **capture `AGENTS.md`**: calendar route → single `--finalize` command; Step 5b/5c exempt calendar routes.
- **`tests/inbox/conftest.py`** unifies the bare vs packaged `routing_log` module identity (was luck-of-import-order).

## Review
Two adversarial gates (**plan** + **code**), Opus primary + Codex second lens. Plan review caught 3 must-fix HIGHs *before* implementation (mark_processed-must-be-subprocess; exit-code-from-status; log-after-mark ordering). Code review confirmed **no silent-loss path** and drove the subprocess-timeout + argparse-guard hardening. **Full suite: 4785 pass.**

## Scope
The **silent-loss core** of #738/#657 is fixed here. Deferred remainders tracked: **#739** (deterministic relative-date resolver), **#740** (pending-clarification re-ask loop), and calendar classification quality (prep-vs-new-event). #738/#657 left open for that work.

## Deploy / rebaseline
Helpers land via the office2 checkout self-pull; `AGENTS.md` via agent-prompt-sync. **Rebaseline: not required** — agent prompts aren't hashed by audit.sh (#621); no audited surface changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)