### PR TITLE
fix(#753): exempt pre-#746 notes from processed-without-routing-log health rail

### DIFF
--- a/scripts/inbox/prescan.py
+++ b/scripts/inbox/prescan.py
@@ -79,6 +79,7 @@ class InboxFile:
     warning: Optional[str] = None
     parse_failure_reason: Optional[str] = None  # set when classification == "parse-failure" (#185)
     has_stale_error_marker: bool = False  # True when the body has a felix-capture marker but parses cleanly (#185)
+    processed_at_utc: Optional[datetime] = None  # parsed `processed_at` frontmatter (#753 cutover guard); None if absent/unparseable
 
     @property
     def age_days(self) -> float:
@@ -249,6 +250,23 @@ def _extract_frontmatter_block(text: str) -> Optional[str]:
     return None  # unterminated fence → no frontmatter
 
 
+def _parse_processed_at_dt(raw: object) -> Optional[datetime]:
+    """Parse a ``processed_at`` frontmatter value into a tz-aware UTC datetime.
+
+    Returns ``None`` when the value is missing, malformed, or unparseable.
+    Naive datetimes / ISO strings are assumed to be UTC.
+    """
+    if isinstance(raw, datetime):
+        return raw if raw.tzinfo else raw.replace(tzinfo=timezone.utc)
+    if isinstance(raw, str):
+        try:
+            ts = datetime.fromisoformat(raw)
+        except (ValueError, TypeError):
+            return None
+        return ts if ts.tzinfo else ts.replace(tzinfo=timezone.utc)
+    return None
+
+
 def _parse_processed_at_age(
     raw: object, now_utc: datetime
 ) -> Optional[float]:
@@ -257,16 +275,8 @@ def _parse_processed_at_age(
     Returns ``None`` when the value is missing, malformed, or unparseable —
     the caller should fall back to filesystem mtime in that case.
     """
-    if isinstance(raw, datetime):
-        ts = raw if raw.tzinfo else raw.replace(tzinfo=timezone.utc)
-    elif isinstance(raw, str):
-        try:
-            ts = datetime.fromisoformat(raw)
-        except (ValueError, TypeError):
-            return None
-        if ts.tzinfo is None:
-            ts = ts.replace(tzinfo=timezone.utc)
-    else:
+    ts = _parse_processed_at_dt(raw)
+    if ts is None:
         return None
     return (now_utc - ts).total_seconds() / 86400.0
 
@@ -368,6 +378,7 @@ def classify_file(path: Path, now_utc: datetime) -> InboxFile:
     status_raw: Optional[str] = None
     warning: Optional[str] = None
     frontmatter: Optional[dict] = None
+    processed_at_utc: Optional[datetime] = None
 
     try:
         text = path.read_text(encoding="utf-8")
@@ -440,11 +451,9 @@ def classify_file(path: Path, now_utc: datetime) -> InboxFile:
         classification = "unprocessed"
     elif status_raw == "processed":
         # Prefer processed_at frontmatter over filesystem mtime (issue #187).
-        processed_at_age = _parse_processed_at_age(
-            frontmatter.get("processed_at"), now_utc
-        )
-        if processed_at_age is not None:
-            age_days = processed_at_age
+        processed_at_utc = _parse_processed_at_dt(frontmatter.get("processed_at"))
+        if processed_at_utc is not None:
+            age_days = (now_utc - processed_at_utc).total_seconds() / 86400.0
         if age_days > STALE_AGE_DAYS:
             classification = "processed-stale"
         else:
@@ -475,6 +484,7 @@ def classify_file(path: Path, now_utc: datetime) -> InboxFile:
         classification=classification,
         warning=warning,
         has_stale_error_marker=has_stale_error_marker,
+        processed_at_utc=processed_at_utc,
     )
 
 
@@ -670,6 +680,16 @@ _SILENT_LOSS_WARNING = (
     "status:processed but no routing-log entry (silent-loss signature #746)"
 )
 
+# #753 — the #746 atomic-finalize log-before-mark guarantee went live on
+# 2026-07-17 (merge 5f6c0c5e, deployed same day). Notes processed BEFORE this
+# instant predate the routing-log guarantee, so a missing routing-log entry is
+# NOT a silent-loss signal for them (the log simply never covered them). The
+# rail exempts pre-cutover notes to stop a retroactive false-positive storm
+# (51 pre-#746 notes flagged every tick). All pre-#746 processed notes are
+# dated 2026-07-15 or earlier, so a 2026-07-17 cutover has zero false-negative
+# risk for any note the guarantee actually covers.
+ROUTING_LOG_CUTOVER_UTC = datetime(2026, 7, 17, tzinfo=timezone.utc)
+
 
 def _md_candidates(directory: Path) -> list[Path]:
     """Non-recursive ``.md`` files in ``directory``, excluding daily logs.
@@ -714,7 +734,11 @@ def scan_processed_without_routing_log(
     finalized notes (including ``empty``-disposition notes) never trip the rail.
 
     ``needs-review`` and ``unprocessed`` notes are ignored (not ``processed``);
-    parse-failure notes are likewise skipped (no reliable ``status``).
+    parse-failure notes are likewise skipped (no reliable ``status``). Notes
+    processed before ``ROUTING_LOG_CUTOVER_UTC`` (the #746 go-live) are exempt
+    (#753): they predate the routing-log guarantee, so a missing entry is not a
+    loss signal. ``processed_at`` frontmatter dates the note; file mtime is the
+    fallback when it is absent/unparseable.
 
     Returns ``(anomalies, warnings)``. ``warnings`` carries a cap-applied notice
     when the combined candidate set exceeds ``ARCHIVE_SCAN_CAP``.
@@ -746,6 +770,13 @@ def scan_processed_without_routing_log(
             continue
         if reader.has(path.name):
             continue  # correctly finalized — has ≥1 routing-log entry.
+        # #753 — exempt notes processed before the #746 routing-log guarantee.
+        # Such notes cannot have a routing-log entry (the guarantee did not yet
+        # exist), so a missing entry is not a silent-loss signal. Fall back to
+        # filesystem mtime when processed_at is absent/unparseable.
+        effective_utc = info.processed_at_utc or info.mtime_utc
+        if effective_utc < ROUTING_LOG_CUTOVER_UTC:
+            continue
         anomalies.append(
             ArchiveAnomaly(
                 path=str(path),

--- a/tests/inbox/test_prescan_health_rail.py
+++ b/tests/inbox/test_prescan_health_rail.py
@@ -51,8 +51,23 @@ class _FakeReader:
         return filename in self._present
 
 
-def _write_note(path: Path, status: str, body: str = "Body.\n") -> None:
-    path.write_text(f"---\nstatus: {status}\n---\n\n{body}", encoding="utf-8")
+def _write_note(
+    path: Path,
+    status: str,
+    body: str = "Body.\n",
+    processed_at: str | None = None,
+) -> None:
+    """Write a note. ``processed`` notes get a ``processed_at`` so the #753
+    pre-cutover exemption does not make silent-loss-rail tests depend on the
+    real filesystem clock; default is post-cutover (flag-eligible). Pass an
+    explicit ``processed_at`` (e.g. a pre-cutover date) to exercise the guard.
+    """
+    fm = f"status: {status}\n"
+    if processed_at is not None:
+        fm += f"processed_at: {processed_at}\n"
+    elif status == "processed":
+        fm += "processed_at: 2026-07-17T12:00:00Z\n"  # post-#753-cutover default
+    path.write_text(f"---\n{fm}---\n\n{body}", encoding="utf-8")
 
 
 def _run_prescan_against(
@@ -227,6 +242,95 @@ class TestSilentLossRailUnit:
         )
         assert anomalies == []
         assert warnings == []
+
+
+# ---------------------------------------------------------------------------
+# #753 — pre-#746 cutover exemption for the silent-loss rail
+# ---------------------------------------------------------------------------
+
+
+class TestSilentLossRailCutover:
+    def test_pre_cutover_processed_note_exempt(self, tmp_path: Path):
+        """A note processed BEFORE the #746 go-live is not flagged (it predates
+        the routing-log guarantee, so a missing entry is not a loss signal)."""
+        inbox = tmp_path / "inbox"
+        processed = tmp_path / "processed"
+        inbox.mkdir()
+        processed.mkdir()
+        # One of the real 51 pre-#746 notes (#753): processed 2026-07-15.
+        _write_note(
+            inbox / "old-orphan.md", "processed", processed_at="2026-07-15T16:00:31Z"
+        )
+        anomalies, _ = prescan.scan_processed_without_routing_log(
+            inbox, processed, NOW, _FakeReader(present=set())
+        )
+        assert anomalies == []
+
+    def test_post_cutover_processed_note_still_flagged(self, tmp_path: Path):
+        """A note processed AT/AFTER the cutover with no log entry is a real
+        silent-loss anomaly and must still be flagged."""
+        inbox = tmp_path / "inbox"
+        processed = tmp_path / "processed"
+        inbox.mkdir()
+        processed.mkdir()
+        _write_note(
+            inbox / "new-orphan.md", "processed", processed_at="2026-07-18T09:00:00Z"
+        )
+        anomalies, _ = prescan.scan_processed_without_routing_log(
+            inbox, processed, NOW, _FakeReader(present=set())
+        )
+        assert len(anomalies) == 1
+        assert anomalies[0].classification == "processed-without-routing-log"
+
+    def test_cutover_boundary_is_inclusive_of_cutover_instant(self, tmp_path: Path):
+        """A note processed exactly at the cutover instant is flagged (the
+        guarantee holds from the cutover onward)."""
+        inbox = tmp_path / "inbox"
+        processed = tmp_path / "processed"
+        inbox.mkdir()
+        processed.mkdir()
+        _write_note(
+            inbox / "boundary.md", "processed", processed_at="2026-07-17T00:00:00Z"
+        )
+        anomalies, _ = prescan.scan_processed_without_routing_log(
+            inbox, processed, NOW, _FakeReader(present=set())
+        )
+        assert len(anomalies) == 1
+
+    def test_no_processed_at_falls_back_to_mtime(self, tmp_path: Path):
+        """When ``processed_at`` is absent, the guard uses file mtime: an old
+        mtime is exempt, a recent mtime is flagged."""
+        import os
+
+        inbox = tmp_path / "inbox"
+        processed = tmp_path / "processed"
+        inbox.mkdir()
+        processed.mkdir()
+        # No processed_at frontmatter; set mtime pre-cutover → exempt.
+        old = inbox / "undated-old.md"
+        old.write_text("---\nstatus: processed\n---\n\nBody.\n", encoding="utf-8")
+        pre = datetime(2026, 6, 1, tzinfo=timezone.utc).timestamp()
+        os.utime(old, (pre, pre))
+        # No processed_at; recent mtime post-cutover → flagged.
+        new = inbox / "undated-new.md"
+        new.write_text("---\nstatus: processed\n---\n\nBody.\n", encoding="utf-8")
+        post = datetime(2026, 7, 18, tzinfo=timezone.utc).timestamp()
+        os.utime(new, (post, post))
+
+        anomalies, _ = prescan.scan_processed_without_routing_log(
+            inbox, processed, NOW, _FakeReader(present=set())
+        )
+        flagged = {Path(a.path).name for a in anomalies}
+        assert flagged == {"undated-new.md"}
+
+    def test_classify_file_populates_processed_at_utc(self, tmp_path: Path):
+        """``classify_file`` exposes the parsed ``processed_at`` for the guard."""
+        note = tmp_path / "n.md"
+        _write_note(note, "processed", processed_at="2026-07-15T16:00:31Z")
+        info = prescan.classify_file(note, NOW)
+        assert info.processed_at_utc == datetime(
+            2026, 7, 15, 16, 0, 31, tzinfo=timezone.utc
+        )
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Closes #753.

The #746 `processed-without-routing-log` health rail retroactively flagged all 51 `processed` notes that predate the routing-log guarantee (processed ≤ 2026-07-15) as silent-loss anomalies — a false-positive storm that nags on every inbox tick (and now bundles with the #749 intake digest). A note processed before #746's atomic-finalize log-before-mark went live (2026-07-17) **cannot** have a routing-log entry, so a missing entry is not a loss signal.

## Fix
- `classify_file` exposes parsed `processed_at_utc` (extracted `_parse_processed_at_dt`; `_parse_processed_at_age` delegates — behavior-preserving).
- `scan_processed_without_routing_log` exempts notes whose effective date (`processed_at`, else file mtime) `< ROUTING_LOG_CUTOVER_UTC` (2026-07-17). The rail then only watches notes #746 actually guarantees a log for.

## Content-safety (the 3 active July notes — all accounted for, no active loss)
- `Inbox 2026-07-13` → its 6 tasks routed to Vikunja (now awaiting #749 intake). ✅
- `Inbox 2026-07-15` → routed to `08-Journal/Journal 2026-07-15 0942.md`. ✅
- `Inbox 2026-07-14` → the known 2026-07-14 incident (misclassified as calendar); note intact, call already happened. ⚠️ past silent-loss, no recovery needed.

## Verification
- New `TestSilentLossRailCutover` (exemption, post-cutover-still-flagged, boundary, mtime fallback, `processed_at_utc` population). 426 inbox tests pass; ruff clean.
- reviewer-renata (Opus) adversarial review: APPROVE — false-negative-safe (2-day margin; all real pre-#746 notes ≤07-15), tz-correct, refactor behavior-preserving.

Rebaseline: not required — `scripts/inbox/**` is not an audited surface.

🤖 Generated with [Claude Code](https://claude.com/claude-code)