### PR TITLE
refactor(#761): canonical scripts/common/et_datetime.py + migrate ET/UTC surfaces

### DIFF
--- a/scripts/calendar_routing/validate_calendar_event.py
+++ b/scripts/calendar_routing/validate_calendar_event.py
@@ -38,6 +38,14 @@ from datetime import datetime, timedelta
 from typing import Optional
 from zoneinfo import ZoneInfo
 
+# NOTE: this validator is invoked by SCRIPT PATH — its live entrypoint is
+# ``python3 scripts/calendar_routing/validate_calendar_event.py`` (see
+# ``scripts/openclaw/agents/felix-admin-calendar/AGENTS.md``), and its module
+# docstring guarantees purity. It therefore deliberately does NOT import
+# ``scripts.common`` (that would fail with ModuleNotFoundError under script-path
+# invocation — the #668 ``-m`` trap), so it keeps its own local Eastern zone
+# rather than sourcing the canonical ``scripts.common.et_datetime.ET_ZONE`` (the
+# #761 consolidation stops at this boundary by design).
 DEFAULT_TIMEZONE = "America/New_York"
 DEFAULT_CALENDAR_ID = "primary"
 # Credential-set selector for the direct-API calendar helper (D5). Flipped from

--- a/scripts/common/alert_bus/render.py
+++ b/scripts/common/alert_bus/render.py
@@ -14,16 +14,11 @@ emitters share one behavior.
 from __future__ import annotations
 
 from datetime import datetime, timezone
-from zoneinfo import ZoneInfo
 
+from scripts.common import et_datetime
 from scripts.deploy.lib.verify import redact_secrets
 
 from .model import Alert
-
-# Kent's operating timezone. The "local" timestamp must render in Eastern —
-# office2's system TZ is Etc/UTC, so a bare ``astimezone()`` would make "local"
-# identical to UTC (#759). DST-aware via zoneinfo.
-_ET_ZONE = ZoneInfo("America/New_York")
 
 # Bounded length for redacted detail values. Matches the deployer's
 # ERROR_SUMMARY_MAX so migrated failure alerts keep byte-comparable bodies.
@@ -54,13 +49,14 @@ def _format_timestamp(ts: datetime) -> str:
 
     A naive timestamp is assumed to already be UTC (the Alert default is
     UTC-aware; this only guards hand-built naive values). "local" is rendered in
-    Eastern explicitly — NOT via a bare ``astimezone()``, which would follow the
-    host TZ (office2 = Etc/UTC) and make "local" == UTC (#759).
+    Eastern via the canonical ``et_datetime.to_et`` (#761) — NOT a bare
+    ``astimezone()``, which would follow the host TZ (office2 = Etc/UTC) and make
+    "local" == UTC (#759).
     """
     if ts.tzinfo is None:
         ts = ts.replace(tzinfo=timezone.utc)
     utc = ts.astimezone(timezone.utc)
-    local = ts.astimezone(_ET_ZONE)
+    local = et_datetime.to_et(ts)
     return f"{utc.isoformat()} (UTC) / {local.isoformat()} (local)"
 
 

--- a/scripts/common/et_datetime.py
+++ b/scripts/common/et_datetime.py
@@ -1,0 +1,168 @@
+"""Canonical Eastern-time date/time utilities (#761).
+
+Single source of truth for the ET/UTC boundary. Vikunja and office2 both
+default to UTC; surfaces that cross that boundary previously re-derived the
+same conversions inline, which is why the *same* ET-vs-UTC bug shape recurred
+on five independent code paths (#733/#736/#739/#757/#759). Consolidating the
+conversions here breaks that whack-a-mole cycle.
+
+Adopted so far (#761): escalation write (``record_completion``) + read
+(``enumerate_candidates``), intake ``apply_reply`` + ``scan_inbox``, and the
+alert-bus renderer. Not yet folded in (each still carries an inline copy, to be
+migrated incrementally): the ``scripts/habits/*`` date logic,
+``scripts/security/credential_health_check/vikunja_writer.py`` (its own
+end-of-day ET write), ``scripts/sync/guards.py``, and the calendar validator
+``scripts/calendar_routing/validate_calendar_event.py`` — the last is invoked by
+script path and deliberately avoids a ``scripts.common`` import (the #668 ``-m``
+trap), so it keeps a local zone constant.
+
+Hard rule: never use a bare no-argument ``dt.astimezone()``. On office2 the
+host TZ is ``Etc/UTC``, so a bare call silently yields UTC, not Eastern (the
+#759 shape). Always convert with an explicit zone — this module does, and the
+pytest AST guard ``tests/common/test_no_bare_astimezone.py`` enforces the rule
+repo-wide.
+"""
+
+from __future__ import annotations
+
+from datetime import date, datetime, timezone, tzinfo
+from zoneinfo import ZoneInfo
+
+#: Kent's operating timezone. DST-aware (``-04:00`` EDT / ``-05:00`` EST).
+ET_ZONE = ZoneInfo("America/New_York")
+
+__all__ = [
+    "ET_ZONE",
+    "to_et",
+    "today_et",
+    "parse_vikunja_instant",
+    "et_calendar_date",
+    "et_end_of_day",
+]
+
+
+def to_et(value: datetime, *, assume: tzinfo = timezone.utc) -> datetime:
+    """Return *value* as an aware datetime in :data:`ET_ZONE`.
+
+    A naive *value* is interpreted as being in *assume* (default UTC — the
+    alert-bus and Vikunja convention). Callers whose naive values are
+    wall-clock Eastern (calendar routing) pass ``assume=ET_ZONE``.
+    """
+    if value.tzinfo is None:
+        value = value.replace(tzinfo=assume)
+    return value.astimezone(ET_ZONE)
+
+
+def today_et(*, now: datetime | None = None) -> date:
+    """Return today's calendar date in :data:`ET_ZONE`.
+
+    *now* (aware, or naive-assumed-UTC) is injectable for tests; it defaults to
+    the current instant. Using the Eastern calendar date — not the UTC one —
+    is what keeps "today"/"tomorrow" correct for Kent between ~19:00–23:59 ET,
+    when the UTC date has already rolled over (the #733 class).
+    """
+    if now is None:
+        now = datetime.now(timezone.utc)
+    return to_et(now).date()
+
+
+def parse_vikunja_instant(value: object) -> datetime | None:
+    """Parse a Vikunja ``due_date`` string into an aware **UTC** instant.
+
+    Vikunja serializes every ``due_date`` to UTC ``Z`` (#733/#736), but a value
+    written as an ET offset (``…-04:00``) denotes the same instant. This returns
+    that instant in UTC so callers can compare instants (#757) or take an
+    Eastern calendar date (:func:`et_calendar_date`).
+
+    Returns ``None`` — the "no usable due date" signal — for: a non-str /
+    empty / whitespace-only value; any **year <= 1** datetime (this covers the
+    ``0001-01-01`` "unset" sentinel in every offset spelling, and defensively
+    excludes any other year-1 value too — checked *before* conversion, since a
+    year-1 ``.astimezone()`` can ``OverflowError``); a **naive** datetime
+    (Vikunja values are always aware, so a naive one is malformed and is
+    excluded rather than assumed UTC — matching the escalation read-side's
+    deliberate "don't guess a timezone" safety choice); and any value that fails
+    ISO-8601 parsing.
+
+    Note the ``year <= 1`` and naive exclusions are slightly *broader* than the
+    prior inline ``apply_reply._due_instant`` (which only pre-checked the literal
+    ``0001-01-01`` prefix and assumed naive→UTC). That is safe for the existing
+    callers — the readback-compare only ever sees modern aware strings on both
+    sides — but a future reuse on a surface that can produce naive or non-Jan-1
+    year-1 strings will exclude values the old inline copy would have accepted.
+    """
+    if not isinstance(value, str):
+        return None
+    stripped = value.strip()
+    if not stripped:
+        return None
+    normalized = (
+        stripped.replace("Z", "+00:00") if stripped.endswith("Z") else stripped
+    )
+    try:
+        parsed = datetime.fromisoformat(normalized)
+    except ValueError:
+        return None
+    if parsed.tzinfo is None:
+        return None
+    if parsed.year <= 1:
+        return None
+    try:
+        return parsed.astimezone(timezone.utc)
+    except (OverflowError, ValueError, OSError):
+        return None
+
+
+def et_calendar_date(value: object, *, zone: tzinfo = ET_ZONE) -> date | None:
+    """Return the Eastern calendar date of a Vikunja ``due_date`` string.
+
+    Parses via :func:`parse_vikunja_instant`, converts to *zone* (default
+    :data:`ET_ZONE`; overridable for tests), and takes the calendar date — so a
+    ``23:00 UTC`` due date reads as the *prior* Eastern day, which is what makes
+    day-boundary classification consistent. Returns ``None`` when the value is
+    excluded (see :func:`parse_vikunja_instant`).
+    """
+    instant = parse_vikunja_instant(value)
+    if instant is None:
+        return None
+    try:
+        return instant.astimezone(zone).date()
+    except (OverflowError, ValueError, OSError):
+        return None
+
+
+def et_end_of_day(target: date | str) -> str:
+    """Render a date as an end-of-day Eastern instant string.
+
+    Returns ``YYYY-MM-DDT23:59:59±HH:MM`` anchored to ``23:59:59`` in
+    :data:`ET_ZONE` with the DST-correct offset (``-04:00`` EDT / ``-05:00``
+    EST) — never UTC ``Z``. Writing UTC midnight (``…T00:00:00Z``) lands in the
+    *prior* Eastern evening, so a task due "June 15" reads back as June 14 and
+    is mis-classified as overdue a day early (#733). End-of-day ET is the single
+    correct ``due_date`` write for every Vikunja surface.
+
+    *target* is a :class:`datetime.date` or a ``YYYY-MM-DD`` string.
+
+    Raises:
+        ValueError: If *target* is a non-``YYYY-MM-DD`` string, or a
+            pre-standardization date whose Eastern offset carries sub-minute
+            seconds (e.g. a year-1 Local-Mean-Time ``-04:56:02``) — never a real
+            due date and a violation of the ``±HH:MM`` contract.
+    """
+    if isinstance(target, str):
+        target = date.fromisoformat(target)
+    anchor = datetime(
+        target.year, target.month, target.day, 23, 59, 59, tzinfo=ET_ZONE
+    )
+    raw_offset = anchor.strftime("%z")
+    if len(raw_offset) != 5:
+        # Modern Eastern Time is always a whole-hour offset (``-0400`` /
+        # ``-0500`` → 5 chars). A longer value carries a pre-1883 Local Mean
+        # Time offset with seconds (e.g. ``-045602``), which is never a real
+        # due date and would break the ``YYYY-MM-DDT23:59:59±HH:MM`` contract.
+        raise ValueError(
+            f"date {target.isoformat()!r} resolves to a non-standard UTC "
+            f"offset {raw_offset!r}; expected a modern Eastern date"
+        )
+    offset = f"{raw_offset[:3]}:{raw_offset[3:]}"
+    return f"{target.isoformat()}T23:59:59{offset}"

--- a/scripts/escalation/enumerate_candidates.py
+++ b/scripts/escalation/enumerate_candidates.py
@@ -53,7 +53,7 @@ day.
 
 Public surface
 --------------
-Constants: ``LOCAL_TZ``, ``SENTINEL_DUE_DATE``, ``PER_PAGE``
+Constants: ``LOCAL_TZ``, ``PER_PAGE``
 Dataclass: ``EscalationCandidate``
 Functions: ``normalize_due_date``, ``filter_candidates``, ``fetch_all_tasks``, ``main``
 """
@@ -64,16 +64,16 @@ import json
 import sys
 import zoneinfo
 from dataclasses import asdict, dataclass
-from datetime import date, datetime
+from datetime import date
 from pathlib import Path
 from typing import Any, Iterable, Literal, Optional
 
+from scripts.common import et_datetime
 from scripts.common.vikunja_client import VikunjaClient, VikunjaError
 from scripts.common.vikunja_scope import get_escalation_excluded_project_ids
 
 __all__ = [
     "LOCAL_TZ",
-    "SENTINEL_DUE_DATE",
     "PER_PAGE",
     "EscalationCandidate",
     "normalize_due_date",
@@ -84,11 +84,9 @@ __all__ = [
 
 #: Local timezone for "today" and due-date comparisons (H8). Escalation
 #: operates in Kent's local TZ so date boundaries fall on America/New_York
-#: calendar days, not UTC days — mirrors ``derive_state.LOCAL_TZ``.
-LOCAL_TZ = zoneinfo.ZoneInfo("America/New_York")
-
-#: Vikunja's "no due date" sentinel value (year 1, per SKILL.md §1).
-SENTINEL_DUE_DATE = "0001-01-01T00:00:00Z"
+#: calendar days, not UTC days. Sourced from the canonical ET utility (#761)
+#: so there is one ``America/New_York`` definition repo-wide.
+LOCAL_TZ = et_datetime.ET_ZONE
 
 #: Vikunja's hard cap on page size for ``/tasks/all``.
 PER_PAGE = 50
@@ -128,26 +126,19 @@ class EscalationCandidate:
 def normalize_due_date(value: Any, *, local_tz: zoneinfo.ZoneInfo = LOCAL_TZ) -> Optional[date]:
     """Parse a Vikunja ``due_date`` value into a local (ET) calendar date.
 
-    Per H8: rejects (returns ``None`` for) ``None``, empty/whitespace-only
-    strings, the ``0001-01-01T00:00:00Z`` sentinel (and any other-offset
-    spelling of the same year-1 "unset" moment, e.g.
-    ``0001-01-01T00:00:00+00:00``), non-str values, and any value that fails
-    ISO-8601 parsing. A successfully parsed value is converted to
-    ``local_tz`` and the **local calendar date** is returned (not the raw
-    UTC date) — this is what makes the day-boundary tests (23:00 UTC vs
-    01:00 UTC) classify consistently.
-
-    Post-merge Codex review (#723): the literal-string sentinel check only
-    caught the exact ``0001-01-01T00:00:00Z`` spelling. A variant like
-    ``0001-01-01T00:00:00+00:00`` parses successfully as a year-1
-    ``datetime``, and converting a year-1 datetime via ``.astimezone()`` can
-    raise ``OverflowError`` (the local-offset arithmetic underflows
-    ``datetime.min``), crashing the whole escalation run instead of
-    excluding the one malformed task. Guarded two ways: (1) any parsed
-    datetime with ``year <= 1`` is treated as the sentinel and excluded
-    BEFORE the timezone conversion; (2) the conversion itself is wrapped to
-    catch ``OverflowError``/``ValueError``/``OSError`` defensively and
-    exclude rather than raise.
+    Thin H8 wrapper over the canonical
+    :func:`scripts.common.et_datetime.et_calendar_date` (#761), which owns the
+    shared parse / sentinel / naive / year-1 exclusion logic. Behavior is
+    unchanged: returns ``None`` for ``None``, empty/whitespace-only strings, the
+    ``0001-01-01`` year-1 "unset" sentinel in any offset spelling, naive
+    datetimes (excluded — not assumed UTC — the deliberate "don't guess a
+    timezone" H8 choice), and any value that fails ISO-8601 parsing; otherwise
+    converts the instant to ``local_tz`` and returns the **local calendar
+    date** (not the raw UTC date), which is what keeps day-boundary
+    classification (23:00 UTC vs 01:00 UTC) consistent. The year-1 exclusion
+    (before conversion) and the defensive ``OverflowError``/``ValueError``/
+    ``OSError`` guard around the conversion (the #723 / H9 fix) both live in the
+    canonical helper now.
 
     Args:
         value: The raw ``due_date`` field from a Vikunja task dict.
@@ -158,34 +149,7 @@ def normalize_due_date(value: Any, *, local_tz: zoneinfo.ZoneInfo = LOCAL_TZ) ->
         The local calendar :class:`date`, or ``None`` if the value must be
         excluded per H8.
     """
-    if not isinstance(value, str):
-        return None
-    stripped = value.strip()
-    if not stripped:
-        return None
-    if stripped == SENTINEL_DUE_DATE:
-        return None
-    normalized = stripped.replace("Z", "+00:00") if stripped.endswith("Z") else stripped
-    try:
-        parsed = datetime.fromisoformat(normalized)
-    except ValueError:
-        return None
-    if parsed.tzinfo is None:
-        # Malformed / naive datetime — H8 requires an aware value. Do not
-        # guess a timezone; exclude rather than silently assume UTC.
-        return None
-    if parsed.year <= 1:
-        # Any spelling of the year-1 "no due date" sentinel (not just the
-        # exact 0001-01-01T00:00:00Z string) — exclude BEFORE the timezone
-        # conversion, which can OverflowError on a year-1 datetime.
-        return None
-    try:
-        local_dt = parsed.astimezone(local_tz)
-    except (OverflowError, ValueError, OSError):
-        # Defensive: a conversion failure means we cannot classify this
-        # value — exclude rather than crash the whole escalation run (H9).
-        return None
-    return local_dt.date()
+    return et_datetime.et_calendar_date(value, zone=local_tz)
 
 
 def _qualifies(
@@ -362,7 +326,7 @@ def main(argv: Optional[list[str]] = None) -> int:
             print(f"error: --date '{args.date}' is not a valid YYYY-MM-DD date", file=sys.stderr)
             return 3
     else:
-        today = datetime.now(LOCAL_TZ).date()
+        today = et_datetime.today_et()
 
     token: Optional[str] = None
     if args.token_path is not None:

--- a/scripts/escalation/record_completion.py
+++ b/scripts/escalation/record_completion.py
@@ -69,11 +69,11 @@ import os
 import sys
 import urllib.error
 import urllib.request
-import zoneinfo
 from datetime import date, datetime, timedelta, timezone
 from pathlib import Path
 from typing import Any, Optional
 
+from scripts.common import et_datetime
 from scripts.common.state_log_schema import (
     validate_record as _validate_shared_record,
 )
@@ -118,8 +118,9 @@ HTTP_TIMEOUT_SECONDS = 30
 JSONL_STATE_DIR = Path("/data/services/openclaw/state/escalation")
 
 #: Kent's local timezone (FR-004). All ``snooze_until`` arithmetic and the
-#: write-time ``date`` resolution happen in this TZ.
-LOCAL_TZ = zoneinfo.ZoneInfo("America/New_York")
+#: write-time ``date`` resolution happen in this TZ. Sourced from the canonical
+#: ET utility (#761) so there is one ``America/New_York`` definition repo-wide.
+LOCAL_TZ = et_datetime.ET_ZONE
 
 #: File mode for per-project JSONL files (rw-rw-r--).
 _STATE_FILE_MODE: int = 0o664
@@ -286,7 +287,7 @@ def _today_local() -> date:
     ``datetime.now``. All snooze-arithmetic and the write-time ``date`` field
     flow through here.
     """
-    return datetime.now(LOCAL_TZ).date()
+    return et_datetime.today_et()
 
 
 def _now_utc_iso() -> str:
@@ -318,52 +319,6 @@ def _compute_snooze_until(snooze_days: int) -> str:
             f"snooze_days '{snooze_days!r}' must be a positive integer"
         )
     return (_today_local() + timedelta(days=snooze_days)).isoformat()
-
-
-def _reschedule_due_date_et(reschedule_to: str) -> str:
-    """Render a ``YYYY-MM-DD`` reschedule target as an end-of-day ET instant.
-
-    Vikunja stores ``due_date`` as an instant, but the escalation candidate
-    logic (:func:`scripts.escalation.enumerate_candidates.normalize_due_date`)
-    reads it back as an **America/New_York calendar date**. Writing UTC
-    midnight (``<date>T00:00:00Z``) lands in the *prior* ET evening, so a task
-    rescheduled "to June 15" would read back as June 14 and be mis-classified
-    as overdue a day early (#733).
-
-    We anchor to ``23:59:59`` in :data:`LOCAL_TZ` with the DST-correct offset
-    (``-04:00`` EDT / ``-05:00`` EST), matching the habits #112 fix
-    (``scripts/habits/set_due_dates.py``). The ``## Date handling`` rule in the
-    escalation agent prompt ("resolve in America/New_York, never use the ``Z``
-    suffix") is thereby enforced at the single write site.
-
-    Args:
-        reschedule_to: Target due date as ``YYYY-MM-DD``.
-
-    Returns:
-        ISO-8601 string ``YYYY-MM-DDT23:59:59<offset>``.
-
-    Raises:
-        ValueError: If ``reschedule_to`` is not a valid ``YYYY-MM-DD`` date.
-    """
-    target = date.fromisoformat(reschedule_to)
-    anchor = datetime(
-        target.year, target.month, target.day, 23, 59, 59, tzinfo=LOCAL_TZ
-    )
-    raw_offset = anchor.strftime("%z")
-    if len(raw_offset) != 5:
-        # Modern Eastern Time is always a whole-hour offset (``-0400`` /
-        # ``-0500`` → 5 chars). A longer value means a pre-standardization
-        # Local Mean Time offset carrying seconds (e.g. ``-045602`` for
-        # year-1 / pre-1883 targets), which is never a real reschedule and
-        # would violate the ``YYYY-MM-DDT23:59:59±HH:MM`` contract. Reject
-        # rather than emit a malformed due_date.
-        raise ValueError(
-            f"reschedule_to {reschedule_to!r} resolves to a non-standard "
-            f"UTC offset {raw_offset!r}; expected a modern Eastern date"
-        )
-    # raw_offset is a whole-hour ``±HHMM``; render as ISO-8601 ``±HH:MM``.
-    offset = f"{raw_offset[:3]}:{raw_offset[3:]}"
-    return f"{target.isoformat()}T23:59:59{offset}"
 
 
 # ---------------------------------------------------------------------------
@@ -503,7 +458,7 @@ def _vikunja_side_effects(
             "PATCH",
             url,
             token,
-            body={"due_date": _reschedule_due_date_et(reschedule_to)},
+            body={"due_date": et_datetime.et_end_of_day(reschedule_to)},
         )
         actions.append("task_PATCH_due_date")
 

--- a/scripts/intake/apply_reply.py
+++ b/scripts/intake/apply_reply.py
@@ -63,12 +63,11 @@ import json
 import os
 import sys
 from dataclasses import dataclass, field
-from datetime import date, datetime, timedelta, timezone
+from datetime import datetime, timedelta, timezone
 from pathlib import Path
 from typing import Any
-from zoneinfo import ZoneInfo
 
-from scripts.common import vikunja_refs
+from scripts.common import et_datetime, vikunja_refs
 from scripts.common.vikunja_client import (
     VikunjaAuthError,
     VikunjaError,
@@ -124,8 +123,6 @@ DEFAULT_WINDOW_HOURS = 48
 #: Bound every external Vikunja call (seconds); the client also has its own
 #: default, but the apply states its budget explicitly (NFR-005).
 _HTTP_TIMEOUT = 30.0
-
-ET_ZONE = ZoneInfo("America/New_York")
 
 #: Logical Inbox project name resolved via the #748 seam (never hardcoded id).
 INBOX_PROJECT_NAME = "inbox"
@@ -375,34 +372,12 @@ def correlate_digest(
 
 # ---------------------------------------------------------------------------
 # Tier-2 helpers — ET end-of-day due date (#733)
+#
+# The ET end-of-day write and the Vikunja-instant parse both live in the
+# canonical ``scripts.common.et_datetime`` module (#761):
+# ``et_datetime.et_end_of_day`` (formerly the inline ``_et_eod``) and
+# ``et_datetime.parse_vikunja_instant`` (formerly the inline ``_due_instant``).
 # ---------------------------------------------------------------------------
-
-
-def _et_eod(date_str: str) -> str:
-    """Render a ``YYYY-MM-DD`` date as an end-of-day ET instant (#733).
-
-    Anchors to ``23:59:59`` in :data:`ET_ZONE` with the DST-correct offset
-    (``-04:00`` EDT / ``-05:00`` EST), never UTC ``Z`` — writing UTC midnight
-    lands in the *prior* ET evening and mis-dates the task a day early. Reuses
-    the ``scripts.escalation.record_completion._reschedule_due_date_et`` approach
-    inline (there is no ``scripts/common/et_datetime.py``).
-
-    Raises :class:`ValueError` for a non-``YYYY-MM-DD`` value or a pre-standard
-    (sub-minute-offset) date, so a malformed ``due:`` is echoed back rather than
-    written as a garbage instant.
-    """
-    target = date.fromisoformat(date_str)
-    anchor = datetime(
-        target.year, target.month, target.day, 23, 59, 59, tzinfo=ET_ZONE
-    )
-    raw_offset = anchor.strftime("%z")
-    if len(raw_offset) != 5:
-        raise ValueError(
-            f"due date {date_str!r} resolves to a non-standard UTC offset "
-            f"{raw_offset!r}; expected a modern Eastern date"
-        )
-    offset = f"{raw_offset[:3]}:{raw_offset[3:]}"
-    return f"{target.isoformat()}T23:59:59{offset}"
 
 
 # ---------------------------------------------------------------------------
@@ -439,27 +414,6 @@ def _has_due(task: dict[str, Any]) -> bool:
     """True iff the task carries a real (non-sentinel) due date."""
     due = task.get("due_date")
     return isinstance(due, str) and bool(due) and not due.startswith(_UNSET_DUE_PREFIX)
-
-
-def _due_instant(value: object) -> datetime | None:
-    """Parse a Vikunja due-date string to an aware UTC instant, or ``None`` when
-    it is missing / the unset sentinel / unparseable.
-
-    Vikunja serializes every ``due_date`` to UTC ``Z`` (#733/#736), so a due-date
-    we write as an ET offset (``…-04:00``) reads back as the same instant in
-    ``…Z`` form. Comparing the *instant* (not the string) is what makes the
-    readback diff correct — a raw string compare false-fails on that
-    representation change (#757).
-    """
-    if not isinstance(value, str) or not value or value.startswith(_UNSET_DUE_PREFIX):
-        return None
-    try:
-        parsed = datetime.fromisoformat(value.replace("Z", "+00:00"))
-    except ValueError:
-        return None
-    if parsed.tzinfo is None:
-        parsed = parsed.replace(tzinfo=timezone.utc)
-    return parsed.astimezone(timezone.utc)
 
 
 def _is_recurring(task: dict[str, Any]) -> bool:
@@ -515,7 +469,9 @@ def _post_task_fields(
             # Vikunja normalizes due_dates to UTC 'Z' (#733/#736), so compare the
             # INSTANT — a raw string compare of our ET-offset write against the
             # returned UTC form false-fails and triggers a retry storm (#757).
-            if _due_instant(got) != _due_instant(value):
+            if et_datetime.parse_vikunja_instant(
+                got
+            ) != et_datetime.parse_vikunja_instant(value):
                 raise ApplyError(
                     f"field readback for task {task_id}: due_date instant is "
                     f"{got!r}, expected {value!r} (partial-replace drift, #524)."
@@ -665,7 +621,7 @@ def _plan_line(
             )
         else:
             try:
-                eod = _et_eod(line.due)
+                eod = et_datetime.et_end_of_day(line.due)
                 if task.get("due_date") != eod:
                     plan.field_changes["due_date"] = eod
                 plan.applied["due_date"] = eod
@@ -996,7 +952,7 @@ def apply_reply(
 
 
 def _et_date(now_utc: datetime) -> str:
-    return now_utc.astimezone(ET_ZONE).date().isoformat()
+    return et_datetime.to_et(now_utc).date().isoformat()
 
 
 def append_ledger(

--- a/scripts/intake/scan_inbox.py
+++ b/scripts/intake/scan_inbox.py
@@ -62,9 +62,8 @@ from dataclasses import dataclass, field
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
 from typing import Any
-from zoneinfo import ZoneInfo
 
-from scripts.common import vikunja_refs
+from scripts.common import et_datetime, vikunja_refs
 from scripts.common.vikunja_client import VikunjaError
 from scripts.intake.shorthand_key import render_hint
 
@@ -128,8 +127,6 @@ QUADRANT_LABELS = frozenset({"q:do", "q:schedule", "q:delegate", "q:eliminate"})
 
 #: Canonical ordering of the missing-field tokens in the digest/record.
 _MISSING_FIELD_ORDER = ("project", "friction", "quadrant")
-
-ET_ZONE = ZoneInfo("America/New_York")
 
 
 class IntakeError(Exception):
@@ -421,7 +418,7 @@ def build_digest_record(
     return {
         "digest_id": digest_id,
         "created_utc": _utc_iso(now_utc),
-        "created_et_date": now_utc.astimezone(ET_ZONE).date().isoformat(),
+        "created_et_date": et_datetime.to_et(now_utc).date().isoformat(),
         "source_cron": source_cron,
         "entries": [entry.to_dict() for entry in entries],
     }
@@ -572,7 +569,7 @@ def write_tick_artifact(state_dir: Path, tick: TickRecord) -> Path:
     started = datetime.strptime(
         tick.started_at_utc, "%Y-%m-%dT%H:%M:%SZ"
     ).replace(tzinfo=timezone.utc)
-    et_date = started.astimezone(ET_ZONE).date().isoformat()
+    et_date = et_datetime.to_et(started).date().isoformat()
     path = state_dir / f"intake-tick-{et_date}.json"
     _atomic_write_json(path, tick.to_dict())
     _atomic_write_json(state_dir / "intake-tick-latest.json", tick.to_dict())

--- a/tests/common/test_et_datetime.py
+++ b/tests/common/test_et_datetime.py
@@ -1,0 +1,152 @@
+"""Unit tests for the canonical Eastern-time utilities (#761).
+
+These pin the behavior the migrated surfaces depend on: the DST-correct
+end-of-day write (#733), the Vikunja-instant parse that tolerates UTC-``Z``
+normalization while rejecting the year-1 sentinel (#736/#757), the Eastern
+calendar-date read, and the render-in-ET conversion (#759).
+"""
+from __future__ import annotations
+
+from datetime import date, datetime, timezone
+from zoneinfo import ZoneInfo
+
+import pytest
+
+from scripts.common import et_datetime as et
+
+UTC = timezone.utc
+
+
+# ---------------------------------------------------------------------------
+# et_end_of_day (#733)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "target, expected",
+    [
+        ("2026-06-15", "2026-06-15T23:59:59-04:00"),  # EDT
+        ("2026-01-15", "2026-01-15T23:59:59-05:00"),  # EST
+        ("2026-03-09", "2026-03-09T23:59:59-04:00"),  # day after spring-forward
+        ("2026-03-07", "2026-03-07T23:59:59-05:00"),  # day before spring-forward
+    ],
+)
+def test_et_end_of_day_dst_offsets(target, expected):
+    assert et.et_end_of_day(target) == expected
+
+
+def test_et_end_of_day_accepts_date_object():
+    assert et.et_end_of_day(date(2026, 6, 15)) == "2026-06-15T23:59:59-04:00"
+
+
+@pytest.mark.parametrize("bad", ["2026-13-99", "not-a-date", "2026/06/15"])
+def test_et_end_of_day_rejects_malformed_string(bad):
+    with pytest.raises(ValueError):
+        et.et_end_of_day(bad)
+
+
+@pytest.mark.parametrize("pre_standard", ["0001-01-01", "1800-06-15"])
+def test_et_end_of_day_rejects_pre_standard_offset(pre_standard):
+    # Pre-1883 Local Mean Time offsets carry sub-minute seconds → not a modern
+    # Eastern date; must raise rather than emit a malformed instant.
+    with pytest.raises(ValueError, match="non-standard UTC offset"):
+        et.et_end_of_day(pre_standard)
+
+
+def test_et_end_of_day_round_trips_to_the_same_date_in_et():
+    written = et.et_end_of_day("2026-07-20")
+    # Vikunja would store this as UTC-Z; the Eastern calendar date must survive.
+    assert et.et_calendar_date(written) == date(2026, 7, 20)
+
+
+# ---------------------------------------------------------------------------
+# parse_vikunja_instant (#736/#757)
+# ---------------------------------------------------------------------------
+
+
+def test_parse_vikunja_instant_utc_z():
+    got = et.parse_vikunja_instant("2026-07-21T03:59:59Z")
+    assert got == datetime(2026, 7, 21, 3, 59, 59, tzinfo=UTC)
+
+
+def test_parse_vikunja_instant_et_offset_normalizes_to_utc():
+    # An ET-offset write and its UTC-Z readback are the SAME instant (#757).
+    et_write = et.parse_vikunja_instant("2026-07-20T23:59:59-04:00")
+    utc_readback = et.parse_vikunja_instant("2026-07-21T03:59:59Z")
+    assert et_write == utc_readback
+
+
+@pytest.mark.parametrize(
+    "sentinel",
+    [
+        "0001-01-01T00:00:00Z",
+        "0001-01-01T00:00:00+00:00",
+        "0001-01-01",
+    ],
+)
+def test_parse_vikunja_instant_rejects_year1_sentinel(sentinel):
+    assert et.parse_vikunja_instant(sentinel) is None
+
+
+@pytest.mark.parametrize(
+    "bad", [None, 42, "", "   ", "not-a-date", "2026-07-20T23:59:59"]
+)
+def test_parse_vikunja_instant_rejects_bad_values(bad):
+    # The last case is a NAIVE datetime — excluded (not assumed UTC), matching
+    # the escalation read-side's "don't guess a timezone" safety choice.
+    assert et.parse_vikunja_instant(bad) is None
+
+
+# ---------------------------------------------------------------------------
+# et_calendar_date (#736)
+# ---------------------------------------------------------------------------
+
+
+def test_et_calendar_date_utc_evening_is_prior_eastern_day():
+    # 2026-07-21T02:00:00Z == 2026-07-20 22:00 EDT → Eastern date is the 20th.
+    assert et.et_calendar_date("2026-07-21T02:00:00Z") == date(2026, 7, 20)
+
+
+def test_et_calendar_date_excludes_sentinel_and_naive():
+    assert et.et_calendar_date("0001-01-01T00:00:00Z") is None
+    assert et.et_calendar_date("2026-07-20T00:00:00") is None  # naive
+
+
+def test_et_calendar_date_zone_override():
+    # In UTC the calendar date is the 21st; in ET it is the 20th.
+    value = "2026-07-21T02:00:00Z"
+    assert et.et_calendar_date(value, zone=UTC) == date(2026, 7, 21)
+    assert et.et_calendar_date(value) == date(2026, 7, 20)
+
+
+# ---------------------------------------------------------------------------
+# to_et / today_et (#759 render, #733 today)
+# ---------------------------------------------------------------------------
+
+
+def test_to_et_converts_aware_utc():
+    got = et.to_et(datetime(2026, 7, 21, 3, 0, 0, tzinfo=UTC))
+    assert got.utcoffset().total_seconds() == -4 * 3600
+    assert (got.year, got.month, got.day, got.hour) == (2026, 7, 20, 23)
+
+
+def test_to_et_naive_assumed_utc_by_default():
+    got = et.to_et(datetime(2026, 7, 21, 3, 0, 0))
+    assert got == datetime(2026, 7, 21, 3, 0, 0, tzinfo=UTC).astimezone(et.ET_ZONE)
+
+
+def test_to_et_naive_assume_et_for_wallclock_callers():
+    # Calendar routing treats a naive anchor as wall-clock Eastern.
+    got = et.to_et(datetime(2026, 7, 20, 9, 0, 0), assume=et.ET_ZONE)
+    assert (got.year, got.month, got.day, got.hour) == (2026, 7, 20, 9)
+    assert got.tzinfo is et.ET_ZONE or str(got.tzinfo) == "America/New_York"
+
+
+def test_today_et_uses_eastern_calendar_date():
+    # 00:30 UTC on the 21st is still 20:30 ET on the 20th.
+    now = datetime(2026, 7, 21, 0, 30, 0, tzinfo=UTC)
+    assert et.today_et(now=now) == date(2026, 7, 20)
+
+
+def test_today_et_defaults_to_now():
+    assert isinstance(et.today_et(), date)

--- a/tests/common/test_no_bare_astimezone.py
+++ b/tests/common/test_no_bare_astimezone.py
@@ -1,0 +1,112 @@
+"""Repo-wide guard: no bare no-argument ``dt.astimezone()`` in ``scripts/`` (#761).
+
+On office2 the host TZ is ``Etc/UTC``, so a bare ``dt.astimezone()`` (no zone
+argument) silently converts to UTC instead of the intended local/Eastern zone
+— the #759 shape, where the alert bus rendered "local" == UTC. Every real
+conversion must pass an explicit zone (``timezone.utc`` or an
+``America/New_York`` ``ZoneInfo``); the canonical utilities in
+``scripts/common/et_datetime.py`` do.
+
+This is the durable regression guard for that rule. It is a pytest test (not a
+tooling script) so it runs automatically under ``make test`` / test-ci with no
+hook wiring, mirroring the SC-001 gate (``tests/common/test_sc001_grep.py``).
+It ``ast``-walks every ``scripts/**/*.py`` and fails, naming each ``file:line``,
+on any ``x.astimezone()`` call with no positional and no keyword arguments.
+Positive/negative controls below keep it fails-closed.
+"""
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+_REPO_ROOT = Path(__file__).resolve().parent.parent.parent
+_SCRIPTS_ROOT = _REPO_ROOT / "scripts"
+
+
+def _bare_astimezone_findings(rel_posix: str, source: str) -> list[str]:
+    """Return ``file:line`` findings for bare no-arg ``.astimezone()`` calls."""
+    findings: list[str] = []
+    try:
+        tree = ast.parse(source)
+    except SyntaxError:
+        # A synthetic control *fragment* may not parse as a module; real
+        # runtime files always do.
+        return findings
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Call):
+            continue
+        func = node.func
+        if (
+            isinstance(func, ast.Attribute)
+            and func.attr == "astimezone"
+            and not node.args
+            and not node.keywords
+        ):
+            findings.append(
+                f"{rel_posix}:{node.lineno}: bare astimezone() — pass an "
+                f"explicit zone (timezone.utc or scripts.common.et_datetime.ET_ZONE)"
+            )
+    return findings
+
+
+def _scan_files() -> list[Path]:
+    return sorted(_SCRIPTS_ROOT.rglob("*.py"))
+
+
+def _scan_all() -> list[str]:
+    findings: list[str] = []
+    for path in _scan_files():
+        rel_posix = path.relative_to(_REPO_ROOT).as_posix()
+        findings.extend(
+            _bare_astimezone_findings(rel_posix, path.read_text(encoding="utf-8"))
+        )
+    return findings
+
+
+# ---------------------------------------------------------------------------
+# The gate
+# ---------------------------------------------------------------------------
+
+
+def test_no_bare_astimezone_in_scripts():
+    """No ``scripts/`` code may call ``dt.astimezone()`` without a zone (#759)."""
+    findings = _scan_all()
+    assert not findings, (
+        "Bare no-argument astimezone() found — on office2 (host TZ Etc/UTC) it "
+        "silently yields UTC, not Eastern (#759). Pass an explicit zone or use "
+        "scripts.common.et_datetime:\n  " + "\n  ".join(findings)
+    )
+
+
+def test_scan_actually_covers_files():
+    """Guard the guard: a broken glob that scanned nothing would be vacuously
+    green. Assert the scan sees known date-handling consumers."""
+    rels = {p.relative_to(_REPO_ROOT).as_posix() for p in _scan_files()}
+    assert "scripts/common/et_datetime.py" in rels
+    assert "scripts/common/alert_bus/render.py" in rels
+    assert "scripts/escalation/record_completion.py" in rels
+
+
+def test_guard_fires_on_bare_call():
+    """Positive control: a reintroduced bare ``astimezone()`` MUST be caught,
+    otherwise the gate is a no-op."""
+    for snippet in (
+        "x = ts.astimezone()",
+        "return dt.astimezone()",
+        "value = some.nested.ts.astimezone()",
+    ):
+        hits = _bare_astimezone_findings("synthetic.py", snippet)
+        assert hits, f"guard failed to fire on bare call {snippet!r}"
+
+
+def test_guard_ignores_explicit_zone_calls():
+    """Negative control: an ``astimezone(...)`` with an explicit zone (positional
+    or keyword) must NOT flag — precision, no false positives."""
+    for snippet in (
+        "x = ts.astimezone(timezone.utc)",
+        "local = ts.astimezone(ET_ZONE)",
+        "d = ts.astimezone(ZoneInfo('America/New_York'))",
+        "x = ts.astimezone(tz=timezone.utc)",
+    ):
+        hits = _bare_astimezone_findings("synthetic.py", snippet)
+        assert hits == [], f"false positive on explicit-zone call {snippet!r}: {hits}"

--- a/tests/escalation/test_enumerate_candidates.py
+++ b/tests/escalation/test_enumerate_candidates.py
@@ -405,14 +405,11 @@ class TestMainCli:
     def test_default_date_uses_today_et_when_omitted(
         self, capsys, patch_vikunja_client, patch_excluded_ids, monkeypatch
     ) -> None:
-        from datetime import datetime as real_datetime
-
-        class _FrozenDatetime(real_datetime):
-            @classmethod
-            def now(cls, tz=None):
-                return real_datetime(2026, 7, 12, 9, 0, 0, tzinfo=tz)
-
-        monkeypatch.setattr(ec, "datetime", _FrozenDatetime)
+        # "today" now flows through the canonical et_datetime.today_et() (#761);
+        # freeze it to the test's reference day.
+        monkeypatch.setattr(
+            ec.et_datetime, "today_et", lambda **_: date(2026, 7, 12)
+        )
         task = make_task(1, due_date="2026-07-12T12:00:00Z", priority=3)
         patch_vikunja_client(FakeVikunjaClient(pages=[[task], []]))
         patch_excluded_ids([])

--- a/tests/escalation/test_record_completion.py
+++ b/tests/escalation/test_record_completion.py
@@ -200,27 +200,12 @@ class TestHappyPathPerEventType:
         # calendar date). June is EDT, so the offset is -04:00.
         assert body == {"due_date": "2026-06-15T23:59:59-04:00"}
 
-    def test_reschedule_due_date_et_uses_dst_aware_offset(self):
-        """`_reschedule_due_date_et` picks EDT vs EST by the target date (#733)."""
-        # Summer target -> EDT (-04:00); winter target -> EST (-05:00).
-        assert rc._reschedule_due_date_et("2026-06-15") == "2026-06-15T23:59:59-04:00"
-        assert rc._reschedule_due_date_et("2026-01-15") == "2026-01-15T23:59:59-05:00"
-        # Day after the 2026 spring-forward transition (2026-03-08) is EDT.
-        assert rc._reschedule_due_date_et("2026-03-09") == "2026-03-09T23:59:59-04:00"
-        # Day before spring-forward is still EST.
-        assert rc._reschedule_due_date_et("2026-03-07") == "2026-03-07T23:59:59-05:00"
-
-    def test_reschedule_due_date_et_rejects_bad_date(self):
-        """`_reschedule_due_date_et` raises on invalid / pre-modern dates."""
-        # Not a real calendar date.
-        with pytest.raises(ValueError):
-            rc._reschedule_due_date_et("2026-13-99")
-        # Pre-standardization (pre-1883) ET carries a sub-minute LMT offset
-        # (e.g. -04:56:02) that would emit a malformed due_date; reject it.
-        with pytest.raises(ValueError):
-            rc._reschedule_due_date_et("0001-01-01")
-        with pytest.raises(ValueError):
-            rc._reschedule_due_date_et("1800-06-15")
+    # The ET end-of-day write logic moved to the canonical helper
+    # ``scripts.common.et_datetime.et_end_of_day`` (#761); its DST-offset and
+    # pre-standard-date rejection are unit-tested in
+    # ``tests/common/test_et_datetime.py``. The reschedule write path is still
+    # covered end-to-end by ``test_record_rescheduled_*`` above, which asserts
+    # the emitted ``due_date`` body is ``2026-06-15T23:59:59-04:00``.
 
     def test_record_snoozed_computes_snooze_until_at_write_time(
         self,


### PR DESCRIPTION
## Summary

Consolidates the scattered ET/UTC date handling that caused the **same** bug shape to recur on five independent code paths (#733/#736/#739/#757/#759) into one canonical module, and migrates the escalation, intake, and alert-bus surfaces onto it — removing the inline duplicates (net −124 LOC of duplicated date logic).

Root class: Vikunja + office2 default to UTC; code assumed UTC or forgot to convert to Eastern. One shared utility retires the whack-a-mole for the migrated surfaces.

## New module — `scripts/common/et_datetime.py`

| function | purpose |
|---|---|
| `to_et(dt, *, assume=utc)` | instant → aware Eastern (DST-aware) |
| `today_et(*, now=None)` | today's ET calendar date |
| `parse_vikunja_instant(s)` | Vikunja `due_date` string → aware UTC instant \| None |
| `et_calendar_date(s, zone)` | ET calendar date of a `due_date` string |
| `et_end_of_day(date\|str)` | `YYYY-MM-DDT23:59:59±HH:MM` ET end-of-day write |

## Migrated surfaces (each dropped its own inline copy + duplicated `ZoneInfo`)
- `escalation/record_completion.py` — `_reschedule_due_date_et` → `et_end_of_day`; `_today_local` → `today_et`
- `escalation/enumerate_candidates.py` — `normalize_due_date` delegates to `et_calendar_date` (signature + H8/H9 behavior preserved)
- `intake/apply_reply.py` — `_et_eod` → `et_end_of_day`; `_due_instant` → `parse_vikunja_instant`; `_et_date` → `to_et`
- `intake/scan_inbox.py` — `astimezone(ET_ZONE).date()` → `to_et(...).date()`
- `common/alert_bus/render.py` — local render → `to_et`

## CI guard
`tests/common/test_no_bare_astimezone.py` — a fails-closed pytest AST gate banning bare no-arg `dt.astimezone()` repo-wide (the #759 shape: on office2's `Etc/UTC` host it silently yields UTC, not Eastern). Runs under `make test` / Test CI, no workflow change.

## Scope decisions
- **Closes #736** (read-side ET-date consolidation).
- **Calendar validator NOT migrated:** `validate_calendar_event.py`'s live entrypoint is script-path (`python3 scripts/.../x.py`), so a `scripts.common` import breaks it with `ModuleNotFoundError` — the #668 `-m` trap (caught by its CLI tests). Left self-contained with an explanatory comment. Live evidence reinforcing #668.
- **#739 not closed:** the relative-date resolver already exists in the calendar validator, and its only new consumer (the capture calendar route) is design-gated on a time-of-day policy — shipping it here would be unwired dead code.

## Review
Adversarially reviewed by reviewer-renata (Opus): **no High/Medium findings**, behavior-preserving for all reachable inputs. LOW/INFO items folded (dead `SENTINEL_DUE_DATE` removed, stale docstrings fixed, module scope claim narrowed).

## Testing
Full non-live suite green: **5589 passed, 42 skipped, 1 xfailed**. `validate_docs` / `validate_privacy_boundary` / `validate_architecture_data` all pass.

**Rebaseline:** not required — no audited surface touched (helpers only; no agent prompt, deploy lib, systemd unit, or dependency manifest changed, #621).

Closes #736

🤖 Generated with [Claude Code](https://claude.com/claude-code)