### PR TITLE
fix(#740): prescan skips inbox notes awaiting a calendar clarification reply

### DIFF
--- a/scripts/inbox/handle_clarification_state.py
+++ b/scripts/inbox/handle_clarification_state.py
@@ -155,6 +155,49 @@ def subcommand_sweep(path: Path, now_utc: datetime) -> int:
     return 0
 
 
+def pending_filenames(path: Path, now_utc: datetime) -> set[str]:
+    """Return the set of note **basenames** with a live pending-clarification entry.
+
+    "Live" == a well-formed ``created_at`` in the past and within
+    :data:`SWEEP_MAX_AGE`. This is the WITHHOLD consumer (``prescan`` drops these
+    notes from the tick), so it must fail **open**: an entry with a missing,
+    non-string, unparseable, or future ``created_at`` is treated as NOT live so
+    the note is *released*, never stranded — the opposite doubt-direction from
+    ``sweep``'s :func:`_is_aged_out` ("keep on doubt"). See :func:`_is_live`.
+    Because release is decided here at read time (not by the physical sweep), a
+    note is guaranteed to re-enter the scan once its entry ages out, bounding the
+    re-ask loop to once per window (#740).
+
+    Filenames are normalized to their basename so a path-form and a basename-form
+    key both match the inbox note's ``Path.name`` (the deterministic contract is
+    a basename — ``classify_content`` emits ``path.name`` — but this is defensive
+    against the agent ever passing a path). Deduped, so accumulated duplicate
+    entries for the same note collapse.
+    """
+    out: set[str] = set()
+    for entry in load_state(path):
+        name = entry.get("note_filename")
+        if not isinstance(name, str) or not name:
+            continue
+        if _is_live(entry.get("created_at"), now_utc):
+            out.add(os.path.basename(name))
+    return out
+
+
+def subcommand_pending(path: Path, note_filename: str, now_utc: datetime) -> int:
+    """Print ``pending=true``/``pending=false`` for one note filename (#740).
+
+    True iff a live (non-aged-out) PendingClarification entry exists for
+    ``note_filename``. Gives the capture agent the deterministic "is this note
+    already awaiting Kent?" check its ``AGENTS.md`` re-dispatch rule needs but
+    previously lacked; ``prescan.py`` uses :func:`pending_filenames` directly to
+    filter such notes out of the tick before the agent ever sees them.
+    """
+    is_pending = note_filename in pending_filenames(path, now_utc)
+    print(f"pending={'true' if is_pending else 'false'}")
+    return 0
+
+
 def subcommand_match(path: Path, reply_content: str) -> int:
     """Print the most-recent matching entry as JSON, or `null`.
 
@@ -237,6 +280,29 @@ def _is_aged_out(created_raw: object, now_utc: datetime) -> bool:
     return (now_utc - created) >= SWEEP_MAX_AGE
 
 
+def _is_live(created_raw: object, now_utc: datetime) -> bool:
+    """True iff `created_raw` is a well-formed, non-future, within-window stamp.
+
+    This is the WITHHOLD predicate (see :func:`pending_filenames`) and must fail
+    **open** — the opposite doubt-direction from :func:`_is_aged_out`. A missing,
+    non-string, unparseable, or FUTURE `created_at` returns ``False`` (not live →
+    do not withhold → release the note), so a bad timestamp can never strand a
+    note indefinitely (the #746/D9 silent-loss class). "Live" is strictly a
+    non-negative age below :data:`SWEEP_MAX_AGE`; anything else releases.
+
+    Note `_is_live` and `_is_aged_out` are deliberately NOT complements: a future
+    stamp is neither aged-out (sweep keeps it) nor live (withhold releases it).
+    """
+    if not isinstance(created_raw, str):
+        return False
+    try:
+        created = _parse_iso_z(created_raw)
+    except ValueError:
+        return False
+    age = now_utc - created
+    return timedelta(0) <= age < SWEEP_MAX_AGE
+
+
 # --------------------------------------------------------------------------
 # CLI
 # --------------------------------------------------------------------------
@@ -275,6 +341,13 @@ def _build_parser() -> argparse.ArgumentParser:
     sweep_p = sub.add_parser("sweep", help="Delete entries older than 24h.")
     _add_state_file_arg(sweep_p)
 
+    pending_p = sub.add_parser(
+        "pending",
+        help="Print whether a note filename has a live pending entry (#740).",
+    )
+    pending_p.add_argument("--note-filename", required=True)
+    _add_state_file_arg(pending_p)
+
     match_p = sub.add_parser(
         "match",
         help="Find the most-recent PendingClarification matching a reply.",
@@ -298,6 +371,8 @@ def main(argv: list[str] | None = None) -> int:
         )
     if args.subcommand == "sweep":
         return subcommand_sweep(state_path, now_utc)
+    if args.subcommand == "pending":
+        return subcommand_pending(state_path, args.note_filename, now_utc)
     if args.subcommand == "match":  # pragma: no branch - argparse enforces
         return subcommand_match(state_path, args.reply_content)
     return 2  # pragma: no cover - argparse rejects unknown subcommands

--- a/scripts/inbox/prescan.py
+++ b/scripts/inbox/prescan.py
@@ -146,6 +146,11 @@ class PrescanResult:
     marker_cleanup_needed: list = field(default_factory=list)  # [<abs path>]
     # #568 — defensive safety rail for the silent-content-loss bug class (#563).
     archive_anomalies: list = field(default_factory=list)  # [ArchiveAnomaly as dict]
+    # #740 — notes withheld this tick because they are awaiting a calendar
+    # clarification reply from Kent (a live pending-calendar-clarifications
+    # entry). Bounded by the 24h sweep, so a note is released — not stranded —
+    # once its entry ages out. [{"path": ..., "filename": ...}]
+    pending_skipped: list = field(default_factory=list)
 
 
 # ---------------------------------------------------------------------------
@@ -850,6 +855,18 @@ def _append_daily_log(
         lines.append("### Unprocessed handed to agent")
         for u in unprocessed:
             lines.append(f"- {u.path.name}")
+    # #740 — notes withheld this tick because they await a calendar clarification
+    # reply. Rendered so a withheld note is never fully invisible in the forensic
+    # log (it is filtered out of "Unprocessed handed to agent" above). Omitted
+    # when empty to keep healthy ticks quiet.
+    if result.pending_skipped:
+        lines.append("")
+        lines.append(
+            f"### pending calendar clarification — withheld "
+            f"(count={len(result.pending_skipped)})"
+        )
+        for p in result.pending_skipped:
+            lines.append(f"- {p['filename']}")
     # #568 — defensive safety rail. Section is OMITTED when no anomalies
     # to avoid log noise on healthy ticks (the common case).
     if result.archive_anomalies:
@@ -870,6 +887,44 @@ def _append_daily_log(
 
 def _emit_stderr(msg: str) -> None:
     print(msg, file=sys.stderr)
+
+
+def _pending_clarification_filenames(
+    now_utc: datetime,
+) -> tuple[set[str], Optional[dict]]:
+    """Return note filenames awaiting a calendar clarification reply (#740).
+
+    Reads the shared clarification-state file via
+    ``handle_clarification_state.pending_filenames`` (the same 24h aging rule
+    ``sweep`` uses). Returns ``(names, warning_or_None)``. Fail-safe: any
+    import or read error yields an empty set plus a warning dict, so a broken or
+    unreadable clarification store never withholds a note from the agent — it
+    just disables the skip for that run. An absent state file is the normal
+    "nothing pending" case and returns an empty set with no warning.
+    """
+    try:
+        from scripts.inbox.handle_clarification_state import (
+            STATE_PATH_DEFAULT,
+            pending_filenames,
+        )
+    except ImportError as exc:  # pragma: no cover - defensive (partial deploy)
+        return set(), {
+            "path": "scripts/inbox/handle_clarification_state.py",
+            "reason": (
+                f"handle_clarification_state not importable ({exc}); "
+                "pending-calendar skip disabled this run"
+            ),
+        }
+    try:
+        return pending_filenames(STATE_PATH_DEFAULT, now_utc), None
+    except Exception as exc:  # pragma: no cover - defensive
+        return set(), {
+            "path": str(STATE_PATH_DEFAULT),
+            "reason": (
+                f"pending-calendar clarification state unreadable ({exc}); "
+                "pending-calendar skip disabled this run"
+            ),
+        }
 
 
 def run_prescan() -> int:
@@ -955,7 +1010,28 @@ def run_prescan() -> int:
     # Dedup shift (D9): unprocessed notes are handed to the agent every tick
     # regardless of routing-log presence. Terminal status removes a note from
     # this list upstream (via classification), not a filename filter here.
-    unprocessed_filtered: list[InboxFile] = list(unprocessed)
+    #
+    # #740 — the ONE deterministic filename filter that IS safe: a note awaiting
+    # a calendar clarification reply from Kent (a live pending-calendar entry).
+    # Unlike the removed routing-log dedup, this cannot strand a note — the 24h
+    # clarification sweep ages the entry out, after which the note re-enters the
+    # scan and the agent re-asks (once per window instead of every tick). Skipping
+    # it here is what stops the 4×/day re-classify + re-WhatsApp loop. Fail-safe:
+    # any error reading the clarification state → skip the filter (never withhold
+    # a note on a broken read).
+    pending_clarification_names, pending_warning = _pending_clarification_filenames(
+        started
+    )
+    if pending_warning is not None:
+        warnings.append(pending_warning)
+    unprocessed_filtered = [
+        f for f in unprocessed if f.path.name not in pending_clarification_names
+    ]
+    pending_skipped = [
+        {"path": str(f.path), "filename": f.path.name}
+        for f in unprocessed
+        if f.path.name in pending_clarification_names
+    ]
 
     # #185 — FR-005 parse_failures list.
     parse_failures_json = [
@@ -1030,6 +1106,7 @@ def run_prescan() -> int:
         dedup_skipped=dedup_skipped,
         marker_cleanup_needed=marker_cleanup_needed,
         archive_anomalies=[asdict(a) for a in archive_anomalies],
+        pending_skipped=pending_skipped,
     )
 
     _emit_stderr("prescan: writing daily log")

--- a/tests/inbox/test_handle_clarification_state.py
+++ b/tests/inbox/test_handle_clarification_state.py
@@ -598,6 +598,124 @@ def test_subcommand_help_exits_zero(
     assert excinfo.value.code == 0
 
 
+# --------------------------------------------------------------------------
+# pending (#740) — deterministic "is this note awaiting Kent?" query
+# --------------------------------------------------------------------------
+
+
+def _entry(note_filename: str, created: datetime, title: str = "Meet Rob") -> dict:
+    return {
+        "note_filename": note_filename,
+        "partial_payload": {"title": title},
+        "created_at": _iso_z(created),
+    }
+
+
+def _entry_raw(note_filename: str, created_at_value: object) -> dict:
+    """Entry with an arbitrary (possibly malformed) ``created_at`` value."""
+    return {
+        "note_filename": note_filename,
+        "partial_payload": {"title": "Meet Rob"},
+        "created_at": created_at_value,
+    }
+
+
+def test_pending_filenames_returns_live_excludes_aged(tmp_path: Path) -> None:
+    now = datetime(2026, 7, 18, 12, 0, 0, tzinfo=timezone.utc)
+    state = tmp_path / "pending.json"
+    _write_state(
+        state,
+        [
+            _entry("live.md", now - timedelta(hours=1)),
+            _entry("aged.md", now - timedelta(hours=25)),
+        ],
+    )
+    names = hcs.pending_filenames(state, now)
+    assert names == {"live.md"}
+
+
+def test_pending_filenames_dedups_duplicate_entries(tmp_path: Path) -> None:
+    now = datetime(2026, 7, 18, 12, 0, 0, tzinfo=timezone.utc)
+    state = tmp_path / "pending.json"
+    _write_state(
+        state,
+        [
+            _entry("dup.md", now - timedelta(hours=2)),
+            _entry("dup.md", now - timedelta(hours=1)),
+        ],
+    )
+    assert hcs.pending_filenames(state, now) == {"dup.md"}
+
+
+def test_pending_filenames_empty_on_absent_file(tmp_path: Path) -> None:
+    now = datetime(2026, 7, 18, 12, 0, 0, tzinfo=timezone.utc)
+    assert hcs.pending_filenames(tmp_path / "nope.json", now) == set()
+
+
+def test_pending_filenames_fails_open_on_bad_created_at(tmp_path: Path) -> None:
+    """#740 Finding 1: a missing / malformed / future ``created_at`` must NOT
+    withhold the note (fail OPEN — release), or a bad stamp strands it forever."""
+    now = datetime(2026, 7, 18, 12, 0, 0, tzinfo=timezone.utc)
+    state = tmp_path / "pending.json"
+    _write_state(
+        state,
+        [
+            {"note_filename": "missing.md", "partial_payload": {}},  # no created_at
+            {"note_filename": "null.md", "partial_payload": {}, "created_at": None},
+            _entry_raw("bad.md", "not-a-timestamp"),
+            _entry_raw("nonstr.md", 12345),
+            _entry("future.md", now + timedelta(hours=3)),  # future stamp
+            _entry("live.md", now - timedelta(hours=1)),  # the one real live entry
+        ],
+    )
+    # Only the genuinely-live entry is withheld; every doubtful stamp releases.
+    assert hcs.pending_filenames(state, now) == {"live.md"}
+
+
+def test_pending_filenames_normalizes_path_to_basename(tmp_path: Path) -> None:
+    """#740 Finding 3: a path-form stored filename still matches the inbox
+    basename (defensive; the contract is a basename)."""
+    now = datetime(2026, 7, 18, 12, 0, 0, tzinfo=timezone.utc)
+    state = tmp_path / "pending.json"
+    _write_state(
+        state, [_entry("01-Inbox/Deep 2026-07-18 0900.md", now - timedelta(hours=1))]
+    )
+    assert hcs.pending_filenames(state, now) == {"Deep 2026-07-18 0900.md"}
+
+
+def test_pending_subcommand_true_for_live_entry(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    now = datetime.now(timezone.utc)
+    state = tmp_path / "pending.json"
+    _write_state(state, [_entry("here.md", now - timedelta(hours=1))])
+    rc = hcs.main(
+        ["pending", "--note-filename", "here.md", "--state-file", str(state)]
+    )
+    assert rc == 0
+    assert capsys.readouterr().out.strip() == "pending=true"
+
+
+def test_pending_subcommand_false_for_aged_and_unknown(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    now = datetime.now(timezone.utc)
+    state = tmp_path / "pending.json"
+    _write_state(state, [_entry("aged.md", now - timedelta(hours=30))])
+    # aged-out entry → not pending
+    rc = hcs.main(
+        ["pending", "--note-filename", "aged.md", "--state-file", str(state)]
+    )
+    assert rc == 0
+    assert capsys.readouterr().out.strip() == "pending=false"
+    # filename with no entry at all → not pending
+    rc = hcs.main(
+        ["pending", "--note-filename", "other.md", "--state-file", str(state)]
+    )
+    assert rc == 0
+    assert capsys.readouterr().out.strip() == "pending=false"
+
+
 def test_module_runs_as_main(monkeypatch: pytest.MonkeyPatch) -> None:
     """`python3 -m scripts.inbox.handle_clarification_state sweep` works.
 

--- a/tests/inbox/test_prescan_pending_clarification.py
+++ b/tests/inbox/test_prescan_pending_clarification.py
@@ -1,0 +1,206 @@
+"""#740 — prescan withholds notes awaiting a calendar clarification reply.
+
+When a calendar-classified inbox note is incomplete, the capture agent records a
+``pending-calendar-clarifications`` entry and leaves the note unprocessed while
+it waits on Kent. Before this fix ``prescan`` re-listed such a note every tick
+(dedup only skipped terminal-``status`` notes), so the agent re-classified and
+re-WhatsApp'd Kent 4×/day until the 24h sweep aged the entry out.
+
+These tests prove prescan now filters a note with a *live* pending entry out of
+``unprocessed_paths`` (surfacing it in ``pending_skipped``), that an aged-out /
+absent entry does NOT withhold the note (the loop is bounded, not stranding),
+and that an unreadable clarification store fails safe (note still handed over).
+"""
+from __future__ import annotations
+
+import io
+import json
+import sys
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+# Match the sibling prescan tests' module-aliasing so the routing_log object
+# prescan imports package-qualified is the same one conftest put on sys.path.
+import routing_log as _routing_log_mod  # noqa: E402
+sys.modules.setdefault("scripts.inbox.routing_log", _routing_log_mod)
+
+import prescan  # noqa: E402
+from scripts.inbox import handle_clarification_state as hcs  # noqa: E402
+
+
+NOW = datetime(2026, 7, 18, 12, 0, 0, tzinfo=timezone.utc)
+
+
+# ---------------------------------------------------------------------------
+# Harness
+# ---------------------------------------------------------------------------
+
+
+def _write_unprocessed(path: Path, body: str = "Body.\n") -> None:
+    path.write_text(f"---\nstatus: unprocessed\n---\n\n{body}", encoding="utf-8")
+
+
+def _write_pending_state(path: Path, entries: list) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(entries), encoding="utf-8")
+
+
+def _entry(note_filename: str, created: datetime) -> dict:
+    return {
+        "note_filename": note_filename,
+        "partial_payload": {"title": "Meet Rob"},
+        "created_at": created.replace(microsecond=0).strftime("%Y-%m-%dT%H:%M:%SZ"),
+    }
+
+
+def _run_prescan(inbox: Path, processed: Path, state_file: Path, monkeypatch) -> dict:
+    registry = inbox.parent / "registry.json"
+    registry.write_text(
+        json.dumps(
+            {"paths": {"inbox": str(inbox), "inbox_processed": str(processed)}}
+        ),
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("PRESCAN_REGISTRY_PATH", str(registry))
+    log_dir = inbox.parent / "logs"
+    log_dir.mkdir(parents=True, exist_ok=True)
+    monkeypatch.setenv("PRESCAN_LOG_DIR", str(log_dir))
+    # Point the clarification-state lookup at the test's file. prescan's helper
+    # reads handle_clarification_state.STATE_PATH_DEFAULT at call time.
+    monkeypatch.setattr(hcs, "STATE_PATH_DEFAULT", state_file)
+
+    captured = io.StringIO()
+    monkeypatch.setattr(sys, "stdout", captured)
+    rc = prescan.run_prescan()
+    sys.stdout = sys.__stdout__
+    assert rc == 0, f"run_prescan returned {rc}"
+    return json.loads(captured.getvalue().strip().splitlines()[-1])
+
+
+def _setup(tmp_path: Path) -> tuple[Path, Path, Path]:
+    inbox = tmp_path / "inbox"
+    processed = tmp_path / "processed"
+    inbox.mkdir()
+    processed.mkdir()
+    state_file = tmp_path / "state" / "pending-calendar-clarifications.json"
+    return inbox, processed, state_file
+
+
+# ---------------------------------------------------------------------------
+# Integration: run_prescan skip behavior
+# ---------------------------------------------------------------------------
+
+
+def test_note_with_live_pending_entry_is_withheld(tmp_path, monkeypatch):
+    # run_prescan reads the real wall clock, so anchor the entry to real now
+    # (a fixed future constant would be treated as not-live and released).
+    live = datetime.now(timezone.utc) - timedelta(hours=1)
+    inbox, processed, state = _setup(tmp_path)
+    _write_unprocessed(inbox / "Inbox 2026-07-18 0900.md")
+    _write_pending_state(
+        state, [_entry("Inbox 2026-07-18 0900.md", live)]
+    )
+    result = _run_prescan(inbox, processed, state, monkeypatch)
+
+    assert result["unprocessed_count"] == 0
+    assert result["unprocessed_paths"] == []
+    assert [e["filename"] for e in result["pending_skipped"]] == [
+        "Inbox 2026-07-18 0900.md"
+    ]
+
+
+def test_aged_out_pending_entry_releases_the_note(tmp_path, monkeypatch):
+    inbox, processed, state = _setup(tmp_path)
+    _write_unprocessed(inbox / "Inbox 2026-07-18 0900.md")
+    # created 30h ago → past the 24h sweep window → not pending anymore.
+    _write_pending_state(
+        state, [_entry("Inbox 2026-07-18 0900.md", datetime.now(timezone.utc) - timedelta(hours=30))]
+    )
+    result = _run_prescan(inbox, processed, state, monkeypatch)
+
+    assert result["unprocessed_count"] == 1
+    assert result["pending_skipped"] == []
+    assert result["unprocessed_paths"][0].endswith("Inbox 2026-07-18 0900.md")
+
+
+def test_absent_state_file_hands_note_over(tmp_path, monkeypatch):
+    inbox, processed, state = _setup(tmp_path)  # state file never created
+    _write_unprocessed(inbox / "Inbox 2026-07-18 0900.md")
+    result = _run_prescan(inbox, processed, state, monkeypatch)
+
+    assert result["unprocessed_count"] == 1
+    assert result["pending_skipped"] == []
+    # No warning for an absent (normal, nothing-pending) state file.
+    assert not any("clarification" in w.get("reason", "") for w in result["warnings"])
+
+
+def test_only_the_pending_note_is_withheld(tmp_path, monkeypatch):
+    live = datetime.now(timezone.utc) - timedelta(hours=2)
+    inbox, processed, state = _setup(tmp_path)
+    _write_unprocessed(inbox / "pending.md")
+    _write_unprocessed(inbox / "ready.md")
+    _write_pending_state(state, [_entry("pending.md", live)])
+    result = _run_prescan(inbox, processed, state, monkeypatch)
+
+    assert result["unprocessed_count"] == 1
+    assert result["unprocessed_paths"][0].endswith("ready.md")
+    assert [e["filename"] for e in result["pending_skipped"]] == ["pending.md"]
+
+
+def test_malformed_created_at_does_not_strand_the_note(tmp_path, monkeypatch):
+    """#740 Finding 1: a valid-JSON array with one entry whose ``created_at`` is
+    malformed must NOT withhold the note indefinitely — it fails open (released),
+    so a bad stamp can never silently strand a note (the #746/D9 class)."""
+    inbox, processed, state = _setup(tmp_path)
+    _write_unprocessed(inbox / "Inbox 2026-07-18 0900.md")
+    _write_pending_state(
+        state,
+        [
+            {
+                "note_filename": "Inbox 2026-07-18 0900.md",
+                "partial_payload": {"title": "Meet Rob"},
+                "created_at": "totally-not-a-timestamp",
+            }
+        ],
+    )
+    result = _run_prescan(inbox, processed, state, monkeypatch)
+    assert result["unprocessed_count"] == 1
+    assert result["pending_skipped"] == []
+    assert result["unprocessed_paths"][0].endswith("Inbox 2026-07-18 0900.md")
+
+
+def test_unreadable_state_fails_safe_with_warning(tmp_path, monkeypatch):
+    inbox, processed, state = _setup(tmp_path)
+    _write_unprocessed(inbox / "note.md")
+    # Corrupt (non-JSON) state → helper raises internally → fail-safe: note is
+    # still handed over, and a warning is surfaced (not withheld on a bad read).
+    state.parent.mkdir(parents=True, exist_ok=True)
+    state.write_text("{ this is not json", encoding="utf-8")
+    result = _run_prescan(inbox, processed, state, monkeypatch)
+
+    assert result["unprocessed_count"] == 1
+    assert result["pending_skipped"] == []
+    assert any("clarification" in w.get("reason", "") for w in result["warnings"])
+
+
+# ---------------------------------------------------------------------------
+# Unit: _pending_clarification_filenames fail-safe wrapper
+# ---------------------------------------------------------------------------
+
+
+def test_pending_helper_returns_names_no_warning(tmp_path, monkeypatch):
+    state = tmp_path / "pending.json"
+    _write_pending_state(state, [_entry("a.md", NOW - timedelta(hours=1))])
+    monkeypatch.setattr(hcs, "STATE_PATH_DEFAULT", state)
+    names, warning = prescan._pending_clarification_filenames(NOW)
+    assert names == {"a.md"}
+    assert warning is None
+
+
+def test_pending_helper_corrupt_file_returns_empty_and_warning(tmp_path, monkeypatch):
+    state = tmp_path / "pending.json"
+    state.write_text("not json", encoding="utf-8")
+    monkeypatch.setattr(hcs, "STATE_PATH_DEFAULT", state)
+    names, warning = prescan._pending_clarification_filenames(NOW)
+    assert names == set()
+    assert warning is not None and "clarification" in warning["reason"]


### PR DESCRIPTION
## Summary

Stops the 4×/day re-classify + re-WhatsApp loop for incomplete calendar notes. When a calendar-classified inbox note is incomplete, the capture agent records a `pending-calendar-clarifications` entry and leaves the note unprocessed while awaiting Kent. `prescan` re-listed it every tick (dedup only skips terminal-`status` notes after the #746/D9 shift), so the agent re-classified and re-pinged Kent every inbox tick until the 24h sweep aged the entry out.

## Fix (helper-only — no agent-prompt change)
- **`handle_clarification_state.py`**: `pending_filenames(path, now)` + a `pending --note-filename` query (the deterministic "is this note already awaiting Kent?" check the AGENTS.md re-dispatch rule referenced but lacked).
- **`prescan.py`**: `run_prescan` drops notes with a *live* pending entry from `unprocessed`, records them in a new `pending_skipped` field (also rendered in the daily log), via a fail-safe `_pending_clarification_filenames` wrapper (import/read error → empty set + warning; never withhold on a broken read). Absent state file = normal nothing-pending case, no warning.

Because prescan now enforces "don't re-dispatch a pending note" deterministically upstream, **no `felix-admin-capture/AGENTS.md` edit is needed** (no agent-prompt-sync / rotate).

## Safety — deliberately avoids the #746/D9 stranding class
- **Release is decided at read time** by `_is_live`, independent of the physical `sweep` deleting the entry — a note re-enters the scan once its entry ages out even if `sweep` never runs. Loop bounded to once/24h instead of every tick.
- **`_is_live` fails OPEN** (reviewer Finding 1, HIGH): a missing / non-string / unparseable / **future** `created_at` *releases* the note rather than withholding it forever — the opposite doubt-direction from `sweep`'s `_is_aged_out` ("keep on doubt"). A bad timestamp can never silently strand a note.
- **Basename normalization** (Finding 3): a path-form key still matches the inbox note's `Path.name` (contract is a basename — `classify_content` emits `path.name`; this is defensive).

## Review
Adversarially reviewed by reviewer-renata (Opus). Findings folded here: **1 (HIGH, fail-open), 3 (basename), 4 (daily-log trace)**. Finding **2** (deterministic `remove`/`resolve` subcommand — the calendar agent currently hand-rolls JSON removal) filed as **#763**; it is no longer ship-blocking once the withhold path fails open. Finding **5** (basename collision on delete+recreate) is an accepted residual risk given timestamped filenames.

## Testing
Full non-live suite green: **5604 passed, 42 skipped, 1 xfailed** (+15 new tests, incl. the malformed-`created_at`-does-not-strand proof).

**Rebaseline:** not required — helper-only, no audited surface touched.

Closes #740

🤖 Generated with [Claude Code](https://claude.com/claude-code)