### PR TITLE
fix(#668): env_assumptions catches the -m trap (script-path invocation of scripts.*-importing helpers)

### DIFF
--- a/scripts/openclaw/agents/env_assumptions.py
+++ b/scripts/openclaw/agents/env_assumptions.py
@@ -12,12 +12,12 @@ first, so it depends on neither the deployed cwd nor an inherited env var::
     cd /home/claude/kg-automation && python3 -m scripts.<pkg>.<mod> [absolute args]
     cd /home/claude/kg-automation && python3 scripts/<path>.py [absolute args]
 
-NOTE: this checker validates the invocation *shape*, not whether the target script
-is runnable by path. The file-path form is correct ONLY for a self-contained script;
-any helper that does ``import scripts.…`` must use the ``-m scripts.<pkg>.<mod>`` form
-(running by path does not put the repo root on ``sys.path``). Prefer ``-m`` for every
-repo helper. (Standing rule; strengthening the checker to resolve the target's imports
-is a tracked follow-up.)
+The file-path form is correct ONLY for a self-contained script; any helper that
+does ``import scripts.…`` must use the ``-m scripts.<pkg>.<mod>`` form (running by
+path does not put the repo root on ``sys.path``). As of #668 the checker resolves
+the target of a ``python3 scripts/<path>.py`` invocation against this checkout and
+flags it (``SCRIPT_PATH_IMPORTS_SCRIPTS``) when the target imports ``scripts.…`` —
+so the ``-m`` trap is caught at authoring time, not at the next cron ModuleNotFoundError.
 
 Rationale: OpenClaw's ``exec`` tool runs commands in a sanitized subshell that
 STRIPS ``PYTHONPATH``, so the old #658 ``cd "${PYTHONPATH:?…}"`` anchor exits 127 on
@@ -57,6 +57,7 @@ class ViolationKind(enum.Enum):
 
     BARE_M_SCRIPTS = "bare_m_scripts"
     RELATIVE_SCRIPT = "relative_script"
+    SCRIPT_PATH_IMPORTS_SCRIPTS = "script_path_imports_scripts"
     PYTHONPATH_ANCHOR = "pythonpath_anchor"
     HARDCODED_ABS_PATH = "hardcoded_abs_path"
     HOME_RELATIVE_WRITE = "home_relative_write"
@@ -70,6 +71,10 @@ _REMEDIATION = {
     ),
     ViolationKind.RELATIVE_SCRIPT: (
         "anchor with cd /home/claude/kg-automation && python3 scripts/....py"
+    ),
+    ViolationKind.SCRIPT_PATH_IMPORTS_SCRIPTS: (
+        "target imports scripts.* — run it as python3 -m scripts.<pkg>.<mod>; "
+        "the path form fails ModuleNotFoundError (repo root not on sys.path)"
     ),
     ViolationKind.PYTHONPATH_ANCHOR: (
         "${PYTHONPATH:?...} fails under OpenClaw exec — use "
@@ -137,6 +142,34 @@ _WAIVER_RE = re.compile(r"#\s*env-guard:\s*waive\s+(?P<kind>[a-z_]+)", re.IGNORE
 
 # The hardcoded checkout literal(s) we treat as a checkout-path assumption.
 _HARDCODED_CHECKOUT_RE = re.compile(r"/home/[^/\s]+/(?:repos/)?kg-automation")
+
+# #668 — a target repo helper that imports the ``scripts`` package. Such a helper
+# fails ``ModuleNotFoundError`` when run by path (``python3 scripts/x.py`` does not
+# put the repo root on ``sys.path``); only ``-m scripts.<pkg>.<mod>`` works.
+_IMPORTS_SCRIPTS_RE = re.compile(r"^\s*(?:from|import)\s+scripts[.\s]", re.MULTILINE)
+
+# This checker lives at ``<repo>/scripts/openclaw/agents/env_assumptions.py``; the
+# repo root (which the prompts' ``scripts/<path>.py`` invocations resolve against)
+# is three parents up. Resolving the target against this checkout is correct
+# because every helper a prompt can invoke lives in this same repo.
+_REPO_ROOT = Path(__file__).resolve().parents[3]
+
+
+def _target_imports_scripts(rel_path: str) -> bool:
+    """True if the repo helper at ``scripts/<rel_path>`` imports ``scripts.…``.
+
+    Resolves ``rel_path`` (the capture after ``scripts/``) against this checkout
+    and reads the target. Deterministic file I/O only (same repo state → same
+    answer). A missing/unreadable target returns ``False`` — the shape checks
+    still apply; we only *add* the ``-m``-trap finding when we can prove the
+    target is an importer.
+    """
+    target = _REPO_ROOT / "scripts" / rel_path
+    try:
+        source = target.read_text(encoding="utf-8")
+    except (FileNotFoundError, OSError, ValueError, IsADirectoryError):
+        return False
+    return bool(_IMPORTS_SCRIPTS_RE.search(source))
 
 
 # --- Recognizer ---------------------------------------------------------------
@@ -243,9 +276,20 @@ def _classify(start: int, text: str, path: str) -> list[Finding]:
 
     # Relative-script invocations (`python3 scripts/x.py`) and bare imperative
     # `scripts/x.py` references — same anchor rule as the -m form (Codex HIGH-2).
+    # #668: for the first concrete match, if the target imports scripts.* it is
+    # the `-m` trap — flag SCRIPT_PATH_IMPORTS_SCRIPTS *regardless of the anchor*
+    # (an importer-by-path fails ModuleNotFoundError even with a correct
+    # checkout-cd), and steer to `-m` rather than the anchored-path form. A
+    # self-contained target keeps the existing anchor rule.
     for m in _REL_SCRIPT_RE.finditer(text):
         if "<" in m.group("path"):  # placeholder like scripts/<pkg>/x.py
             continue
+        if _target_imports_scripts(m.group("path")):
+            findings.append(
+                Finding(path, start, ViolationKind.SCRIPT_PATH_IMPORTS_SCRIPTS, snippet,
+                        _REMEDIATION[ViolationKind.SCRIPT_PATH_IMPORTS_SCRIPTS])
+            )
+            break
         if _governing_anchor(text[: m.start()]) is None:
             findings.append(
                 Finding(path, start, ViolationKind.RELATIVE_SCRIPT, snippet,

--- a/scripts/openclaw/agents/tests/test_env_assumptions.py
+++ b/scripts/openclaw/agents/tests/test_env_assumptions.py
@@ -29,7 +29,7 @@ def test_canonical_checkout_cd_m_form_passes():
 
 
 def test_canonical_checkout_cd_relative_script_form_passes():
-    text = "cd /home/claude/kg-automation && python3 scripts/inbox/prescan.py --self-check"
+    text = "cd /home/claude/kg-automation && python3 scripts/openclaw/agents/main/felix-file-issue.py --self-check"
     assert scan_text(text) == []
 
 
@@ -97,7 +97,7 @@ def test_home_relative_write_flagged():
 
 
 def test_relative_script_python3_form_unanchored_flagged():
-    assert _kinds("python3 scripts/inbox/prescan.py --self-check") == [
+    assert _kinds("python3 scripts/openclaw/agents/main/felix-file-issue.py --self-check") == [
         ViolationKind.RELATIVE_SCRIPT
     ]
 
@@ -115,14 +115,14 @@ def test_relative_script_with_checkout_cd_passes():
 
 def test_relative_script_backslash_continuation_anchored_passes():
     text = (
-        "cd /home/claude/kg-automation && python3 scripts/inbox/prescan.py \\\n"
+        "cd /home/claude/kg-automation && python3 scripts/openclaw/agents/main/felix-file-issue.py \\\n"
         "  --input-file /tmp/reply.json"
     )
     assert scan_text(text) == []
 
 
 def test_relative_script_backslash_continuation_unanchored_flagged():
-    text = "python3 scripts/inbox/prescan.py \\\n  --input-file /tmp/reply.json"
+    text = "python3 scripts/openclaw/agents/main/felix-file-issue.py \\\n  --input-file /tmp/reply.json"
     findings = scan_text(text)
     assert [f.kind for f in findings] == [ViolationKind.RELATIVE_SCRIPT]
     assert findings[0].line == 1  # reports the STARTING line
@@ -130,7 +130,7 @@ def test_relative_script_backslash_continuation_unanchored_flagged():
 
 def test_relative_script_governed_by_pythonpath_suppressed():
     # A relative script after a ${PYTHONPATH:?} cd is only reported as PYTHONPATH_ANCHOR.
-    text = 'cd "${PYTHONPATH:?x}" && python3 scripts/inbox/prescan.py'
+    text = 'cd "${PYTHONPATH:?x}" && python3 scripts/openclaw/agents/main/felix-file-issue.py'
     assert _kinds(text) == [ViolationKind.PYTHONPATH_ANCHOR]
 
 
@@ -148,7 +148,7 @@ def test_wrong_path_cd_kgale_flagged():
 
 
 def test_wrong_path_cd_tmp_relative_script_flagged():
-    text = "cd /tmp/kg-automation && python3 scripts/inbox/prescan.py"
+    text = "cd /tmp/kg-automation && python3 scripts/openclaw/agents/main/felix-file-issue.py"
     assert _kinds(text) == [ViolationKind.RELATIVE_SCRIPT]
 
 
@@ -254,7 +254,7 @@ def test_waiver_wrong_kind_does_not_suppress():
 
 
 def test_waiver_relative_script_suppresses():
-    text = "python3 scripts/inbox/prescan.py  # env-guard: waive relative_script — intentional"
+    text = "python3 scripts/openclaw/agents/main/felix-file-issue.py  # env-guard: waive relative_script — intentional"
     assert scan_text(text) == []
 
 
@@ -272,3 +272,58 @@ def test_finding_carries_line_and_remediation():
     assert findings[0].line == 1
     # Remediation steers to the checkout-cd form.
     assert "/home/claude/kg-automation" in findings[0].remediation
+
+
+# --- SCRIPT_PATH_IMPORTS_SCRIPTS (the -m trap, #668) --------------------------
+# These use REAL repo files so the checker resolves the target's imports:
+#   scripts/inbox/prescan.py            imports scripts.*  (an importer)
+#   scripts/openclaw/agents/main/felix-file-issue.py       self-contained
+_IMPORTER = "scripts/inbox/prescan.py"
+_SELF_CONTAINED = "scripts/openclaw/agents/main/felix-file-issue.py"
+
+
+def test_script_path_importer_flagged_even_when_anchored():
+    """#668: an importer run by path is the -m trap and fails at runtime EVEN
+    with a correct checkout-cd — so it must be flagged despite the anchor."""
+    text = f"cd /home/claude/kg-automation && python3 {_IMPORTER} --self-check"
+    assert _kinds(text) == [ViolationKind.SCRIPT_PATH_IMPORTS_SCRIPTS]
+
+
+def test_script_path_importer_unanchored_flagged_as_import_trap():
+    """The importer check takes priority over RELATIVE_SCRIPT (the -m form is the
+    correct fix, not the anchored-path form)."""
+    assert _kinds(f"python3 {_IMPORTER}") == [
+        ViolationKind.SCRIPT_PATH_IMPORTS_SCRIPTS
+    ]
+
+
+def test_script_path_importer_remediation_steers_to_m_form():
+    findings = scan_text(f"cd /home/claude/kg-automation && python3 {_IMPORTER}")
+    assert findings[0].kind is ViolationKind.SCRIPT_PATH_IMPORTS_SCRIPTS
+    assert "-m scripts" in findings[0].remediation
+
+
+def test_m_form_of_importer_is_compliant():
+    """The correct -m form of the same importer must NOT be flagged."""
+    text = "cd /home/claude/kg-automation && python3 -m scripts.inbox.prescan"
+    assert scan_text(text) == []
+
+
+def test_self_contained_script_by_path_not_import_trapped():
+    """A genuinely self-contained script by path is compliant when anchored —
+    the importer check must not false-flag it (regression guard)."""
+    text = f"cd /home/claude/kg-automation && python3 {_SELF_CONTAINED}"
+    assert scan_text(text) == []
+
+
+def test_nonexistent_script_path_not_import_trapped():
+    """A path we cannot resolve to a real file cannot be proven an importer, so
+    the -m-trap finding is not added (the shape rules still apply)."""
+    text = "cd /home/claude/kg-automation && python3 scripts/does/not/exist.py"
+    assert ViolationKind.SCRIPT_PATH_IMPORTS_SCRIPTS not in _kinds(text)
+
+
+def test_importer_placeholder_path_not_flagged():
+    """A `<placeholder>` path is documentation, never resolved."""
+    text = "cd /home/claude/kg-automation && python3 scripts/inbox/<helper>.py"
+    assert ViolationKind.SCRIPT_PATH_IMPORTS_SCRIPTS not in _kinds(text)


### PR DESCRIPTION
## Summary

The env-assumption checker validated invocation *shape* but not whether the target was runnable **by path**. It green-lit `cd /home/claude/kg-automation && python3 scripts/x.py` as compliant — but any helper doing `import scripts.…` fails `ModuleNotFoundError` when run by path (repo root not on `sys.path`); only `-m scripts.<pkg>.<mod>` works. This is the **3rd occurrence** of the `-m` trap class (hit again this run in #665/#761), and the checker's own docstring flagged strengthening it as a tracked follow-up.

## Fix
New `ViolationKind.SCRIPT_PATH_IMPORTS_SCRIPTS`. For a `python3 scripts/<path>.py` invocation, resolve the target against this checkout and — if it matches `^(from|import) scripts.` — flag it **regardless of the checkout-cd anchor** (an importer-by-path fails even with a correct anchor) and steer to the `-m` form. Deterministic file I/O only (reads the target in the same repo; a missing/unresolvable target is **not** flagged, so the finding is only *added* when provable). A self-contained target keeps the existing anchor rule.

## Test correction (notable)
The existing unit tests used `scripts/inbox/prescan.py` — an importer invoked as `-m` in production — as their "compliant relative-script" example, i.e. the exact wrong assumption #668 catches. Swapped those to a genuinely self-contained script (`felix-file-issue.py`) and added `SCRIPT_PATH_IMPORTS_SCRIPTS` cases: anchored + unanchored importer **caught**; `-m` form, self-contained, nonexistent path, and `<placeholder>` **not** flagged.

## No live breakage / preventive only
The 3 live script-path invocations in agent prompts (`validate_calendar_event.py`, `felix-file-issue.py`, `log_action.py`) are all **self-contained** — none is newly flagged, so the fleet guard stays green. This is a pure preventive guard: **no prompt edits, no deploy**.

## Testing
Full suite green (**5616 passed**). **Rebaseline:** not required (a `.py` checker, not an audited surface). Deploys via checkout self-pull (fleet guard runs in Test CI + `validate_workspace`).

Closes #668

🤖 Generated with [Claude Code](https://claude.com/claude-code)