### PR TITLE
fix(#608): preventive ratchet — day-specific habits must recur at least weekly

### DIFF
--- a/scripts/habits/schedule_loader.py
+++ b/scripts/habits/schedule_loader.py
@@ -122,6 +122,15 @@ def _normalize_designated_weekdays(
     return tuple(ordered)
 
 
+#: A day-specific habit recurs on its designated weekday, i.e. once per week, so
+#: its Vikunja ``repeat_after`` must be at least one week. Anything smaller —
+#: notably ``0`` — is the missing-recurrence bug that stranded the Mon/Wed/Fri
+#: strength-training tasks in #607 (a completed one-shot never re-armed). This
+#: ratchet (#608) makes a future day-specific entry that omits/zeros the interval
+#: fail loudly at load time instead of silently reintroducing that bug class.
+_WEEK_SECONDS = 604_800
+
+
 def _validate_entry(raw: Any, *, entry_index: int) -> ScheduleEntry:
     """Validate one raw dict entry and return a ``ScheduleEntry``."""
     if not isinstance(raw, dict):
@@ -158,6 +167,19 @@ def _validate_entry(raw: Any, *, entry_index: int) -> ScheduleEntry:
     weekdays = _normalize_designated_weekdays(
         raw.get("designated_weekdays"), entry_index=entry_index
     )
+
+    # #608 preventive ratchet: a day-specific habit recurs weekly, so it MUST
+    # carry at least a one-week ``repeat_after`` — reject the #607 no-rearm shape
+    # (day-specific but zero/sub-week interval) at load time. Daily habits (no
+    # designated_weekdays) are unaffected; their 86400 interval is validated
+    # elsewhere by the non-negative check above.
+    if weekdays and repeat_after < _WEEK_SECONDS:
+        raise ScheduleConfigError(
+            f"habits[{entry_index}] ({title!r}) is day-specific "
+            f"(designated_weekdays={list(weekdays)}) but repeat_after_seconds="
+            f"{repeat_after} is below one week ({_WEEK_SECONDS}); a day-specific "
+            f"habit must repeat at least weekly or it never re-arms (#607/#608)"
+        )
 
     return ScheduleEntry(
         task_id=task_id,

--- a/tests/habits/test_schedule_loader.py
+++ b/tests/habits/test_schedule_loader.py
@@ -78,7 +78,7 @@ habits:
   - task_id: 9
     title: "Multi"
     designated_weekdays: ["Thu", "Mon", "Thu", "Fri"]
-    repeat_after_seconds: 86400
+    repeat_after_seconds: 604800
 """,
         )
         entries = sl.load_schedule(path)
@@ -165,6 +165,70 @@ habits:
         )
         with pytest.raises(sl.ScheduleConfigError, match="not a valid"):
             sl.load_schedule(path)
+
+    def test_day_specific_zero_repeat_rejected(self, tmp_path: Path) -> None:
+        """#608 ratchet: a day-specific habit with repeat_after_seconds=0 (the
+        #607 no-rearm shape) must fail loudly at load time."""
+        path = _write(
+            tmp_path,
+            """
+habits:
+  - task_id: 75
+    title: "Strength training — Monday"
+    designated_weekdays: ["Mon"]
+    repeat_after_seconds: 0
+""",
+        )
+        with pytest.raises(sl.ScheduleConfigError, match="never re-arms"):
+            sl.load_schedule(path)
+
+    def test_day_specific_sub_week_repeat_rejected(self, tmp_path: Path) -> None:
+        """A day-specific habit with a sub-week interval (e.g. daily 86400) is
+        also rejected — a weekday habit recurs at least weekly."""
+        path = _write(
+            tmp_path,
+            """
+habits:
+  - task_id: 76
+    title: "Strength training — Wednesday"
+    designated_weekdays: ["Wed"]
+    repeat_after_seconds: 86400
+""",
+        )
+        with pytest.raises(sl.ScheduleConfigError, match="below one week"):
+            sl.load_schedule(path)
+
+    def test_daily_habit_zero_repeat_allowed_by_ratchet(self, tmp_path: Path) -> None:
+        """The ratchet is scoped to DAY-SPECIFIC entries: a daily habit (no
+        designated_weekdays) is unaffected — repeat_after_seconds=0 loads (the
+        non-negative check still applies, but the weekly-minimum does not)."""
+        path = _write(
+            tmp_path,
+            """
+habits:
+  - task_id: 14
+    title: "Wake at 5:00 AM"
+    repeat_after_seconds: 0
+""",
+        )
+        entries = sl.load_schedule(path)
+        assert entries[0].repeat_after_seconds == 0
+        assert entries[0].designated_weekdays == ()
+
+    def test_day_specific_exactly_one_week_allowed(self, tmp_path: Path) -> None:
+        """The canonical weekly value (604800) is the accepted floor."""
+        path = _write(
+            tmp_path,
+            """
+habits:
+  - task_id: 77
+    title: "Strength training — Friday"
+    designated_weekdays: ["Fri"]
+    repeat_after_seconds: 604800
+""",
+        )
+        entries = sl.load_schedule(path)
+        assert entries[0].repeat_after_seconds == 604800
 
     def test_lowercase_weekday_rejected(self, tmp_path: Path) -> None:
         """3-letter ISO names are case-sensitive — `wed` is not `Wed`."""


### PR DESCRIPTION
## Summary

#607: the Mon/Wed/Fri strength-training tasks were created with `repeat_after=0` (one-shot) → once completed they never re-armed. The acute bug was patched in Vikunja; this is the **preventive ratchet** so a future day-specific habit cannot silently reintroduce the missing-rearm shape (Constitution Directive 6: deterministic guardrail over LLM judgment).

## Change
Extends `schedule_loader._validate_entry`: an entry with a non-empty `designated_weekdays` (a day-specific habit recurs weekly) must carry `repeat_after_seconds >= 604800` (one week). A day-specific entry with `0` or a sub-week interval now fails `ScheduleConfigError` **loudly at load time**. Daily habits (no `designated_weekdays`) are unaffected. Weekday normalization still runs first (an invalid weekday reports its own error before the ratchet).

## Scope honored
- The frozen `phase3-schedule.yaml` still loads (its day-specific entries 75/76/77 already carry `604800` — the #607 fix); **did not edit** that historical migration record.
- Chose **Option 2** (config validation) over Option 1 (live-Vikunja architectural test) — deterministic, no network, guards the canonical config source of truth.

## Tests (acceptance criteria met)
- day-specific `repeat=0` **rejected** (the stated criterion), sub-week rejected, daily `repeat=0` still allowed (ratchet is day-specific-scoped), exactly-one-week accepted;
- fixed one dedupe fixture that used a sub-week interval for a day-specific entry;
- the real-YAML load test still passes. **32 loader tests pass.**

**Rebaseline:** not required (not an audited surface). Deploys via checkout self-pull.

Closes #608

🤖 Generated with [Claude Code](https://claude.com/claude-code)