### PR TITLE
docs(#734): mark deleted F006 Goals project (id 11) as retired across active surfaces

### DIFF
--- a/docs/design/architecture/service-inventory.md
+++ b/docs/design/architecture/service-inventory.md
@@ -122,7 +122,7 @@ spec FR-017.
 - **Data owner**: uid 1000:gid 0 (matches container runtime user)
 - **Backup**: Automatically included (under `/data/services/`)
 - **Runbook**: `docs/runbooks/vikunja-ops.md`
-- **F006 additions**: Goals project (top-level, id=11) for structured goal declarations, `metalcasework` label (#ff9800), Goals saved filter. Setup script: `scripts/vikunja/setup_goals.py`. Goals runbook: `docs/runbooks/goals-ops.md`
+- **F006 additions (Goals project RETIRED)**: the F006 Goals Vikunja project (formerly top-level id=11) and its Goals saved filter were **deleted in the #717/#714 reorg** — the goal-declaration concept now lives in the separate steering-wheel design effort, not as a Vikunja project. `metalcasework` label (#ff9800) still exists. The `scripts/vikunja/setup_goals.py` setup script and `docs/runbooks/goals-ops.md` runbook are retained as F006-v1 historical record (see their retirement banners).
 
 ### Obsidian Sync (pre-F001, updated F011, system-level confirmed #202)
 - **Deployed by**: Manual setup, updated by F011
@@ -212,7 +212,7 @@ spec FR-017.
 - **Purpose**: Autonomous Obsidian inbox processing — classifies content, routes to vault locations, creates Vikunja tasks, writes processing logs
 - **Schedule**: 4x daily via OpenClaw cron (7 AM, 12 PM, 5 PM, 10 PM ET)
 - **Processing logs**: `/home/kgale/second-brain/agents/logs/inbox-processing-YYYY-MM-DD.md`
-- **Vikunja projects used**: Inbox (tasks), Research (research requests), Goals (goal declarations)
+- **Vikunja projects used**: Inbox (tasks), Research (research requests) — the F006 Goals project was retired in the #717/#714 reorg
 - **Privacy boundary**: `04-Growth/_private/` is never accessed
 - **Runbook**: `docs/runbooks/inbox-ops.md`
 - **Updated by**: `harden-inbox-capture-01KWVGZM` (#662, 2026-07-06) — self-contained helper invocations fleet-wide (corrects the #656/#658 env-assumption failure); capture held on haiku (model choice under evaluation, #671). `#256-scope-discipline-guardrails` (2026-05-13) — adds explicit "no unsanctioned reads/edits" prose to AGENTS.md Step 5a + Step 6 after T011 SC-003 verification of #253 surfaced haiku making unsanctioned `edit` attempts on parse_failure notes. `#253-step-5a-6-consolidation` (2026-05-13) — collapses AGENTS.md Step 5a and Step 6 into single-call orchestrator helpers (`handle_marker_cleanup.py`, `handle_parse_failures.py`); applies the deterministic-work-into-scripts principle. `#254-atomic-write-perm-preservation` (2026-05-13) — fixes `_atomic_write` in both marker scripts to preserve target mode (and default new files to `0o664`) so cross-user access by ob (Obsidian Sync daemon, runs as kgale) is not broken by claude-orphaned `0o600` files. `#185-inbox-capture-dedup` (2026-05-12) — adds routing-log dedup + parse-failure halt-and-surface. Previously: `027-inbox-pre-scan-helper` (2026-04-11).

--- a/docs/runbooks/goals-ops.md
+++ b/docs/runbooks/goals-ops.md
@@ -7,6 +7,13 @@ status: draft
 
 # Goals Operations Runbook
 
+> **⚠️ RETIRED (F006 v1, #717/#734).** The Vikunja **Goals project (formerly
+> id=11)** this runbook operates on was **deleted in the #717/#714 reorg**. This
+> document is retained as the F006-v1 historical record; the goal-declaration
+> concept is being redesigned as the separate steering-wheel substrate, not as a
+> Vikunja project. Do not follow the operational steps below against live Vikunja
+> — there is no Goals project to operate on.
+
 This runbook covers the goal declaration system established by F006. Goals are
 outcome declarations — distinct from tasks — that anchor all downstream
 prioritization, escalation, and briefing features.

--- a/docs/runbooks/vikunja-ops.md
+++ b/docs/runbooks/vikunja-ops.md
@@ -181,10 +181,14 @@ included in `scripts/office2/security-monitor/configure-ufw.sh`.
 The Goals project holds goal declarations — outcome statements with target dates
 and evidence criteria. Goals are distinct from tasks: they are anchors, not actions.
 
-### Project Structure
+### Project Structure (F006 Goals project — RETIRED)
+
+> The F006 Goals Vikunja project (formerly top-level id=11) was **deleted in the
+> #717/#714 reorg**. The structure below is historical (F006 v1); the
+> goal-declaration concept now lives in the separate steering-wheel design effort.
 
 ```
-Goals                        ← Top-level project (id=11)
+Goals                        ← Top-level project (id=11) — DELETED (#717)
 ├── Intentional: $5K/month consulting income
 ├── Intentional: $2.5K/month consulting income by Q2
 └── Personal: Complete Against the Tide 5K
@@ -207,7 +211,7 @@ Every goal task must have exactly one identity label.
 | Today | `due_date >= now/d && due_date < now/d+1d && done = false` | due_date asc | F001 |
 | Upcoming | `due_date > now/d && due_date <= now+14d && done = false` | due_date asc | F001 |
 | Overdue | `due_date < now/d && done = false` | due_date asc | F001 |
-| Goals | `project = 11 && done = false` | due_date asc | F006 |
+| ~~Goals~~ (RETIRED #717) | ~~`project = 11 && done = false`~~ — project deleted | — | F006 |
 
 ### Setup Script
 

--- a/scripts/openclaw/skills/vikunja-api/SKILL.md
+++ b/scripts/openclaw/skills/vikunja-api/SKILL.md
@@ -111,7 +111,6 @@ curl -s -H "Authorization: Bearer $(cat /data/services/openclaw/secrets/vikunja-
 | Health & Conditioning | 8 | |
 | Intentional LLC | 9 | |
 | Metal Casework | 10 | |
-| Goals | 11 | Goal declarations (F006) |
 
 ## Labels
 
@@ -291,17 +290,12 @@ curl -s -H "Authorization: Bearer $(cat /data/services/openclaw/secrets/vikunja-
   https://office2.tail0f5f56.ts.net/api/v1/projects/-4/tasks
 ```
 
-### Active Goals (Goals Project)
+### Active Goals — RETIRED
 
-Goals is a real project (not a pseudo-project). Query active goal declarations:
-
-```bash
-curl -s -H "Authorization: Bearer $(cat /data/services/openclaw/secrets/vikunja-api)" \
-  "https://office2.tail0f5f56.ts.net/api/v1/tasks/all?filter=done%20%3D%20false%20%26%26%20project_id%20%3D%20GOALS_PROJECT_ID&sort_by=due_date&order_by=asc"
-```
-
-Replace `GOALS_PROJECT_ID` with the ID resolved by name from the Projects section
-(currently 11).
+The F006 Goals Vikunja project (formerly id 11) was **deleted in the #717/#714
+Vikunja reorg**; there is no Goals project to query. The goal-declaration concept
+continues in the separate steering-wheel design effort, not as a Vikunja project.
+Do not query a "Goals" project by name or id.
 
 ### Ad-Hoc Queries
 
@@ -314,9 +308,9 @@ curl -s -H "Authorization: Bearer $(cat /data/services/openclaw/secrets/vikunja-
 
 **Filter syntax** (URL-encode spaces and operators):
 - `done = false` — incomplete tasks
-- `project_id = 11` — tasks in a specific project
+- `project_id = 13` — tasks in a specific project (13 = Habits, a real project)
 - `due_date < 2026-04-01T00:00:00Z` — tasks due before a date
-- Combine with `&&`: `done = false && project_id = 11`
+- Combine with `&&`: `done = false && project_id = 13`
 
 **Sort options**:
 - `sort_by=due_date&order_by=asc` — by due date, earliest first

--- a/scripts/vikunja/setup_goals.py
+++ b/scripts/vikunja/setup_goals.py
@@ -2,6 +2,12 @@
 """
 setup_goals.py — Configure Vikunja with Goals project, labels, and filter.
 
+RETIRED (F006 v1, #717/#734): the Goals Vikunja project this script creates
+(formerly id=11) was deleted in the #717/#714 reorg. Retained as the F006-v1
+historical record only. Do NOT run it — it would re-create a project that was
+deliberately retired. The goal-declaration concept is being redesigned as the
+separate steering-wheel substrate, not as a Vikunja project.
+
 Idempotent: safe to run multiple times. Creates only missing entities.
 Authenticates interactively via username/password → JWT (not persisted).
 


### PR DESCRIPTION
## Summary

#717/#714 deleted the Vikunja Goals project (id 11), but several active non-escalation surfaces still documented it as **current**, misleading agent/tool use — most importantly the operational `vikunja-api` skill.

## Changes
- **`vikunja-api/SKILL.md`**: removed the `| Goals | 11 |` project row; replaced the "Active Goals (Goals is a real project… currently 11)" query section with a RETIRED note; moved the generic filter examples off the dead id (`11` → `13`, Habits).
- **`service-inventory.md`**: annotated the F006 Goals project + saved filter as retired (#717); dropped Goals from "Vikunja projects used".
- **`vikunja-ops.md`**: marked the Goals project-structure block + `project = 11` saved-filter row RETIRED.
- **`goals-ops.md` + `setup_goals.py`**: retirement banners (F006-v1 historical record; do not run/operate). **Retained rather than deleted** — the goal-declaration concept continues in the separate steering-wheel design effort.

Left `docs/archive/**` + historical research untouched. Docs/annotation only — no behavior change; validators + vikunja tests (348) green.

## Surfaced for Kent (larger, out of #734 scope)
1. `vikunja-api/SKILL.md`'s project table has other likely-stale pre-reorg ids (Everyday=2, Personal Growth=5, Business Acq=6, Health=8, …) — a full post-#714-reorg table refresh is a separate cleanup.
2. The **deployed** skill at `~/.openclaw/skills/vikunja-api/SKILL.md` is ~3 months stale (Apr 10) with **no evident auto-sync** — a skill-deploy/sync gap worth its own issue.

**Rebaseline:** not required (docs). Closes #734

🤖 Generated with [Claude Code](https://claude.com/claude-code)