### PR TITLE
docs(#539): reconcile felix-doc-auditor suspended state + define last-tick suspension semantics

### DIFF
--- a/docs/design/architecture/data/service-inventory.json
+++ b/docs/design/architecture/data/service-inventory.json
@@ -1609,7 +1609,7 @@
         "endpoint": "/data/services/openclaw/felix-doc-auditor-driver/last-tick.json",
         "expected": "status=success within the last 2 hours; exit_code=0; errors=[] (see contracts/tick-signal.contract.md)",
         "timeout_seconds": 5,
-        "note": "Post-#343 health is determined by parsing last-tick.json (structured), not by tailing the prose activity log. Activity log at /home/kgale/second-brain/agents/logs/doc-auditor-YYYY-MM-DD.md remains as a per-tick prose summary."
+        "note": "Post-#343 health is determined by parsing last-tick.json (structured), not by tailing the prose activity log. Activity log at /home/kgale/second-brain/agents/logs/doc-auditor-YYYY-MM-DD.md remains as a per-tick prose summary. SUSPENSION SEMANTICS (#539): the 'expected: status=success within the last 2 hours' contract applies only to the ACTIVE state and resumes on re-enablement. While operational_status=suspended (timer disabled), last-tick.json intentionally RETAINS the last pre-suspension success (2026-05-25T13:28:34Z, status=success, exit_code=0); that stale tick is the EXPECTED steady state, not a failure, and freshness is not evaluated for a suspended entry (validator excludes suspended per LIVE_STATUS_VALUES). The disabled timer + this suspended status — not a mutation of last-tick.json — are the authoritative suspension signal."
       },
       "config_files": [
         {

--- a/docs/runbooks/doc-auditor-driver-ops.md
+++ b/docs/runbooks/doc-auditor-driver-ops.md
@@ -25,6 +25,16 @@ owners: [kgale]
 > [#137](https://github.com/kentonium3/kg-automation/issues/137) to land
 > plus an explicit operator decision. This runbook is retained as the
 > authoritative reference for when re-enablement occurs.
+>
+> **`last-tick.json` during suspension (#539):** the deployed
+> `last-tick.json` intentionally retains the **last pre-suspension success**
+> (`2026-05-25T13:28:34Z`, `status=success`, `exit_code=0`). This stale tick is
+> the **expected** steady state while suspended — NOT a failure and NOT to be
+> mutated. The authoritative "suspended" signal is the disabled timer plus
+> `operational_status: suspended` in `service-inventory.json`, which excludes the
+> entry from freshness health evaluation. On re-enablement the timer resumes and
+> fresh ticks (< 2h) return. `service-inventory.json`, this runbook, and the live
+> office2 state (disabled timer, stale-success tick) now tell one consistent story.
 
 Authoritative operator reference for the scripts-first `felix-doc-auditor`
 driver introduced by mission [#343 — refactor-doc-auditor-to-scripts-first-driver](https://github.com/kentonium3/kg-automation/issues/343).


### PR DESCRIPTION
## Summary

The three surfaces #539 flagged as disagreeing have **converged** since it was filed (2026-06-05): `service-inventory.json` now says `status`/`operational_status: suspended` (no longer "active"), the runbook says SUSPENDED INDEFINITELY, and the live office2 timer is disabled. The one remaining acceptance gap was *"define explicitly what `last-tick.json` should show during a suspension."*

## Change (docs/data only)
- **`service-inventory.json`** health_check note: added SUSPENSION SEMANTICS — the "success within 2h" expectation applies to the ACTIVE state only; while suspended, `last-tick.json` intentionally retains the last pre-suspension success (`2026-05-25T13:28:34Z`) and that stale tick is the **expected** steady state, not a failure (freshness isn't evaluated for suspended entries per the validator's `LIVE_STATUS_VALUES` exclusion).
- **runbook**: added the matching "`last-tick.json` during suspension" definition.

## Notes
- Resolved **without the #516 lifecycle ADR** (per the operator decision to suspend-as-defined now): `STATUS_ENUM` already includes `suspended` and the validator already excludes suspended entries from freshness warnings.
- **Did not mutate** the deployed `last-tick.json` (a real historical tick record); the authoritative suspension signal is the disabled timer + `operational_status: suspended`.

## Acceptance met
inventory + runbook + live office2 (disabled timer, stale-success tick) tell one consistent story; last-tick suspension semantics defined explicitly. Validators green. Rebaseline not required.

Closes #539

🤖 Generated with [Claude Code](https://claude.com/claude-code)