### PR TITLE
fix(#766): drift-check reads office2 workspace files locally on-host (was SSHing a Mac-only alias)

### DIFF
--- a/scripts/openclaw/enforcement/drift_check.py
+++ b/scripts/openclaw/enforcement/drift_check.py
@@ -106,6 +106,30 @@ def compute_remote_hashes(ssh_host: str, file_paths: list[str]) -> dict[str, str
     return hashes
 
 
+def compute_office2_hashes(ssh_host: str, file_paths: list[str]) -> dict:
+    """Hash each deployed office2 workspace file, LOCAL-first (#766).
+
+    The drift-check cron runs **on office2**, where the deployed workspace files
+    (``/data/services/openclaw/…``) are on the local filesystem and the
+    ``ssh_host`` alias (``office2-claude``) does NOT resolve — it is a Mac-only
+    ``~/.ssh/config`` alias. An unconditional ``ssh`` therefore failed every read
+    on the cron host, and the enforcement reported garbage (``file_missing_repo``
+    for every agent), i.e. the whole guard was silently inert.
+
+    Fix: if the workspace files are present on THIS host (we are on office2), read
+    them directly — a genuinely-absent file then reads as ``None`` (office2
+    missing), which is correct. Only when they are not local (the tool is run
+    from the Mac, where the alias resolves) do we batch a single SSH. This makes
+    the tool correct from both vantage points with no host flag or hostname probe.
+    """
+    if not file_paths:
+        return {}
+    on_host = any(os.path.isdir(os.path.dirname(fp)) for fp in file_paths)
+    if on_host:
+        return {fp: compute_local_hash(fp) for fp in file_paths}
+    return compute_remote_hashes(ssh_host, file_paths)
+
+
 def compute_all_hashes(config: dict, repo_root: str) -> dict:
     """Compute current hashes for all tracked files on both sides."""
     ssh_host = config.get("ssh_host", "office2-claude")
@@ -120,8 +144,8 @@ def compute_all_hashes(config: dict, repo_root: str) -> dict:
             remote_paths.append(remote_path)
             path_index[remote_path] = (agent_id, filename)
 
-    # Batch remote hashes
-    remote_hashes = compute_remote_hashes(ssh_host, remote_paths)
+    # Office2 workspace hashes — local-first, SSH only when not on-host (#766).
+    remote_hashes = compute_office2_hashes(ssh_host, remote_paths)
 
     # Build result structure — skip files with SSH errors
     result = {}

--- a/tests/openclaw/enforcement/test_drift_check.py
+++ b/tests/openclaw/enforcement/test_drift_check.py
@@ -9,6 +9,7 @@ from unittest.mock import patch, MagicMock
 from scripts.openclaw.enforcement.drift_check import (
     SSH_ERROR,
     compute_local_hash,
+    compute_office2_hashes,
     compute_remote_hashes,
     compute_all_hashes,
     format_results,
@@ -66,6 +67,65 @@ class TestComputeRemoteHashes:
 
     def test_empty_file_list(self):
         assert compute_remote_hashes("office2-claude", []) == {}
+
+
+class TestComputeOffice2Hashes:
+    """#766 — local-first: on the host where the workspace files live (office2),
+    read them directly; only SSH when they are not local (the Mac)."""
+
+    def test_reads_locally_when_files_present_no_ssh(self, tmp_path):
+        # Simulate on-office2: the workspace files exist on this host.
+        ws = tmp_path / "inbox-agent"
+        ws.mkdir()
+        (ws / "AGENTS.md").write_text("agents body\n")
+        (ws / "TOOLS.md").write_text("tools body\n")
+        paths = [str(ws / "AGENTS.md"), str(ws / "TOOLS.md")]
+
+        with patch(
+            "scripts.openclaw.enforcement.drift_check.subprocess.run"
+        ) as mock_run:
+            result = compute_office2_hashes("office2-claude", paths)
+
+        mock_run.assert_not_called()  # NO ssh when the files are local
+        assert result[paths[0]] == compute_local_hash(paths[0])
+        assert result[paths[1]] == compute_local_hash(paths[1])
+        assert all(v is not None for v in result.values())
+
+    def test_local_missing_file_reads_none_not_ssh_error(self, tmp_path):
+        # On-host, a genuinely-absent workspace file reads as None (office2
+        # missing) — NOT an SSH_ERROR skip.
+        ws = tmp_path / "inbox-agent"
+        ws.mkdir()
+        (ws / "AGENTS.md").write_text("present\n")
+        present = str(ws / "AGENTS.md")
+        absent = str(ws / "GONE.md")
+
+        with patch(
+            "scripts.openclaw.enforcement.drift_check.subprocess.run"
+        ) as mock_run:
+            result = compute_office2_hashes("office2-claude", [present, absent])
+
+        mock_run.assert_not_called()
+        assert result[present] is not None
+        assert result[absent] is None
+
+    def test_falls_back_to_ssh_when_not_on_host(self):
+        # Paths under a non-existent root (the Mac vantage) → SSH.
+        paths = ["/data/services/openclaw/data/AGENTS.md"]
+        mock_result = MagicMock()
+        mock_result.returncode = 0
+        mock_result.stdout = "deadbeef  /data/services/openclaw/data/AGENTS.md\n"
+        mock_result.stderr = ""
+        with patch(
+            "scripts.openclaw.enforcement.drift_check.subprocess.run",
+            return_value=mock_result,
+        ) as mock_run:
+            result = compute_office2_hashes("office2-claude", paths)
+        mock_run.assert_called_once()  # SSH used from the Mac
+        assert result[paths[0]] == "deadbeef"
+
+    def test_empty(self):
+        assert compute_office2_hashes("office2-claude", []) == {}
 
 
 class TestComputeAllHashes:


### PR DESCRIPTION
## Summary

The agent-workspace drift-enforcement cron runs **on office2** (claude crontab, daily 06:00 UTC) but read the deployed workspace hashes via `ssh office2-claude` — a **Mac-only** `~/.ssh/config` alias that does **not resolve on office2**. Every read SSH-errored and the run reported `file_missing_repo` for **all** agents: the guard against silent repo↔office2 workspace drift (#166/#553) was **silently inert**. Found during #654.

## Fix
New `compute_office2_hashes` reads the workspace files **locally when present on this host** (we're on office2 — a genuinely-absent file then reads as `None` = office2-missing, correct), and batches a single SSH only when they're **not** local (run from the Mac, where the alias resolves). Context-agnostic — correct from both vantage points, no host flag or hostname probe. `compute_all_hashes` calls it instead of the unconditional SSH.

Chose the issue's recommended **Option 1** (local read on-host); present-locally detection is cleaner than a hostname check/config flag and handles the missing-file case correctly.

## Tests
4 new: local read (asserts **no** SSH), missing-local-file → `None` (not `SSH_ERROR`), SSH fallback when not on-host, empty. Existing **61** enforcement tests still pass (their `/data/...` paths don't exist on the test host → the already-mocked SSH path). **Will live-verify on office2 post-merge.**

**Rebaseline:** not required. Deploys via checkout self-pull; the next drift-check run uses the fix.

Closes #766

🤖 Generated with [Claude Code](https://claude.com/claude-code)