### PR TITLE
fix(#763): deterministic clarification `remove` subcommand + wire calendar prompt (Directive 6)

### DIFF
--- a/scripts/inbox/handle_clarification_state.py
+++ b/scripts/inbox/handle_clarification_state.py
@@ -155,6 +155,34 @@ def subcommand_sweep(path: Path, now_utc: datetime) -> int:
     return 0
 
 
+def subcommand_remove(path: Path, note_filename: str) -> int:
+    """Remove all pending entries for a resolved note (#763, Directive 6).
+
+    Deletes every entry whose ``note_filename`` matches ``note_filename`` by
+    basename. The calendar agent calls this once a clarification is resolved,
+    instead of hand-rolling a JSON rewrite of the store (which could drop or
+    malform a surviving entry). Deterministic and atomic (``save_state`` RMW),
+    idempotent (a filename with no entry prints ``removed=0``, no error),
+    basename-normalized (a path-form key still matches the stored basename), and
+    safe on an absent file.
+    """
+    target = os.path.basename(note_filename)
+    if not path.exists():
+        print("removed=0")
+        return 0
+    entries = load_state(path)
+    kept = [
+        e
+        for e in entries
+        if os.path.basename(str(e.get("note_filename", ""))) != target
+    ]
+    removed = len(entries) - len(kept)
+    if removed:
+        save_state(path, kept)
+    print(f"removed={removed}")
+    return 0
+
+
 def pending_filenames(path: Path, now_utc: datetime) -> set[str]:
     """Return the set of note **basenames** with a live pending-clarification entry.
 
@@ -341,6 +369,13 @@ def _build_parser() -> argparse.ArgumentParser:
     sweep_p = sub.add_parser("sweep", help="Delete entries older than 24h.")
     _add_state_file_arg(sweep_p)
 
+    remove_p = sub.add_parser(
+        "remove",
+        help="Remove all pending entries for a resolved note filename (#763).",
+    )
+    remove_p.add_argument("--note-filename", required=True)
+    _add_state_file_arg(remove_p)
+
     pending_p = sub.add_parser(
         "pending",
         help="Print whether a note filename has a live pending entry (#740).",
@@ -371,6 +406,8 @@ def main(argv: list[str] | None = None) -> int:
         )
     if args.subcommand == "sweep":
         return subcommand_sweep(state_path, now_utc)
+    if args.subcommand == "remove":
+        return subcommand_remove(state_path, args.note_filename)
     if args.subcommand == "pending":
         return subcommand_pending(state_path, args.note_filename, now_utc)
     if args.subcommand == "match":  # pragma: no branch - argparse enforces

--- a/scripts/openclaw/agents/felix-admin-calendar/AGENTS.md
+++ b/scripts/openclaw/agents/felix-admin-calendar/AGENTS.md
@@ -132,7 +132,7 @@ When re-validation returns `complete: true`, do the following in order:
 
 2. **Apply the Calendar event creation handler above** with the synthesized payload (not a literal `openclaw agent` round-trip): tempfile + the same calendar-helper `create --payload-file … --json` invocation. Its Logging subsection auto-emits `calendar_event_created`/`calendar_event_failed`.
 
-3. **Remove the resolved record** from the JSON-array store (`/data/services/openclaw/state/pending-calendar-clarifications.json`) — don't hand-roll parsing. Records age out via the 24h `sweep`; the invariant is only that a *failed* resolution keeps its record (see Failure mode).
+3. **Remove the resolved record** — deterministic helper, not by hand (#763): `cd /home/claude/kg-automation && python3 -m scripts.inbox.handle_clarification_state remove --note-filename "<matched note_filename>"` (prints `removed=N`). (A *failed* resolution keeps its record — see Failure mode.)
 
 4. **Flip the source note's frontmatter** at `source_inbox_path`: locate the YAML block, set `status: processed` and `processed_at: "<tick_iso>"` (same as re-validation). Atomic write via .tmp + rename, matching capture's pattern.
 

--- a/tests/inbox/test_handle_clarification_state.py
+++ b/tests/inbox/test_handle_clarification_state.py
@@ -716,6 +716,104 @@ def test_pending_subcommand_false_for_aged_and_unknown(
     assert capsys.readouterr().out.strip() == "pending=false"
 
 
+# --------------------------------------------------------------------------
+# remove (#763) — deterministic resolved-record removal (Directive 6)
+# --------------------------------------------------------------------------
+
+
+def test_remove_deletes_matching_and_keeps_others(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    now = datetime.now(timezone.utc)
+    state = tmp_path / "pending.json"
+    _write_state(
+        state,
+        [
+            _entry("resolved.md", now - timedelta(hours=1)),
+            _entry("keep.md", now - timedelta(hours=1)),
+        ],
+    )
+    rc = hcs.main(
+        ["remove", "--note-filename", "resolved.md", "--state-file", str(state)]
+    )
+    assert rc == 0
+    assert capsys.readouterr().out.strip() == "removed=1"
+    remaining = [e["note_filename"] for e in _read_state(state)]
+    assert remaining == ["keep.md"]
+
+
+def test_remove_is_idempotent_no_match(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    now = datetime.now(timezone.utc)
+    state = tmp_path / "pending.json"
+    _write_state(state, [_entry("other.md", now - timedelta(hours=1))])
+    rc = hcs.main(
+        ["remove", "--note-filename", "nope.md", "--state-file", str(state)]
+    )
+    assert rc == 0
+    assert capsys.readouterr().out.strip() == "removed=0"
+    assert len(_read_state(state)) == 1  # untouched
+
+
+def test_remove_removes_all_duplicate_entries(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    now = datetime.now(timezone.utc)
+    state = tmp_path / "pending.json"
+    _write_state(
+        state,
+        [
+            _entry("dup.md", now - timedelta(hours=2)),
+            _entry("dup.md", now - timedelta(hours=1)),
+            _entry("other.md", now - timedelta(hours=1)),
+        ],
+    )
+    rc = hcs.main(
+        ["remove", "--note-filename", "dup.md", "--state-file", str(state)]
+    )
+    assert rc == 0
+    assert capsys.readouterr().out.strip() == "removed=2"
+    assert [e["note_filename"] for e in _read_state(state)] == ["other.md"]
+
+
+def test_remove_basename_normalized(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """A path-form --note-filename still matches a stored basename, and vice versa."""
+    now = datetime.now(timezone.utc)
+    state = tmp_path / "pending.json"
+    _write_state(state, [_entry("Deep 2026-07-18 0900.md", now - timedelta(hours=1))])
+    rc = hcs.main(
+        [
+            "remove",
+            "--note-filename",
+            "01-Inbox/Deep 2026-07-18 0900.md",
+            "--state-file",
+            str(state),
+        ]
+    )
+    assert rc == 0
+    assert capsys.readouterr().out.strip() == "removed=1"
+    assert _read_state(state) == []
+
+
+def test_remove_safe_on_absent_file(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    rc = hcs.main(
+        [
+            "remove",
+            "--note-filename",
+            "x.md",
+            "--state-file",
+            str(tmp_path / "nope.json"),
+        ]
+    )
+    assert rc == 0
+    assert capsys.readouterr().out.strip() == "removed=0"
+
+
 def test_module_runs_as_main(monkeypatch: pytest.MonkeyPatch) -> None:
     """`python3 -m scripts.inbox.handle_clarification_state sweep` works.
 


### PR DESCRIPTION
## Summary
`felix-admin-calendar/AGENTS.md` told the agent to *"remove the resolved record — don't hand-roll parsing,"* but there was **no subcommand** to do it, forcing a hand-rolled JSON rewrite (which can drop/malform a surviving entry). #740's fail-open already removed the silent-loss danger; this closes the **Directive-6** gap.

## Change
- **`handle_clarification_state.py`**: new `remove --note-filename` — deletes all entries for a note by basename (idempotent, atomic RMW, basename-normalized, safe on absent file).
- **`felix-admin-calendar/AGENTS.md` step 3**: replaced the vague instruction with the exact `-m scripts.inbox.handle_clarification_state remove …` invocation. Kept under the 12,000-byte prompt cap.

## Tests
5 new (delete-matching-keep-others, idempotent-no-match, remove-all-dups, basename-normalized, safe-on-absent). 319 inbox+openclaw tests pass.

## Deploy note
Helper via checkout self-pull; calendar prompt via agent-prompt-sync (no rotate — it's a fresh-session-per-delegation sub-agent). **Follow-up in the same effort:** regenerate the drift-check baseline-manifest after the prompt deploys (else the now-working #766 drift-check false-alarms CONFLICT on the changed prompt), and file the systemic manifest-auto-regen gap that exposes.

**Rebaseline:** not required (audit.sh doesn't hash AGENTS.md, #621).

Closes #763