### PR TITLE
fix(#739): calendar time-of-day policy — no-time appointment asks for the time (not midnight)

### DIFF
--- a/scripts/calendar_routing/validate_calendar_event.py
+++ b/scripts/calendar_routing/validate_calendar_event.py
@@ -387,6 +387,20 @@ def _phrase_is_fully_explained(text: str, consumed_spans: list[tuple[int, int]])
     return leftover == ""
 
 
+def _is_all_day_duration(duration: Optional[timedelta]) -> bool:
+    """True iff *duration* signals an all-day event: a positive whole number of
+    days (e.g. "1 day", "2 days"), with no partial-day remainder.
+
+    Used by the #739 time-of-day policy — an all-day event (an anniversary, a
+    holiday) is legitimately time-less and must NOT trigger a start-time
+    clarification the way a timed appointment ("meet Rob Thursday") does.
+    """
+    if duration is None:
+        return False
+    seconds = duration.total_seconds()
+    return seconds >= 86400 and seconds % 86400 == 0
+
+
 def parse_recurrence(natural: Optional[str]) -> Optional[str]:
     """Convert a natural-language recurrence phrase to an RFC 5545 RRULE.
 
@@ -519,8 +533,24 @@ def validate(block: dict) -> dict:
     tick_iso = block.get("tick_iso")
     start_natural = block.get("start_natural")
     start_dt = parse_datetime(start_natural, tick_iso) if isinstance(tick_iso, str) else None
+
+    # Parse the duration early — it doubles as the all-day signal for the
+    # start-time policy below (a whole-day duration means an all-day event).
+    duration = parse_duration(block.get("duration_natural"))
+
     if start_dt is None:
         missing.append("start_datetime")
+    elif _parse_time_component(start_natural) is None and not _is_all_day_duration(duration):
+        # #739 calendar time-of-day policy: the date resolved but the note gave
+        # no explicit time, AND this is not an all-day event. A timed calendar
+        # appointment ("meet Rob Thursday", "call X Monday") must NOT be created
+        # at a guessed default time (parse_datetime falls back to 00:00) —
+        # surface "start_time" so capture asks Kent for the time. An all-day
+        # event (whole-day duration, e.g. an anniversary) is legitimately
+        # time-less and is left to create as-is. (The all-day *fallback* for an
+        # unanswered appointment clarification is tracked separately — it needs
+        # all-day-event support in the calendar helper.)
+        missing.append("start_time")
 
     # end_or_duration is satisfied when EITHER an end datetime parses OR a
     # duration parses; both are checked independently of start so the
@@ -530,7 +560,6 @@ def validate(block: dict) -> dict:
     end_dt_candidate: Optional[datetime] = None
     if isinstance(end_natural, str) and end_natural.strip() and isinstance(tick_iso, str):
         end_dt_candidate = parse_datetime(end_natural, tick_iso)
-    duration = parse_duration(block.get("duration_natural"))
     has_end_or_duration = end_dt_candidate is not None or duration is not None
     if not has_end_or_duration:
         missing.append("end_or_duration")

--- a/tests/calendar/test_validate_calendar_event.py
+++ b/tests/calendar/test_validate_calendar_event.py
@@ -299,6 +299,61 @@ def test_all_day_event_date_only() -> None:
     assert result["calendar_event_payload"]["start_rfc3339"].startswith("2026-06-14T00:00:00")
 
 
+# --- #739 time-of-day policy: timed appointment with no time → clarify --------
+
+
+def test_appointment_date_only_no_time_requires_clarification() -> None:
+    """A timed appointment ('meet Rob Thursday') that resolves a date but gives
+    no explicit time must NOT default to midnight — it surfaces `start_time` so
+    capture asks Kent (calendar time-of-day policy, #739)."""
+    block = {
+        "title": "Meet Rob",
+        "start_natural": "next Thursday",
+        "duration_natural": "1 hour",  # timed, NOT all-day
+        "source_inbox_path": "/tmp/Inbox 2026-06-07 1000.md",
+        "source_block_index": 0,
+        "tick_iso": "2026-06-07T10:00:00-04:00",
+    }
+    result = vce.validate(block)
+    assert result["complete"] is False
+    assert "start_time" in result["missing_fields"]
+    # The date itself resolved fine — only the time is missing.
+    assert "start_datetime" not in result["missing_fields"]
+
+
+def test_appointment_with_explicit_time_no_clarification() -> None:
+    """An appointment WITH an explicit time resolves fully — no start_time ask."""
+    block = {
+        "title": "Meet Rob",
+        "start_natural": "next Thursday at 3pm",
+        "duration_natural": "1 hour",
+        "source_inbox_path": "/tmp/Inbox 2026-06-07 1000.md",
+        "source_block_index": 0,
+        "tick_iso": "2026-06-07T10:00:00-04:00",
+    }
+    result = vce.validate(block)
+    assert result["complete"] is True
+    assert result["calendar_event_payload"]["start_rfc3339"].startswith(
+        "2026-06-11T15:00:00"
+    )
+
+
+def test_all_day_event_date_only_does_not_require_time() -> None:
+    """An all-day event (whole-day duration) is legitimately time-less and must
+    NOT trigger the #739 start_time clarification (regression guard)."""
+    block = {
+        "title": "Anniversary",
+        "start_natural": "June 14, 2026",
+        "duration_natural": "1 day",  # all-day signal
+        "source_inbox_path": "/tmp/Inbox 2026-06-07 1000.md",
+        "source_block_index": 0,
+        "tick_iso": "2026-06-07T10:00:00-04:00",
+    }
+    result = vce.validate(block)
+    assert result["complete"] is True
+    assert "start_time" not in result.get("missing_fields", [])
+
+
 def test_multiple_missing_fields_reported() -> None:
     block = {
         "title": "Mystery event",


### PR DESCRIPTION
## Summary
The deterministic relative-date **resolver was already wired** (`validate` → `parse_datetime`, so date math is off the LLM — #739's headline). The gap was the time-of-day default: `parse_datetime` falls back to `00:00` when a note gives a date but no time, so "Meet Rob Thursday" silently created a **midnight** event.

Per your decision: a timed appointment with a resolved date but **no explicit time** now surfaces `missing: ["start_time"]` → capture asks you the time (option **(i)**), instead of guessing midnight. An **all-day event** (whole-day duration, e.g. an anniversary) is legitimately time-less and creates as-is — new `_is_all_day_duration` guard so the policy targets appointments, not all-day events.

**No capture-prompt change:** the clarification flow already asks for missing fields generically (its example is literally *"What time should <title> be on <date>?"*).

The **(iii) all-day fallback** for an *unanswered* appointment clarification is filed as **#780** (needs all-day-event support in the calendar helper).

## Tests
3 new (date-only appointment → start_time clarification; explicit time → resolves; all-day event → no clarification). 76 calendar + 222 calendar-routing/finalize tests pass.

**Deploy:** self-contained script → checkout self-pull. No prompt change, no rebaseline.

Closes #739