### PR TITLE
fix(#637): alert on agent-prompt-sync per-file copy-failure streaks

### DIFF
--- a/scripts/deploy/lib/health.py
+++ b/scripts/deploy/lib/health.py
@@ -64,6 +64,12 @@ Clock = Callable[[], str]
 # is NOT stamped so it re-attempts on the next failing tick.
 Notifier = Callable[[str, str], bool]
 
+# Render seam (#637): builds the (title, body) for a streak-crossing alert. The
+# default renders the git-advance wording; callers reusing this watermark for a
+# non-git streak (e.g. agent-prompt-sync's per-file COPY failures) pass their own
+# so the alert reads accurately.
+RenderAlert = Callable[["HealthWatermark", AdvanceResult, int], "tuple[str, str]"]
+
 
 def utc_now_iso() -> str:
     """Default clock: current time as ISO-8601 UTC with a trailing ``Z``."""
@@ -161,6 +167,8 @@ def record(
     threshold: int = DEFAULT_THRESHOLD,
     notifier: Notifier | None = None,
     clock: Clock = utc_now_iso,
+    confirmed_reasons: frozenset[str] = CONFIRMED_FAILURE_REASONS,
+    render: "RenderAlert | None" = None,
 ) -> bool:
     """Update *actor*'s watermark from *result*; return True iff an alert fired.
 
@@ -205,7 +213,7 @@ def record(
     elif result.reason == "lock_unavailable":
         # Benign defer — leave the streak untouched. Just re-stamp updated_ts.
         pass
-    elif result.reason in CONFIRMED_FAILURE_REASONS:
+    elif result.reason in confirmed_reasons:
         if state.consecutive_failures == 0 or state.failure_streak_started_ts is None:
             # Starting a new streak: anchor the throttle timestamp.
             state.failure_streak_started_ts = now
@@ -227,7 +235,7 @@ def record(
             # streak.
             delivered = False
             if notifier is not None:
-                title, body = _render_alert(state, result, threshold)
+                title, body = (render or _render_alert)(state, result, threshold)
                 try:
                     delivered = bool(notifier(title, body))
                 except Exception as exc:  # noqa: BLE001 - never crash the tick

--- a/scripts/openclaw/deploy/deploy_agent_prompts.py
+++ b/scripts/openclaw/deploy/deploy_agent_prompts.py
@@ -84,6 +84,17 @@ HEALTH_STATE_PATH_DEFAULT = Path("/data/services/openclaw/deploy/git-health.json
 HEALTH_ACTOR = "agent-prompt-sync"
 HEALTH_TOPIC_ENV = "AGENT_PROMPT_SYNC_NTFY_TOPIC"
 
+# Copy-failure health watermark (#637). A per-file copy failure (exit 1) happens
+# AFTER a successful git advance, so it never reaches the git-advance watermark
+# above — a persistent copy failure (an agent prompt silently not updating, the
+# #563 class this service exists to prevent) was unalerted. Track it on a sibling
+# watermark with its own confirmed reason + render so a copy-failure STREAK fires
+# one ntfy alert, mirroring the git-advance path. Reuses scripts.deploy.lib.health.
+COPY_HEALTH_ACTOR = "agent-prompt-sync-copy"
+COPY_FAILED_REASON = "copy_failed"
+COPY_CONFIRMED_REASONS = frozenset({COPY_FAILED_REASON})
+COPY_HEALTH_FILENAME = "copy-health.json"
+
 MD5_CHUNK_BYTES = 65536
 
 
@@ -150,6 +161,26 @@ def _health_notifier(title: str, body: str) -> bool:
         body,
         topic_env=HEALTH_TOPIC_ENV,
     )
+
+
+def _copy_render(state, result, threshold: int) -> tuple[str, str]:
+    """Render seam for the copy-failure watermark (#637) — copy-accurate wording
+    (the default health render says "git advance stalled", which is wrong here).
+    """
+    title = (
+        f"{state.actor}: prompt-copy failing "
+        f"({state.consecutive_failures}x)"
+    )
+    body = (
+        f"Actor: {state.actor}\n"
+        f"Consecutive ticks with per-file prompt-copy failures: "
+        f"{state.consecutive_failures} (threshold {threshold})\n"
+        f"Streak started: {state.failure_streak_started_ts}\n"
+        f"A deployed agent prompt is not being updated on office2 — inspect the "
+        f"agent-prompt-sync audit log (agent-prompt-sync.jsonl) for the failing "
+        f"file(s). This is the #563 silent-prompt-loss class."
+    )
+    return title, body
 
 
 # Exit codes
@@ -797,6 +828,44 @@ def _run_locked_tick(
     )
 
     exit_code = EXIT_PARTIAL_FAILURE if total_errored > 0 else EXIT_SUCCESS
+
+    # #637 — record the per-file COPY outcome on a sibling health watermark so a
+    # persistent copy failure alerts (the git-advance watermark above can't see
+    # it — the pull succeeded). Adapt the copy result onto the health-lib's
+    # AdvanceResult contract (ok=False iff a confirmed reason is set); a clean
+    # copy tick resets the streak. Best-effort: never crash the tick.
+    copy_ok = total_errored == 0
+    copy_result = AdvanceResult(
+        ok=copy_ok,
+        advanced=False,
+        pre_head=git_head,
+        post_head=git_head,
+        origin_head=git_head,
+        behind=0,
+        ahead=0,
+        diverged=False,
+        reason=None if copy_ok else COPY_FAILED_REASON,
+    )
+    try:
+        _health.record(
+            COPY_HEALTH_ACTOR,
+            copy_result,
+            state_path=health_state_path.with_name(COPY_HEALTH_FILENAME),
+            notifier=_health_notifier,
+            confirmed_reasons=COPY_CONFIRMED_REASONS,
+            render=_copy_render,
+        )
+    except Exception as exc:  # noqa: BLE001 - copy-health is escalation, never fatal
+        audit_append(
+            audit_path,
+            audit_record(
+                kind="copy_health_record_error",
+                tick_id=tick_id,
+                error=str(exc)[:200],
+                error_class=type(exc).__name__,
+            ),
+        )
+
     duration_ms = int((time.monotonic() - start) * 1000)
     audit_tick_summary(
         audit_path,

--- a/tests/openclaw/test_deploy_agent_prompts.py
+++ b/tests/openclaw/test_deploy_agent_prompts.py
@@ -13,7 +13,7 @@ import json
 import os
 import sys
 from pathlib import Path
-from unittest.mock import patch
+from unittest.mock import patch, MagicMock
 
 import pytest
 
@@ -643,6 +643,64 @@ def test_run_tick_per_file_error_exit_1(tmp_path):
     assert parsed[-1]["files_errored"] == 1
 
 
+def _copy_failure_repo(tmp_path):
+    dst_dir = tmp_path / "dst"
+    dst_dir.mkdir()
+    repo = _setup_fake_repo(tmp_path, {
+        "test-agent": {"source_in_repo": "src/", "workspace": str(dst_dir)},
+    })
+    (repo / "src").mkdir()
+    (repo / "src" / "AGENTS.md").write_bytes(b"v2")
+    (dst_dir / "AGENTS.md").write_bytes(b"v1")  # drifted → copy attempted
+    return repo
+
+
+def test_single_copy_failure_increments_copy_health_no_alert(tmp_path):
+    """#637: one per-file copy failure increments the SEPARATE copy-health
+    watermark (the git-advance one stays clean — the pull succeeded) and does not
+    alert below threshold."""
+    repo = _copy_failure_repo(tmp_path)
+    log = tmp_path / "audit.jsonl"
+    health_state = tmp_path / "git-health.json"
+    args = dap.parse_args([])
+    notifier = MagicMock(return_value=True)
+    with patch.object(dap, "_health_notifier", notifier), \
+         patch.object(dap, "atomic_copy", side_effect=OSError("disk full")), \
+         _patch_advance_success("a" * 40):
+        rc = dap.run_tick(args, repo_root=repo, audit_path=log,
+                          health_state_path=health_state)
+    assert rc == dap.EXIT_PARTIAL_FAILURE
+    copy_state = json.loads((tmp_path / dap.COPY_HEALTH_FILENAME).read_text())
+    assert copy_state["consecutive_failures"] == 1
+    git_state = json.loads(health_state.read_text())
+    assert git_state["consecutive_failures"] == 0  # git advance was clean
+    notifier.assert_not_called()  # 1 < threshold
+
+
+def test_copy_failure_streak_alerts_at_threshold(tmp_path):
+    """#637: a copy failure repeated to threshold fires exactly one copy-health
+    alert, with copy-accurate wording (not the git 'advance stalled' text)."""
+    from scripts.deploy.lib.health import DEFAULT_THRESHOLD
+
+    repo = _copy_failure_repo(tmp_path)
+    log = tmp_path / "audit.jsonl"
+    health_state = tmp_path / "git-health.json"
+    args = dap.parse_args([])
+    notifier = MagicMock(return_value=True)
+    with patch.object(dap, "_health_notifier", notifier), \
+         patch.object(dap, "atomic_copy", side_effect=OSError("disk full")):
+        for i in range(DEFAULT_THRESHOLD):
+            with _patch_advance_success(chr(ord("a") + i) * 40):
+                rc = dap.run_tick(args, repo_root=repo, audit_path=log,
+                                  health_state_path=health_state)
+            assert rc == dap.EXIT_PARTIAL_FAILURE
+    copy_state = json.loads((tmp_path / dap.COPY_HEALTH_FILENAME).read_text())
+    assert copy_state["consecutive_failures"] == DEFAULT_THRESHOLD
+    notifier.assert_called_once()  # exactly one alert per streak
+    title, _body = notifier.call_args.args
+    assert "prompt-copy failing" in title  # copy-accurate, not "git advance stalled"
+
+
 def test_run_tick_dry_run_no_mutations(tmp_path, capsys):
     """--dry-run mode: drift present, but no audit log entries, no file changes."""
     dst_dir = tmp_path / "dst"
@@ -972,16 +1030,21 @@ def test_run_tick_records_health_on_success(tmp_path):
                           health_state_path=health_state)
 
     assert rc == dap.EXIT_SUCCESS
-    rec_spy.assert_called_once()
-    call = rec_spy.call_args
-    assert call.args[0] == dap.HEALTH_ACTOR
+    # health.record is called twice now: the git advance AND the copy outcome
+    # (#637). Locate the git-advance call by actor.
+    git_calls = [c for c in rec_spy.call_args_list if c.args[0] == dap.HEALTH_ACTOR]
+    assert len(git_calls) == 1
+    call = git_calls[0]
     assert isinstance(call.args[1], AdvanceResult)
     assert call.kwargs["state_path"] == health_state
     assert call.kwargs["notifier"] is dap._health_notifier
-    # The watermark was written with a success reset.
+    # The git watermark was written with a success reset.
     state = json.loads(health_state.read_text())
     assert state["consecutive_failures"] == 0
     assert state["last_success_head"] == sha
+    # #637: a clean tick also resets the copy-health watermark (0 failures).
+    copy_state = json.loads((health_state.parent / dap.COPY_HEALTH_FILENAME).read_text())
+    assert copy_state["consecutive_failures"] == 0
 
 
 def test_run_tick_records_health_on_failure(tmp_path):


### PR DESCRIPTION
## Summary
The headline #637 (silent multi-week stall) was already covered — a **git-advance** failure streak alerts. But a **per-file copy failure** (`EXIT_PARTIAL_FAILURE`, exit 1) happens *after* a successful git advance, so it never reached that watermark: a persistent copy failure meant an agent prompt silently stopped updating on office2 (the #563 silent-prompt-loss class) with **no alert**. This closes that residual (the narrowed scope you chose).

## Change
- **`scripts/deploy/lib/health.py`**: `record` gains two backward-compatible seams — `confirmed_reasons` (which reasons count toward the streak) and `render` (title/body builder). Reuses the same streak/throttle/delivery-gated machinery for a non-git watermark without duplication. **felix-deployer + the git path untouched** (defaults).
- **`deploy_agent_prompts.py`**: after the copy loop, record the copy outcome on a **sibling `copy-health.json`** watermark with a copy-accurate render, so a copy-failure streak fires one ntfy alert. Clean tick resets it. Best-effort — never crashes the tick.

## Tests
Single copy failure increments copy-health (no alert below threshold) + git-health stays clean; a streak to threshold fires exactly one alert with "prompt-copy failing" wording; existing health test updated for the second record call. **114 health + 31 prompt-sync/copy tests pass.**

**Deploy:** checkout self-pull. **Rebaseline:** not required.

Closes #637