### PR TITLE
feat(#736): date-only due-date migration helper (dry-run default; apply reviewed separately)

### DIFF
--- a/scripts/vikunja/migrate_date_only_due_dates.py
+++ b/scripts/vikunja/migrate_date_only_due_dates.py
@@ -1,0 +1,216 @@
+#!/usr/bin/env python3
+"""One-time migration: normalize date-only Vikunja due-dates to end-of-day ET (#736).
+
+Vikunja stores every ``due_date`` as a UTC instant. A **date-only** pick (the
+user chose a date, no time) is stored as midnight in some timezone —
+``<date>T00:00:00Z`` (UTC midnight) or ``<date>T04:00:00Z`` / ``<date>T05:00:00Z``
+(ET midnight, EDT/EST). The escalation read-side converts the stored instant to
+an **America/New_York calendar date**, so a midnight-UTC value reads as the
+*prior* ET day: a task "due June 15" stored ``2026-06-15T00:00:00Z`` reads as
+June 14 and escalates a day early (#736).
+
+Felix's own reschedule/intake writes already use end-of-day ET (which round-trips
+correctly). This migrates the **legacy / UI-set** date-only values to the same
+convention so every due-date reads back on its intended day.
+
+Key insight: for a date-only value the intended calendar date IS the value's
+**date component** (the UI stores ``<intended-date>T<midnight-in-its-tz>``), so we
+rewrite it to end-of-day ET of that date via
+:func:`scripts.common.et_datetime.et_end_of_day`. Genuine datetimes (a real time
+of day) and values already at EOD-ET are left untouched — the migration is
+**idempotent** (a re-run is a no-op).
+
+Dry-run by default; ``--apply`` executes. Writes go through the **kent token**
+(``vikunja-api-kent``) via an allowlisted read-modify-write with an instant-based
+readback check (Vikunja normalizes due_date to UTC ``Z``, so a string compare
+false-fails, #757). Mirrors ``scripts/vikunja/migrate_tasks.py``.
+"""
+from __future__ import annotations
+
+import argparse
+import sys
+from typing import Any, Optional
+
+from scripts.common import et_datetime
+from scripts.common.vikunja_client import VikunjaClient, VikunjaError
+from scripts.common.vikunja_config import get_vikunja_base_url
+from scripts.vikunja.migrate_tasks import (
+    DEFAULT_KENT_TOKEN_FILE,
+    _WRITABLE_FIELDS,
+    _read_token_file,
+    _writable_payload,
+    list_all_tasks,
+)
+
+#: Vikunja's "no due date" sentinel prefix (year-1).
+_UNSET_DUE_PREFIX = "0001-01-01"
+
+
+class MigrationError(Exception):
+    """Fail-loud migration error (readback mismatch, Vikunja error)."""
+
+
+def _is_date_only(due_str: str) -> bool:
+    """True iff the due-date is a date-only pick (midnight in UTC or Eastern).
+
+    A calendar-date pick has no time-of-day and is stored as midnight in some
+    timezone; a genuine timed event has a non-midnight time and is left alone.
+    """
+    instant = et_datetime.parse_vikunja_instant(due_str)  # aware UTC | None
+    if instant is None:
+        return False
+    if instant.hour == 0 and instant.minute == 0 and instant.second == 0:
+        return True  # midnight UTC (e.g. T00:00:00Z)
+    et = et_datetime.to_et(instant)
+    return et.hour == 0 and et.minute == 0 and et.second == 0  # midnight ET
+
+
+def plan_migration(tasks: list[dict]) -> list[dict]:
+    """Return planned changes for date-only due-dates.
+
+    Each entry: ``{task_id, title, old_due, new_due}``. Skips tasks with no due,
+    the unset sentinel, genuine datetimes, un-normalizable dates, and values
+    already equal to the EOD-ET target (idempotent).
+    """
+    plan: list[dict] = []
+    for task in tasks:
+        due = task.get("due_date")
+        if (
+            not isinstance(due, str)
+            or not due
+            or due.startswith(_UNSET_DUE_PREFIX)
+        ):
+            continue
+        if not _is_date_only(due):
+            continue
+        # Intended calendar date = the value's date component (the UI stores
+        # <intended-date>T<midnight-in-its-tz>). Normalize to EOD-ET of that date.
+        try:
+            new_due = et_datetime.et_end_of_day(due[:10])
+        except ValueError:
+            continue  # non-standard / pre-modern date — never a real due date
+        # Idempotent: same instant → nothing to do.
+        if et_datetime.parse_vikunja_instant(due) == et_datetime.parse_vikunja_instant(new_due):
+            continue
+        plan.append(
+            {
+                "task_id": task["id"],
+                "title": task.get("title", ""),
+                "old_due": due,
+                "new_due": new_due,
+            }
+        )
+    return plan
+
+
+def apply_change(client: Any, task: dict, new_due: str) -> None:
+    """RMW the task's ``due_date`` to *new_due*; readback-verify the INSTANT.
+
+    Echoes the writable-field allowlist so Vikunja's partial-replace can't zero
+    an unstated field (#524), then compares the readback due_date by *instant*
+    (Vikunja returns it as UTC ``Z``, so a string compare of our ET-offset write
+    false-fails, #757). Other allowlisted fields must be byte-unchanged.
+    """
+    task_id = task["id"]
+    payload = _writable_payload(task)
+    payload["due_date"] = new_due
+    client.post(f"/tasks/{task_id}", json=payload)
+
+    readback = client.get(f"/tasks/{task_id}")
+    if not isinstance(readback, dict):
+        raise MigrationError(f"task {task_id}: readback returned a non-object")
+    if et_datetime.parse_vikunja_instant(
+        readback.get("due_date")
+    ) != et_datetime.parse_vikunja_instant(new_due):
+        raise MigrationError(
+            f"task {task_id}: due_date readback instant is "
+            f"{readback.get('due_date')!r}, expected {new_due!r}"
+        )
+    for name in _WRITABLE_FIELDS:
+        if name == "due_date":
+            continue
+        if name in payload and readback.get(name) != payload[name]:
+            raise MigrationError(
+                f"task {task_id}: field {name!r} drifted from {payload[name]!r} "
+                f"to {readback.get(name)!r} (partial-replace, #524)"
+            )
+
+
+def _print_plan(plan: list[dict]) -> None:
+    for change in plan:
+        title = str(change["title"])[:50]
+        print(
+            f"  task {change['task_id']}: {title!r}\n"
+            f"      {change['old_due']}  ->  {change['new_due']}"
+        )
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    p = argparse.ArgumentParser(
+        prog="migrate_date_only_due_dates",
+        description=(
+            "Normalize legacy/UI date-only Vikunja due-dates to end-of-day ET "
+            "(#736). Dry-run by default; --apply writes."
+        ),
+    )
+    p.add_argument(
+        "--apply",
+        action="store_true",
+        help="Execute the writes (default is a read-only dry-run).",
+    )
+    p.add_argument(
+        "--token-file",
+        default=DEFAULT_KENT_TOKEN_FILE,
+        help=f"Kent-token file (default {DEFAULT_KENT_TOKEN_FILE}).",
+    )
+    p.add_argument(
+        "--base-url",
+        default=None,
+        help="Vikunja base URL (default: config-resolved).",
+    )
+    return p
+
+
+def main(argv: Optional[list[str]] = None, *, client: Any | None = None) -> int:
+    args = _build_parser().parse_args(argv)
+
+    if client is None:
+        token = _read_token_file(args.token_file)
+        base_url = args.base_url or get_vikunja_base_url()
+        client = VikunjaClient(base_url=base_url, token=token)
+
+    try:
+        tasks = list_all_tasks(client)
+    except VikunjaError as exc:
+        print(f"error: could not list tasks: {exc}", file=sys.stderr)
+        return 1
+
+    plan = plan_migration(tasks)
+    _print_plan(plan)
+    mode = "APPLY" if args.apply else "DRY-RUN"
+    print(
+        f"{mode}: {len(plan)} date-only due-date(s) to normalize to end-of-day ET "
+        f"(of {len(tasks)} tasks scanned)"
+    )
+
+    if not args.apply:
+        print("(dry-run — no changes written; re-run with --apply)")
+        return 0
+
+    by_id = {t["id"]: t for t in tasks}
+    applied = 0
+    try:
+        for change in plan:
+            apply_change(client, by_id[change["task_id"]], change["new_due"])
+            applied += 1
+    except (MigrationError, VikunjaError) as exc:
+        print(
+            f"error after {applied} applied: {exc}", file=sys.stderr
+        )
+        return 1
+    print(f"applied={applied}")
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover
+    sys.exit(main())

--- a/tests/vikunja/test_migrate_date_only_due_dates.py
+++ b/tests/vikunja/test_migrate_date_only_due_dates.py
@@ -1,0 +1,159 @@
+"""Tests for the date-only due-date migration (#736).
+
+The migration normalizes legacy/UI date-only Vikunja due-dates (midnight in some
+tz) to end-of-day ET. These pin the classification (what counts as date-only vs a
+genuine datetime), the idempotence (already-EOD-ET values are skipped), and the
+apply path's instant-based readback (Vikunja returns due_date as UTC ``Z``, so a
+string compare of the ET-offset write would false-fail — #757).
+"""
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+import pytest
+
+from scripts.vikunja import migrate_date_only_due_dates as m
+
+
+# ---------------------------------------------------------------------------
+# Normalizing mock — mimics live Vikunja: a POST stores the due_date re-serialized
+# to UTC 'Z', so the apply readback exercises the instant-compare (#757), not a
+# string compare that would false-fail on the ET-offset write.
+# ---------------------------------------------------------------------------
+
+
+class _NormalizingVikunja:
+    def __init__(self, tasks: list[dict]):
+        self.tasks = {t["id"]: dict(t) for t in tasks}
+        self.posts: list[tuple[int, dict]] = []
+
+    def _pages(self):
+        return list(self.tasks.values())
+
+    def get(self, path, **_):
+        if path == "/tasks/all":
+            return self._pages()
+        tid = int(path.rsplit("/", 1)[1])
+        return dict(self.tasks[tid])
+
+    def post(self, path, *, json=None, **_):
+        tid = int(path.rsplit("/", 1)[1])
+        payload = dict(json or {})
+        due = payload.get("due_date")
+        if isinstance(due, str) and due and not due.startswith("0001-01-01"):
+            inst = datetime.fromisoformat(due.replace("Z", "+00:00")).astimezone(
+                timezone.utc
+            )
+            payload["due_date"] = inst.strftime("%Y-%m-%dT%H:%M:%SZ")
+        self.tasks[tid].update(payload)
+        self.posts.append((tid, payload))
+        return dict(self.tasks[tid])
+
+
+def _task(tid, due, title="T"):
+    return {"id": tid, "title": title, "due_date": due, "project_id": 1}
+
+
+# ---------------------------------------------------------------------------
+# plan_migration — classification
+# ---------------------------------------------------------------------------
+
+
+def test_plan_normalizes_midnight_utc():
+    plan = m.plan_migration([_task(1, "2026-06-15T00:00:00Z")])
+    assert len(plan) == 1
+    assert plan[0]["new_due"] == "2026-06-15T23:59:59-04:00"
+
+
+def test_plan_normalizes_midnight_edt():
+    # 04:00Z = midnight EDT June 15 → same intended date, same EOD-ET target.
+    plan = m.plan_migration([_task(1, "2026-06-15T04:00:00Z")])
+    assert len(plan) == 1
+    assert plan[0]["new_due"] == "2026-06-15T23:59:59-04:00"
+
+
+def test_plan_normalizes_midnight_est():
+    # 05:00Z = midnight EST Jan 15 → EOD-ET Jan 15 (winter offset -05:00).
+    plan = m.plan_migration([_task(1, "2026-01-15T05:00:00Z")])
+    assert len(plan) == 1
+    assert plan[0]["new_due"] == "2026-01-15T23:59:59-05:00"
+
+
+def test_plan_skips_genuine_datetime():
+    # A real time-of-day (11:30) is a timed event — left untouched.
+    assert m.plan_migration([_task(1, "2026-06-15T11:30:00Z")]) == []
+
+
+def test_plan_idempotent_on_already_eod_et():
+    # An already-normalized EOD-ET value is not midnight → skipped.
+    assert m.plan_migration([_task(1, "2026-06-15T23:59:59-04:00")]) == []
+
+
+def test_plan_skips_no_due_and_sentinel():
+    tasks = [
+        _task(1, None),
+        _task(2, ""),
+        _task(3, "0001-01-01T00:00:00Z"),
+    ]
+    assert m.plan_migration(tasks) == []
+
+
+def test_plan_reports_id_title_and_old_due():
+    plan = m.plan_migration([_task(7, "2026-06-15T00:00:00Z", title="Pay rent")])
+    assert plan[0]["task_id"] == 7
+    assert plan[0]["title"] == "Pay rent"
+    assert plan[0]["old_due"] == "2026-06-15T00:00:00Z"
+
+
+# ---------------------------------------------------------------------------
+# apply_change — RMW + instant readback
+# ---------------------------------------------------------------------------
+
+
+def test_apply_writes_eod_et_and_readback_passes():
+    client = _NormalizingVikunja([_task(1, "2026-06-15T00:00:00Z")])
+    task = client.get("/tasks/1")
+    m.apply_change(client, task, "2026-06-15T23:59:59-04:00")
+    # Stored as UTC-Z by the normalizing mock; the same instant as our write.
+    assert client.tasks[1]["due_date"] == "2026-06-16T03:59:59Z"
+
+
+def test_apply_readback_detects_other_field_drift():
+    class _DriftingVikunja(_NormalizingVikunja):
+        def get(self, path, **kw):
+            r = super().get(path, **kw)
+            if path != "/tasks/all":
+                r["title"] = "CHANGED"  # simulate a partial-replace zeroing
+            return r
+
+    client = _DriftingVikunja([_task(1, "2026-06-15T00:00:00Z", title="Keep")])
+    task = {"id": 1, "title": "Keep", "due_date": "2026-06-15T00:00:00Z", "project_id": 1}
+    with pytest.raises(m.MigrationError, match="drifted"):
+        m.apply_change(client, task, "2026-06-15T23:59:59-04:00")
+
+
+# ---------------------------------------------------------------------------
+# main — dry-run vs apply
+# ---------------------------------------------------------------------------
+
+
+def test_main_dry_run_writes_nothing(capsys):
+    client = _NormalizingVikunja(
+        [_task(1, "2026-06-15T00:00:00Z"), _task(2, "2026-06-15T11:30:00Z")]
+    )
+    rc = m.main([], client=client)
+    assert rc == 0
+    assert client.posts == []  # no writes on dry-run
+    out = capsys.readouterr().out
+    assert "DRY-RUN: 1 date-only" in out
+
+
+def test_main_apply_normalizes(capsys):
+    client = _NormalizingVikunja(
+        [_task(1, "2026-06-15T00:00:00Z"), _task(2, "2026-06-15T11:30:00Z")]
+    )
+    rc = m.main(["--apply"], client=client)
+    assert rc == 0
+    assert len(client.posts) == 1  # only the date-only task written
+    assert client.posts[0][0] == 1
+    assert capsys.readouterr().out.strip().endswith("applied=1")


### PR DESCRIPTION
## Summary
The one-time migration for #736 (you chose **(b) normalize**). Vikunja stores due_dates as UTC instants; a **date-only** pick lands as midnight in some tz (`T00:00:00Z` UTC, or `T04/05:00:00Z` ET), and the escalation read-side reads a midnight-UTC value as the **prior** ET day → "due June 15" reads as June 14 and escalates a day early. Felix's own writes already use EOD-ET; this brings the legacy/UI values to the same convention.

For a date-only value the intended date **is** the value's date component (the UI stores `<intended-date>T<midnight-in-its-tz>`), so it rewrites to `et_end_of_day(date-component)`. Genuine datetimes and already-EOD-ET values are untouched (**idempotent**). Writes use the kent token via an allowlisted RMW with an **instant-based** readback (#757).

## This PR merges the helper ONLY — it does NOT run `--apply`
Dry-run is the default. The plan is: merge → deploy → **run the live dry-run, review the exact planned changes with you** → confirm a fresh Restic backup → `--apply` → verify → close #736.

## Tests
11 — classification (midnight UTC/EDT/EST → EOD-ET; genuine datetime + already-EOD-ET skipped; no-due/sentinel skipped), instant-readback via a normalizing mock, other-field-drift fail-loud, dry-run writes nothing, apply writes only date-only tasks. Full vikunja suite (359) green.

**Rebaseline:** not required (helper only, self-pull deploy).

Refs #736 (closed after apply + verify)