### PR TITLE
fix(#779): drift-check treats repo==office2 as NO_CHANGE (stop false CONFLICT on prompt deploys)

### DIFF
--- a/scripts/openclaw/enforcement/detection.py
+++ b/scripts/openclaw/enforcement/detection.py
@@ -43,6 +43,14 @@ def classify_drift(
 
     Compares current hashes on both sides against their respective baselines
     to determine which side(s) changed since the last reconciliation.
+
+    #779: repo and office2 **agreeing** is the deployed-correctly state — it is
+    NOT drift, regardless of the (possibly stale) baseline. When both sides move
+    to the same new value via a legitimate deploy (e.g. an agent-prompt-sync of an
+    edited prompt), an un-regenerated manifest baseline would otherwise classify
+    it CONFLICT (both differ from baseline) and false-alarm. So a repo==office2
+    match short-circuits to NO_CHANGE; the baseline is consulted only to attribute
+    DIRECTION when the two sides genuinely diverge.
     """
     if current_repo is None and current_office2 is None:
         return DriftState.FILE_MISSING_REPO  # Both missing is unusual
@@ -52,6 +60,12 @@ def classify_drift(
 
     if current_office2 is None:
         return DriftState.FILE_MISSING_OFFICE2
+
+    # A repo↔office2 match is definitionally not drift (they agree = deployed
+    # correctly), regardless of the baseline. This removes the false CONFLICT on
+    # every legitimate prompt deploy (#779).
+    if current_repo == current_office2:
+        return DriftState.NO_CHANGE
 
     repo_changed = current_repo != baseline_repo
     office2_changed = current_office2 != baseline_office2

--- a/tests/openclaw/enforcement/test_detection.py
+++ b/tests/openclaw/enforcement/test_detection.py
@@ -38,14 +38,21 @@ class TestClassifyDrift:
         """Both missing — treated as file_missing_repo."""
         assert classify_drift(None, None, "aaa", "aaa") == DriftState.FILE_MISSING_REPO
 
-    def test_no_baseline_both_present(self):
-        """No baseline hashes (new file on both sides) → both changed from None."""
-        assert classify_drift("aaa", "aaa", None, None) == DriftState.CONFLICT
+    def test_repo_office2_match_is_no_change_regardless_of_baseline(self):
+        """#779: repo == office2 is the deployed-correctly state → NO_CHANGE, even
+        with no/stale baseline (a legit prompt deploy moves both sides to the same
+        new value; that must NOT false-alarm CONFLICT)."""
+        assert classify_drift("aaa", "aaa", None, None) == DriftState.NO_CHANGE
+        # Same match, but the baseline holds an older agreed value (the stale case).
+        assert classify_drift("new", "new", "old", "old") == DriftState.NO_CHANGE
 
-    def test_no_baseline_same_hash(self):
-        """Both sides have same hash but baseline is None → both changed."""
-        result = classify_drift("same", "same", None, None)
-        assert result == DriftState.CONFLICT
+    def test_divergence_still_classified_by_baseline(self):
+        """#779: when the two sides genuinely diverge, the baseline still attributes
+        direction (this is the only case the baseline is consulted)."""
+        # repo moved off the agreed baseline, office2 hasn't → repo changed.
+        assert classify_drift("new", "old", "old", "old") == DriftState.REPO_CHANGED
+        # office2 hand-edited off the agreed baseline, repo hasn't → office2 changed.
+        assert classify_drift("old", "hand", "old", "old") == DriftState.OFFICE2_CHANGED
 
 
 class TestIsFactoryDefault:


### PR DESCRIPTION
## Summary
Now that the drift-check cron runs (#766), every legitimate agent-prompt deploy false-alarmed **CONFLICT**: `classify_drift` compared each side to the manifest baseline, so a prompt edit deploying to both sides made both differ from the (un-regenerated) baseline → CONFLICT, even though repo and office2 **agreed**. The workaround was regenerating the manifest after every prompt PR (as #763 had to).

## Fix (option 2 — smallest + most correct)
A repo↔office2 match is **definitionally not drift**. `classify_drift` short-circuits `current_repo == current_office2` → `NO_CHANGE`, regardless of baseline. The baseline is consulted only to attribute **direction** when the two sides genuinely diverge. No more manifest regen on prompt deploys.

## Tests
repo==office2 → NO_CHANGE even with no/stale baseline (the false-alarm cases, now correct); genuine divergence still attributed by baseline. Two tests that encoded the old false-alarm updated. **65 enforcement tests pass.**

**Deploy:** self-pull. **Rebaseline:** not required.

Closes #779