### PR TITLE
feat(#780): all-day calendar event support (item 1) + #739 whole-day completion

### DIFF
--- a/scripts/calendar_routing/validate_calendar_event.py
+++ b/scripts/calendar_routing/validate_calendar_event.py
@@ -598,15 +598,25 @@ def validate(block: dict) -> dict:
         "calendar_id": DEFAULT_CALENDAR_ID,
         "account": DEFAULT_ACCOUNT,
         "summary": title,
-        "start_rfc3339": _rfc3339(start_dt),
-        "end_rfc3339": _rfc3339(end_dt),
-        "start_timezone": DEFAULT_TIMEZONE,
         "location": block.get("location"),
         "description": description,
         "rrule": rrule,
         "attendees": block.get("attendees"),
         "source_inbox_path": source_inbox_path,
     }
+    # #780: a whole-day, time-less event is a TRUE all-day event — emit the
+    # date-based (`start_date`/`end_date`) form so the calendar helper creates a
+    # Google all-day event, not a midnight-to-midnight timed one. Google's all-day
+    # end is exclusive, which `end_dt` (start + whole-day duration → next midnight)
+    # already satisfies: its calendar date is the exclusive end. Otherwise emit the
+    # timed (`start_rfc3339`) form.
+    if _is_all_day_duration(duration) and _parse_time_component(start_natural) is None:
+        payload["start_date"] = start_dt.date().isoformat()
+        payload["end_date"] = end_dt.date().isoformat()
+    else:
+        payload["start_rfc3339"] = _rfc3339(start_dt)
+        payload["end_rfc3339"] = _rfc3339(end_dt)
+        payload["start_timezone"] = DEFAULT_TIMEZONE
     return {
         "complete": True,
         "missing_fields": [],

--- a/scripts/calendar_routing/validate_calendar_event.py
+++ b/scripts/calendar_routing/validate_calendar_event.py
@@ -607,9 +607,11 @@ def validate(block: dict) -> dict:
     # #780: a whole-day, time-less event is a TRUE all-day event — emit the
     # date-based (`start_date`/`end_date`) form so the calendar helper creates a
     # Google all-day event, not a midnight-to-midnight timed one. Google's all-day
-    # end is exclusive, which `end_dt` (start + whole-day duration → next midnight)
-    # already satisfies: its calendar date is the exclusive end. Otherwise emit the
-    # timed (`start_rfc3339`) form.
+    # end is exclusive; we take `end_dt`'s calendar date directly. For the common
+    # case `end_dt` is start + a whole-day duration (its date is the exclusive end);
+    # if the block instead carried an explicit end (which takes precedence above),
+    # that end's date is used verbatim — also treated as exclusive. Otherwise emit
+    # the timed (`start_rfc3339`) form.
     if _is_all_day_duration(duration) and _parse_time_component(start_natural) is None:
         payload["start_date"] = start_dt.date().isoformat()
         payload["end_date"] = end_dt.date().isoformat()

--- a/scripts/google/calendar_helper.py
+++ b/scripts/google/calendar_helper.py
@@ -179,6 +179,17 @@ def _time_field(value: str, timezone: str | None) -> dict[str, str]:
     return field
 
 
+def _all_day_field(date_str: str) -> dict[str, str]:
+    """Build a Google all-day ``{date}`` object from a ``YYYY-MM-DD`` string (#780).
+
+    Google represents an all-day event with ``start.date`` / ``end.date`` (a bare
+    calendar date, no time or zone) instead of ``start.dateTime``. The end date is
+    **exclusive**, so a single all-day event on 2026-06-15 is
+    ``start.date=2026-06-15``, ``end.date=2026-06-16``.
+    """
+    return {"date": date_str}
+
+
 def _parse_attendees(raw: str | list[str] | None) -> list[dict[str, str]]:
     """Normalize a comma list or list of emails to ``[{"email": …}]``."""
     if not raw:
@@ -201,19 +212,24 @@ def _build_event_body(
     rrule: str | None,
     attendees: list[dict[str, str]] | None,
     idempotency_key: str | None,
+    all_day: bool = False,
 ) -> dict[str, Any]:
     """Map explicit/envelope fields to a Google Calendar event request body.
 
     Only provided fields are included, so this is reusable for both ``create``
     (full body) and ``update`` (patch — the caller supplies only changed fields).
+
+    When ``all_day`` is set, ``start``/``end`` are ``YYYY-MM-DD`` dates and the
+    body uses Google's all-day ``{date}`` form (no time/zone, exclusive end),
+    #780.
     """
     body: dict[str, Any] = {}
     if summary is not None:
         body["summary"] = summary
     if start is not None:
-        body["start"] = _time_field(start, start_timezone)
+        body["start"] = _all_day_field(start) if all_day else _time_field(start, start_timezone)
     if end is not None:
-        body["end"] = _time_field(end, start_timezone)
+        body["end"] = _all_day_field(end) if all_day else _time_field(end, start_timezone)
     if location is not None:
         body["location"] = location
     if description is not None:
@@ -261,15 +277,23 @@ def _create_fields_from_payload(
             "payload declares attendees; refusing to send invitations from the "
             "inbox path without --allow-attendees"
         )
+    # All-day mode (#780): a payload with `start_date` (YYYY-MM-DD) is an all-day
+    # event; it uses Google's {date} form. `start_rfc3339` is the timed form.
+    all_day = payload.get("start_date") is not None
+    if all_day:
+        start, end = payload.get("start_date"), payload.get("end_date")
+    else:
+        start, end = payload.get("start_rfc3339"), payload.get("end_rfc3339")
     return {
         "summary": payload.get("summary"),
-        "start": payload.get("start_rfc3339"),
-        "end": payload.get("end_rfc3339"),
+        "start": start,
+        "end": end,
         "start_timezone": payload.get("start_timezone"),
         "location": payload.get("location"),
         "description": payload.get("description"),
         "rrule": payload.get("rrule"),
         "attendees": _parse_attendees(attendees_raw) if allow_attendees else [],
+        "all_day": all_day,
     }
 
 
@@ -356,6 +380,7 @@ def _cmd_create(service: Any, args: argparse.Namespace) -> int:
         rrule=fields.get("rrule"),
         attendees=fields.get("attendees"),
         idempotency_key=key,
+        all_day=fields.get("all_day", False),
     )
 
     if args.dry_run:

--- a/tests/calendar/test_validate_calendar_event.py
+++ b/tests/calendar/test_validate_calendar_event.py
@@ -306,6 +306,43 @@ def test_all_day_event_date_only() -> None:
     assert "end_rfc3339" not in payload
 
 
+def test_all_day_event_multi_day_exclusive_end() -> None:
+    """A multi-day all-day event: the exclusive end date is start + N days (#780).
+    Guards the off-by-one that a 1-day case cannot catch."""
+    block = {
+        "title": "Conference",
+        "start_natural": "June 14, 2026",
+        "duration_natural": "3 days",
+        "source_inbox_path": "/tmp/Inbox 2026-06-07 1000.md",
+        "source_block_index": 0,
+        "tick_iso": "2026-06-07T10:00:00-04:00",
+    }
+    result = vce.validate(block)
+    assert result["complete"] is True
+    payload = result["calendar_event_payload"]
+    assert payload["start_date"] == "2026-06-14"
+    assert payload["end_date"] == "2026-06-17"  # 3-day span, exclusive end
+    assert "start_rfc3339" not in payload
+
+
+def test_explicit_time_with_whole_day_duration_stays_timed() -> None:
+    """An explicit time PLUS a whole-day duration is a TIMED event, not all-day
+    (#780): the all-day branch must not swallow it — it keeps start_rfc3339."""
+    block = {
+        "title": "Move-out walkthrough",
+        "start_natural": "June 14, 2026 at 3pm",
+        "duration_natural": "1 day",
+        "source_inbox_path": "/tmp/Inbox 2026-06-07 1000.md",
+        "source_block_index": 0,
+        "tick_iso": "2026-06-07T10:00:00-04:00",
+    }
+    result = vce.validate(block)
+    assert result["complete"] is True
+    payload = result["calendar_event_payload"]
+    assert payload["start_rfc3339"].startswith("2026-06-14T15:00:00")
+    assert "start_date" not in payload
+
+
 # --- #739 time-of-day policy: timed appointment with no time → clarify --------
 
 

--- a/tests/calendar/test_validate_calendar_event.py
+++ b/tests/calendar/test_validate_calendar_event.py
@@ -285,7 +285,10 @@ def test_end_takes_precedence_over_duration_when_both_present() -> None:
 
 
 def test_all_day_event_date_only() -> None:
-    """start_natural is a date-only string → defaults to 00:00; end uses 1-day default."""
+    """A date-only start with a whole-day duration is a TRUE all-day event (#780):
+    the payload uses Google's date form (``start_date``/``end_date``, exclusive
+    end) — NOT a midnight ``start_rfc3339`` — so the calendar helper creates a
+    real all-day event, not a midnight-to-midnight timed one."""
     block = {
         "title": "Anniversary",
         "start_natural": "June 14, 2026",
@@ -296,7 +299,11 @@ def test_all_day_event_date_only() -> None:
     }
     result = vce.validate(block)
     assert result["complete"] is True
-    assert result["calendar_event_payload"]["start_rfc3339"].startswith("2026-06-14T00:00:00")
+    payload = result["calendar_event_payload"]
+    assert payload["start_date"] == "2026-06-14"
+    assert payload["end_date"] == "2026-06-15"  # Google all-day end is exclusive
+    assert "start_rfc3339" not in payload
+    assert "end_rfc3339" not in payload
 
 
 # --- #739 time-of-day policy: timed appointment with no time → clarify --------

--- a/tests/google/test_calendar_helper.py
+++ b/tests/google/test_calendar_helper.py
@@ -283,6 +283,34 @@ def test_create_payload_file_mode(helper, recorder, capsys, tmp_path: Path):
     assert _last_line(capsys).startswith("SUMMARY:")
 
 
+def test_create_payload_all_day_uses_date_form(helper, recorder, capsys, tmp_path: Path):
+    """#780: a payload with ``start_date`` creates a Google all-day event —
+    ``start.date``/``end.date`` (bare dates, exclusive end), never ``dateTime``."""
+    payload = {
+        "action": "create_calendar_event",
+        "calendar_id": "primary",
+        "account": "personal",
+        "summary": "Conference",
+        "start_date": "2026-06-15",
+        "end_date": "2026-06-16",
+        "location": None,
+        "description": "Source: note-9.md",
+        "rrule": None,
+        "attendees": None,
+        "source_inbox_path": "/x/note-9.md",
+    }
+    pf = tmp_path / "payload.json"
+    pf.write_text(json.dumps(payload))
+    recorder.outcomes["insert"] = {"id": "evtA", "htmlLink": "L"}
+    code = run(helper, ["create", "--payload-file", str(pf), "--json"])
+    assert code == 0
+    body = recorder.calls_for("insert")[0]["body"]
+    assert body["start"] == {"date": "2026-06-15"}
+    assert body["end"] == {"date": "2026-06-16"}
+    assert "dateTime" not in body["start"]
+    assert "dateTime" not in body["end"]
+
+
 def test_create_payload_attendees_rejected_without_flag(
     helper, recorder, capsys, tmp_path: Path
 ):


### PR DESCRIPTION
Delivers **#780 item 1** (all-day event support in the calendar helper) and, on top of it, completes the **#739 all-day case**: a whole-day, time-less inbox event now creates a genuine Google all-day event instead of a midnight-to-midnight timed one.

## What ships
1. **`validate_calendar_event`** — a whole-day duration with no explicit time now emits the date-based payload (`start_date`/`end_date`, exclusive end) instead of a midnight `start_rfc3339`. Timed events (explicit time, partial duration) are unchanged.
2. **`calendar_helper`** — `_all_day_field` builds Google's `{date}` object; `_build_event_body` gains an `all_day` flag; the payload path detects `start_date` and threads `all_day` through so `create` uses `start.date`/`end.date`, never `start.dateTime`. Explicit-flag CLI create and `update` are byte-identical (default `all_day=False`).

## Review
reviewer-renata (Opus) adversarial pass — no correctness defect (exclusive-end math incl. multi-day + DST, all-day/timed classification, producer/consumer key contract, idempotency, dry-run, `all_day=False` default all verified). Applied her F1 (multi-day + timed-with-whole-day-duration regression tests) and F2 (comment accuracy). **F3** — neither the timed nor the date path validates `end > start` (pre-existing; Google rejects) — noted as a backlog follow-up, out of scope here.

## Not closing #780
This is **item 1** only. Items 2+3 — the age-out fallback (an unanswered start-time clarification ages out into an all-day event from the pending record's `partial_payload`, gated to start-time-only) — remain; #780 stays open, scoped to that. A concrete spec for it will be posted on #780.

## Gate
`make test` green (5646 passed, 42 skipped); doc/privacy/architecture validators pass.

Rebaseline: not required — no audited surface touched (Python + tests only).