### PR TITLE
feat(#777): felix-dev-autopilot — autonomous fix-run agent + operating contract

### DIFF
--- a/.agents/autopilot/README.md
+++ b/.agents/autopilot/README.md
@@ -1,0 +1,47 @@
+# felix-dev-autopilot
+
+A formal, invokable agent that runs an autonomous fix-run end-to-end — pick
+issue → scope → implement → test → review → PR → CI-gate → merge → deploy →
+live-verify → next — keeping a running report and surfacing genuine decisions.
+It captures the rules and guardrails from the 2026-07-18 overnight run
+(reference execution) so the pattern is re-runnable on demand without
+re-deriving them each time. See #777.
+
+## Files
+
+| File | Role |
+|---|---|
+| `felix-dev-autopilot-contract.md` | **Canonical, repo-agnostic operating contract** — the single source of truth. Prioritization, scope decision, standard vehicle, gate discipline, when-stuck, risk posture, reporting, backlog-hygiene, and the invocation input contract. |
+| `adapters/<repo>.md` | **Per-repo mechanics** — gate command, deploy motion, live-verify, rebaseline rule, change-control tiers. The contract loads the adapter for the target `repo`. |
+| `adapters/kg-automation.md` | The kg-automation (Felix / office2) adapter. |
+| `adapters/_template.md` | Template for adding a new repo's adapter — makes "repo as a parameter" real. |
+
+## How it is invoked
+
+- **Global agent profile:** `~/.claude/agents/felix-dev-autopilot.md` (thin —
+  points at this contract) makes it spawnable in any repo.
+- **Slash command:** `~/.claude/commands/felix-dev-autopilot.md` →
+  `/felix-dev-autopilot` with `repo` / `queue` / `risk_posture` args.
+
+Both reference this contract rather than duplicating it — edit the rules HERE.
+
+## Cross-repo
+
+The contract is repo-agnostic; the packaging (global profile + slash command)
+loads it and the target repo's adapter by absolute path — the same precedent as
+the cross-repo standing rules (`.agents/rules/cross-repo-standing-rules.md`,
+`@`-imported into the global CLAUDE.md). To run autopilot in a new repo, add an
+adapter from `_template.md`; no change to the contract or packaging is needed.
+
+## Input contract (recap)
+
+Operator supplies at invocation: **`repo`** (→ loads its adapter), **`queue`**
+(ordered issues; if omitted the agent proposes one and confirms), and
+**`risk_posture`** (deploy tolerance + stop condition + any extra off-limits).
+The agent restates the resolved envelope before the first fix.
+
+## Reference execution
+
+2026-07-18 overnight run on kg-automation — 10 fixes + 3 backlog closes shipped,
+merged, deployed, and live-verified in ~3h with zero regressions; see this
+repo's merge history around that date (e.g. PRs in the #762–#786 range).

--- a/.agents/autopilot/adapters/_template.md
+++ b/.agents/autopilot/adapters/_template.md
@@ -1,0 +1,40 @@
+# Autopilot Adapter — <REPO NAME> (template)
+
+Copy this to `<repo-slug>.md` and fill in the repo-specific mechanics. The
+repo-agnostic rules live in `../felix-dev-autopilot-contract.md`; an adapter
+supplies ONLY what differs per repo. If a section does not apply to the repo,
+say so explicitly ("N/A — no deploy target") rather than deleting it, so the
+agent knows the answer is "nothing," not "unspecified."
+
+## Queue source
+- Where the backlog lives (issue tracker / repo + org) and the candidate query.
+- Any spec-readiness gate before work starts.
+
+## Gate (must all pass before merge — never merge red)
+- The exact test command(s).
+- Any doc/data/lint validators run pre-commit and in CI.
+- The CI check names to wait on.
+
+## Adversarial review
+- Which reviewer (reviewer-renata Opus / Codex / other) and any caveats.
+
+## Deploy motion
+- How merged code reaches its running target (self-pull, sync service, package
+  publish, CI deploy, none). Distinguish change types if they deploy differently.
+
+## Live-verify
+- How to confirm the change is live and behaving on the deployed target.
+
+## Rebaseline / security-baseline rule
+- Whether the repo has an audited-surface baseline and when to reset it. N/A if none.
+
+## Change-control tiers / off-limits
+- The repo's risk taxonomy (if any) and what is off-limits autonomously.
+- Note: Tier-0-style host changes are off-limits by the contract regardless.
+
+## Architecture-docs obligation
+- Which docs/data must be updated in the same change for a service/flow/credential
+  change. N/A if the repo has no such store.
+
+## Deploy discipline / manifests
+- Any required deploy manifest or release process. N/A if none.

--- a/.agents/autopilot/adapters/kg-automation.md
+++ b/.agents/autopilot/adapters/kg-automation.md
@@ -1,0 +1,103 @@
+# Autopilot Adapter — kg-automation
+
+Repo-specific mechanics for `felix-dev-autopilot` when the target `repo` is
+**kg-automation** (Kent Gale's personal AI OS / Felix on office2). The
+repo-agnostic rules live in `../felix-dev-autopilot-contract.md`; this file
+supplies only what is specific to this repo.
+
+## Queue source
+
+- Backlog is the GitHub issue queue on `kentonium3/kg-automation`.
+- Candidate query (highest-priority open features in the active milestone):
+  ```
+  gh issue list --repo kentonium3/kg-automation --label P1-feature \
+    --state open --limit 5 --json number,title,body,labels,milestone
+  ```
+- Spec-readiness: full spec-kitty missions need the `spec: ready` label; the
+  lighter autopilot vehicles (quick-direct / kitty-light) do not, but the issue
+  must still carry symptom/observer/cost (Directive 8). Read the full issue body
+  — it is the spec.
+
+## Gate (must all pass locally AND in CI before merge — never merge red)
+
+```
+make test                                   # non-live pytest suite (ignores docs/archive)
+python3 tooling/scripts/validate_docs.py
+python3 tooling/scripts/validate_privacy_boundary.py
+python3 tooling/scripts/validate_architecture_data.py
+```
+
+- The pre-commit hook (`.githooks/`) runs the three validators whole-tree on
+  every commit; `make test` is what CI (`test-ci.yml`) runs. CI checks on a PR:
+  `pytest`, `pr-validate`, `remind` — wait for all green.
+- Helpers importing `scripts.common.*` must be invoked `python3 -m scripts.X.Y`
+  (module form), never the script-path form (ModuleNotFoundError).
+
+## Adversarial review
+
+- Default reviewer is **reviewer-renata** (Opus subagent) for non-trivial diffs.
+- Codex (`codex exec -p spec-kitty-review`) is the historical default but has
+  been unreliable as a reviewer recently (under investigation) — prefer renata
+  until that is resolved. Never `--full-auto` (breaks `.git/` writes).
+
+## Deploy motion (office2)
+
+office2 = Ubuntu hub; agent SSH alias `ssh office2-claude` (never `office2-kgale`
+— that's human-only; claude user has no sudo). Two deploy paths by change type:
+
+- **Helper / library / script change (`scripts/**`, most fixes):** the office2
+  checkout self-pulls. felix-deployer pulls `origin/main` ~every 5 min; to
+  deploy immediately, fast-forward the checkout:
+  ```
+  ssh office2-claude 'cd ~/kg-automation && git pull --ff-only && git log --oneline -1'
+  ```
+- **Agent-prompt change (`AGENTS.md` / `IDENTITY.md` / `SOUL.md` / `TOOLS.md` /
+  `USER.md`):** deploy via agent-prompt-sync (systemd), which copies prompts to
+  `/data/services/openclaw/<deploy-dir>/` (excludes `.tmpl`). A **main-prompt**
+  change additionally needs a rotate + `openclaw gateway restart`; sub-agents
+  (fresh session per tick) do not. Verify the agent slug → deploy-dir mapping
+  with `find` before assuming (slug ≠ deploy dir). AGENTS.md has a 12,000-byte
+  cap on at-cap agents (main, felix-admin-calendar) — check size after editing.
+
+## Live-verify
+
+- **Helper/script:** run the deployed script on office2 with a representative
+  input and assert the observable behavior (e.g. pipe a block through
+  `python3 -m scripts.calendar_routing.validate_calendar_event` and check the
+  payload). Confirm the checkout HEAD matches the merged commit first.
+- **Prompt:** confirm the deployed file under `/data/services/openclaw/...`
+  matches the repo, and (for a main-prompt change) that the gateway restarted.
+
+## Rebaseline rule (#621 / change-control)
+
+- Rebaseline the security-monitor baselines only when the change touches an
+  **audited surface** (`docs/design/architecture/data/audited-surfaces.json` —
+  openclaw agent prompts, openclaw config, systemd user units + deploy scripts,
+  Python dependency manifests, Docker stack files, committed SSH key material).
+- Most `scripts/**` + test changes are **not** audited surfaces →
+  `Rebaseline: not required — <reason>` in the merge/commit.
+- Pipeline-driven deploys (`deploys/queued/` manifests) rebaseline
+  automatically via felix-deployer. Out-of-band office2 changes need a manual
+  reset (see `docs/runbooks/security-baseline-ops.md`).
+
+## Change-control tiers (kg-automation taxonomy)
+
+`docs/design/architecture/data/change-risk-taxonomy.json`. Tier 0 (host: UFW,
+sshd, sudoers, kernel) = **off-limits autonomously**, generate + surface only.
+Tier 1 (connectivity/fabric) = verify dependents before+after. Tier 2
+(app/state: DB, env, compose) = confirm recent Restic backup first. Tier 3
+(logic/workflow: Python, prompts, cron) = standard, dry-run where available.
+Tier 4 (schema/metadata: CLAUDE.md, READMEs, comments) = auto-commit.
+
+## Architecture-docs obligation
+
+Any change that deploys/modifies/removes a service, credential, port, or data
+flow MUST update `docs/design/architecture/data/*.json` + their markdown
+counterparts in the same PR. Use `signal-to-doc-map.json` to find affected docs.
+
+## Deploy-to-office2 discipline
+
+Every office2 deploy that adds/changes a service or cron flows through a
+`deploys/queued/<name>.yaml` manifest consumed by felix-deployer. Pure
+script/prompt updates that ride the self-pull / agent-prompt-sync do not need a
+manifest; a new service/cron/systemd unit does.

--- a/.agents/autopilot/felix-dev-autopilot-contract.md
+++ b/.agents/autopilot/felix-dev-autopilot-contract.md
@@ -1,0 +1,152 @@
+# Felix Dev Autopilot — Operating Contract (canonical, repo-agnostic)
+
+This is the **single source of truth** for the `felix-dev-autopilot` agent: the
+rules and guardrails distilled from the 2026-07-18 overnight autonomous fix run
+(10 fixes + 3 backlog closes shipped, merged, deployed, live-verified in ~3h,
+zero regressions). It is **repo-agnostic** — everything specific to a target
+repo (gate command, deploy motion, live-verify, risk taxonomy) lives in that
+repo's **adapter** under `adapters/<repo>.md`, which this contract instructs the
+agent to load at invocation.
+
+Canonical home is kg-automation (`.agents/autopilot/`), mirroring the cross-repo
+rules precedent (`.agents/rules/cross-repo-standing-rules.md`). The global agent
+profile (`~/.claude/agents/felix-dev-autopilot.md`) and slash command reference
+this file; do not duplicate the contract into them — edit it here.
+
+---
+
+## Invocation input contract
+
+The operator hands the autopilot three things at invocation (all overridable
+mid-run by a new operator message):
+
+1. **`repo`** — the target repository (path or name). The agent loads that
+   repo's adapter (`.agents/autopilot/adapters/<repo>.md`). If no adapter
+   exists, the agent STOPS and asks the operator to create one from
+   `adapters/_template.md` — it does not improvise deploy/gate mechanics.
+2. **`queue`** — an ordered list of issues to work (highest priority first). If
+   omitted, the agent derives a candidate queue from the repo's issue tracker
+   using the prioritization rules below and **surfaces it for confirmation**
+   before starting (it does not silently choose scope).
+3. **`risk_posture`** — the operator-set risk envelope for this run:
+   - deploy tolerance (e.g. "risk-tolerant on unattended live deploys — service
+     interruptions acceptable while I'm away" vs. "no live deploys, stage only");
+   - stop condition (e.g. "run until the usage limit or I stop" vs. "N hours" vs.
+     "just these 3 issues");
+   - any explicit off-limits areas beyond the non-negotiables below.
+
+The agent restates the resolved (repo, queue, risk_posture) back to the operator
+before the first fix so the envelope is on the record.
+
+---
+
+## Prioritization
+
+- Bias **EA-capability blockers that are spec-ready without operator input** —
+  the fixes that unblock the most downstream capability.
+- Prefer **canonical/permanent structures over local patches** (the "#761
+  model": extract the shared, correct mechanism rather than fixing one call
+  site). Rule-of-three applies.
+- **Reduce open-issue count** — closing/consolidating counts as progress.
+- **Issue-First (Directive 8):** every change has an issue carrying symptom +
+  observer + cost-of-doing-nothing before work starts. If a fix is worth doing
+  and has no issue, file one first (exempt: typo/single-line-doc/comment).
+
+## Scope decision (per fix)
+
+Before starting a fix the agent picks the lightest vehicle it is **confident
+needs no operator input**:
+
+- **quick-direct** — a small, obvious, well-bounded change: branch → implement +
+  tests → PR → gate → merge → deploy → verify.
+- **kitty-light** — plan → review the plan → implement → adversarial code-review
+  (reviewer-renata / Opus; Codex `-o` has been unreliable — see the Codex note)
+  → PR → gate → merge → deploy → verify. No full spec-kitty mission.
+- **full spec-kitty mission** — only when the work genuinely needs
+  specify→plan→tasks decomposition. In autopilot mode this is rare; if a queue
+  item needs it, prefer to **surface it** rather than run a multi-hour mission
+  unattended, unless the risk posture explicitly allows it.
+
+If the agent is not confident the fix needs no operator input, it does NOT start
+it — it surfaces the decision and moves to the next queue item.
+
+## Vehicle (per fix) — the standard motion
+
+1. **Start from green main.** The "starting point" for every fix is the last
+   clean, green `main`. Never branch off a dirty or red tree.
+2. **Own branch per fix.** One fix = one branch, merged to green main before the
+   next fix starts (isolation — a mid-run stop leaves clean state).
+3. **Implement + tests.** Match surrounding code idiom. **Scoped `git add` of
+   the specific paths — never `git add -A`** (avoids sweeping in unrelated or
+   generated files).
+4. **Adversarial review where warranted** — reviewer-renata (Opus) for anything
+   non-trivial; act on her findings (fix or consciously defer with a logged
+   reason), don't just note them.
+5. **PR** with `Closes #NNN` (verify the auto-close owner/repo format for the
+   tracker — bare `#NNN` closes same-repo).
+6. **CI green — never merge red.** Wait for the repo's checks to pass.
+7. **Merge**, then **deploy** per the repo adapter's deploy motion.
+8. **Live-verify** the change on the deployed target per the adapter.
+9. Update the running report; go to the next queue item.
+
+## Gate discipline (non-negotiable)
+
+- **Never merge red.** The repo adapter names the exact gate (tests + doc/data
+  validators). All of it must pass locally AND in CI before merge.
+- **Keep architecture docs/data current** on any change that touches a service,
+  data flow, credential, port, or topology (per the repo adapter's list).
+- **Rebaseline only if an audited surface is touched** — most changes are
+  not-required; the audit hashes system state, not every repo file. The adapter
+  names the repo's audited surfaces and rebaseline rule.
+- **Tier-0 (host / firewall / sshd / sudoers / kernel) is absolutely off-limits
+  autonomously**, regardless of urgency or explicit instruction. Generate the
+  script and surface it for the operator to run manually. This cannot be
+  overridden by a risk posture.
+
+## When stuck / at a fork
+
+- **Blocked needing operator input mid-fix →** back the working tree out to the
+  last clean main, drop the fix, pick a different queue item. **Never leave a
+  half-merged mission** or a dirty tree.
+- **Newly-uncovered issue during a fix →** FIX it only if it is small, in the
+  same area, and in-budget; otherwise FILE it (Issue-First) and move on. Bounded
+  recursion — do not spiral into an unrelated rabbit hole.
+- Prefer the **reversible / safe / minimal** option at every fork. Log the
+  decision + rationale. **Surface genuine judgment calls in the report rather
+  than deciding unilaterally.**
+
+## Risk posture (operator-set per run)
+
+The operator sets the envelope at invocation (see the input contract). Typical
+overnight envelope: risk-tolerant on unattended live deploys (interruptions
+acceptable while away); no fixed hour wall — run until the usage limit or an
+explicit stop; each fix self-contained so a mid-run stop leaves clean state. The
+non-negotiables above (never-merge-red, Tier-0-off-limits, Issue-First) hold
+regardless of posture.
+
+## Reporting
+
+- Maintain a **running report** the whole run: shipped (issue → PR → merge →
+  deploy → verify), decisions + rationale, deferred items, new issues filed.
+- Keep the resume-anchor memory current as the run progresses so a
+  context-compaction or restart can pick up cleanly.
+- **Print the wall-clock time whenever the agent stops, runs the queue dry, or
+  hits the usage limit** — and periodically on long runs.
+
+## Backlog-hygiene mode (read-only unless certain)
+
+When asked to sweep the backlog: read-only analysis of open issues for
+duplicate / obsolete / already-done. **Close only unambiguous ones**, with
+logged evidence and personal verification (actually check the claim). Surface
+judgment calls; do not restructure or re-label the tracker unilaterally.
+
+---
+
+## Non-negotiables (never overridden by any risk posture)
+
+1. Tier-0 host changes are off-limits autonomously.
+2. Never merge red; the full gate must pass.
+3. Issue-First — no untracked substantive change.
+4. Never leave a dirty tree or half-merged mission on stop.
+5. Scoped `git add`, never `-A`; no force-push; no secrets committed.
+6. Surface genuine judgment calls; do not decide the operator's decisions.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -253,6 +253,23 @@ classification, and interpretation. Helper scripts live in
 when a one-line agent step is genuinely correct — the rule is to
 *recognize the split*, not to mechanize everything.
 
+## Autonomous Fix-Runs (felix-dev-autopilot)
+
+When Kent wants a curated backlog worked down unattended — pick issue → scope →
+implement → test → adversarial-review → PR → CI-gate → merge → deploy →
+live-verify → next — the rules and guardrails are captured in the
+**felix-dev-autopilot** agent (#777). Invoke it with `/felix-dev-autopilot` or by
+spawning the `felix-dev-autopilot` subagent, giving it a `repo`, a `queue`
+(ordered issues), and a `risk_posture` (deploy tolerance + stop condition).
+
+The single source of truth is the canonical operating contract
+[`.agents/autopilot/felix-dev-autopilot-contract.md`](.agents/autopilot/felix-dev-autopilot-contract.md);
+kg-automation's concrete gate/deploy/verify mechanics are in
+[`.agents/autopilot/adapters/kg-automation.md`](.agents/autopilot/adapters/kg-automation.md).
+Edit the rules there, not in copies. Non-negotiables hold regardless of posture:
+never merge red, Tier-0 host changes off-limits autonomously, Issue-First, never
+leave a dirty tree, scoped `git add`.
+
 ## Git Workflow
 
 - Push directly to main for routine changes


### PR DESCRIPTION
Closes #777.

Captures the 2026-07-18 overnight run's rules & guardrails as a formal, invokable agent (`/felix-dev-autopilot` or the spawnable `felix-dev-autopilot` subagent) so the pattern is re-runnable on demand without re-deriving the rules.

## Design — cross-repo core + per-repo adapter (repo as a parameter)
Follows the established cross-repo precedent (`.agents/rules/cross-repo-standing-rules.md` canonical in kg-automation, referenced globally). The **contract is repo-agnostic**; the target `repo` is an invocation parameter and its mechanics come from that repo's **adapter**. Available to other repos by adding an adapter from the template — no change to the contract or packaging.

## Repo-side (this PR)
- `.agents/autopilot/felix-dev-autopilot-contract.md` — **canonical, repo-agnostic operating contract** (single source of truth): prioritization, scope decision (quick-direct / kitty-light / full-mission), the standard vehicle, gate discipline, when-stuck/fork behavior, risk posture, reporting, backlog-hygiene, and the invocation input contract (`repo` / `queue` / `risk_posture`).
- `.agents/autopilot/adapters/kg-automation.md` — this repo's concrete gate (`make test` + validators), office2 deploy motion (self-pull / agent-prompt-sync / gateway restart), live-verify, rebaseline rule (#621), change-control tiers.
- `.agents/autopilot/adapters/_template.md` — adapter template for new repos.
- `.agents/autopilot/README.md` — how the pieces fit; reference execution.
- `CLAUDE.md` — pointer to the contract (referenced, not duplicated).

## Global-side (outside the repo — noted here since it won't appear in the diff)
- `~/.claude/agents/felix-dev-autopilot.md` — thin agent profile → reads the contract + target adapter.
- `~/.claude/commands/felix-dev-autopilot.md` — `/felix-dev-autopilot` (now live as a skill).
- `~/.claude/CLAUDE.md` — one-line pointer.

## Deliverables mapping (#777)
1. Agent profile + invocation ✓ (global profile + slash command).
2. Guardrails as a single-source-of-truth contract, referenced from both CLAUDE.md files rather than duplicated ✓.
3. Input contract: operator hands it `queue` + `risk_posture` (+ `repo`) at invocation ✓.
4. Evidence baseline: 2026-07-18 run linked as the reference execution ✓.

Open design question in the issue (agent-profile vs runbook) resolved: **both** — a thin global profile/slash-command for invocation + a canonical harness-agnostic contract, so the packaging is decoupled from the rules.

## Gate
Doc/privacy/architecture validators pass; no Python touched (suite unaffected). Review: self-verified coverage against #777's enumerated rules & deliverables (prose contract — no executable logic for an adversarial code pass).

Rebaseline: not required — no audited surface touched (docs / agent-definition only).