### PR TITLE
fix(#788): all-day payload works through the calendar agent + no dropped end-time

### DIFF
--- a/scripts/calendar_routing/validate_calendar_event.py
+++ b/scripts/calendar_routing/validate_calendar_event.py
@@ -608,11 +608,21 @@ def validate(block: dict) -> dict:
     # date-based (`start_date`/`end_date`) form so the calendar helper creates a
     # Google all-day event, not a midnight-to-midnight timed one. Google's all-day
     # end is exclusive; we take `end_dt`'s calendar date directly. For the common
-    # case `end_dt` is start + a whole-day duration (its date is the exclusive end);
-    # if the block instead carried an explicit end (which takes precedence above),
-    # that end's date is used verbatim — also treated as exclusive. Otherwise emit
-    # the timed (`start_rfc3339`) form.
-    if _is_all_day_duration(duration) and _parse_time_component(start_natural) is None:
+    # case `end_dt` is start + a whole-day duration (its date is the exclusive end).
+    # An event is all-day only when NEITHER endpoint carries an explicit time: if
+    # the block gave an explicit end WITH a time (which takes precedence for
+    # `end_dt` above), it is a timed event and must keep that time — classifying it
+    # all-day would silently drop the end time (#788). Otherwise emit the timed
+    # (`start_rfc3339`) form.
+    end_has_explicit_time = (
+        end_dt_candidate is not None
+        and _parse_time_component(end_natural) is not None
+    )
+    if (
+        _is_all_day_duration(duration)
+        and _parse_time_component(start_natural) is None
+        and not end_has_explicit_time
+    ):
         payload["start_date"] = start_dt.date().isoformat()
         payload["end_date"] = end_dt.date().isoformat()
     else:

--- a/scripts/openclaw/agents/felix-admin-calendar/AGENTS.md
+++ b/scripts/openclaw/agents/felix-admin-calendar/AGENTS.md
@@ -28,7 +28,7 @@ Judgment paths only (conversational via main + the clarification handler below);
 
 ### Input payload
 
-Parse JSON. **Required**: `action`, `calendar_id`, `account`, `summary`, `start_rfc3339`, `end_rfc3339`, `source_inbox_path`. **Optional**: `start_timezone`, `location`, `description`, `rrule`, `attendees` (list of emails or null), `clarification_id` (set on self-dispatch from the clarification handler below). Use payload values verbatim — defaults (`personal`, `primary`) already resolved upstream.
+Parse JSON. **Required**: `action`, `calendar_id`, `account`, `summary`, `source_inbox_path`, and a start/end pair — **either** `start_rfc3339`+`end_rfc3339` (timed) **or** `start_date`+`end_date` (all-day, `YYYY-MM-DD`). **Optional**: `start_timezone`, `location`, `description`, `rrule`, `attendees` (emails or null), `clarification_id` (set on self-dispatch below). Pass whichever pair is present verbatim — defaults (`personal`, `primary`) already resolved upstream.
 
 ### Calendar helper invocation
 
@@ -41,7 +41,7 @@ cd /home/claude/kg-automation && /data/services/openclaw/felix-calendar/venv/bin
   --idempotency-key "<source_inbox_path>" --json
 ```
 
-The helper reads `summary`/`start_rfc3339`/`end_rfc3339`/`start_timezone`/`location`/`description`/`rrule` from the payload file; refuses `attendees` unless `--allow-attendees` (a note must not silently email people). `--idempotency-key` makes a re-run of the same note a no-op, not a duplicate. `--json` emits `{"status": "created", "event_id": …, "html_link": …}` on a line *before* the final `SUMMARY:` — parse it for `event_id`/`html_link`.
+The helper reads `summary`, the start/end pair (`start_rfc3339`/`end_rfc3339`, or all-day `start_date`/`end_date`), `start_timezone`/`location`/`description`/`rrule` from the payload file; refuses `attendees` unless `--allow-attendees` (a note must not silently email people). `--idempotency-key` makes a re-run of the same note a no-op, not a duplicate. `--json` emits `{"status": "created", "event_id": …, "html_link": …}` on a line *before* the final `SUMMARY:` — parse it for `event_id`/`html_link`.
 
 **Exit codes (contract):** `0` success · `1` operational/API error · `2` usage error · `3` auth failure. On non-zero exit the helper writes `ERROR: …` to stderr and never mutated the calendar. **Surface that error verbatim; NEVER report a created event that did not create (#683); never fall back to `gog` — you have none.**
 
@@ -146,7 +146,7 @@ When re-validation returns `complete: true`, do the following in order:
      --context '{"source_file": "<source_inbox_path>", "gcal_event_id": "<from helper response>"}'
    ```
 
-   The Calendar event creation section's `calendar_event_created` log_action also fires in step 2 — both events cover the resolution flow.
+   (Step 2 also fires `calendar_event_created`.)
 
 6. **Send a turn-summary to Kent on WhatsApp** confirming the event (with gcal html_link if available). Standard end-of-turn output, not a channel-action call.
 
@@ -161,4 +161,4 @@ If the calendar helper in step 2 exits non-zero (`status: "error"`):
 
 ### Why this handler runs first
 
-Main's intent-classification (chat, scheduling, habits, inbox-process) must NOT preempt a calendar clarification reply. The check is cheap and the negative case costs nothing — running it first guarantees a calendar reply is never mis-routed.
+Main's intent-classification must NOT preempt a calendar clarification reply. The check is cheap and the negative case costs nothing — run it first so a calendar reply is never mis-routed.

--- a/tests/calendar/test_validate_calendar_event.py
+++ b/tests/calendar/test_validate_calendar_event.py
@@ -325,6 +325,27 @@ def test_all_day_event_multi_day_exclusive_end() -> None:
     assert "start_rfc3339" not in payload
 
 
+def test_explicit_end_time_with_whole_day_duration_not_dropped() -> None:
+    """An explicit END time must not be silently dropped by the all-day branch
+    (#788): whole-day duration + no start time + an explicit end WITH a time is a
+    TIMED event (end takes precedence), so it keeps start_rfc3339/end_rfc3339 and
+    the 5pm end survives — it does NOT become an all-day date payload."""
+    block = {
+        "title": "Setup then event",
+        "start_natural": "June 14, 2026",
+        "end_natural": "June 15, 2026 at 5pm",
+        "duration_natural": "1 day",
+        "source_inbox_path": "/tmp/Inbox 2026-06-07 1000.md",
+        "source_block_index": 0,
+        "tick_iso": "2026-06-07T10:00:00-04:00",
+    }
+    result = vce.validate(block)
+    assert result["complete"] is True
+    payload = result["calendar_event_payload"]
+    assert "start_date" not in payload  # not classified all-day
+    assert payload["end_rfc3339"].startswith("2026-06-15T17:00:00")  # 5pm preserved
+
+
 def test_explicit_time_with_whole_day_duration_stays_timed() -> None:
     """An explicit time PLUS a whole-day duration is a TIMED event, not all-day
     (#780): the all-day branch must not swallow it — it keeps start_rfc3339."""


### PR DESCRIPTION
Closes #788.

Post-merge **Codex** review of the #786 all-day work (item 1 of #780) — run during this session's Codex-reliability investigation — found two defects the inline reviewer-renata pass structurally couldn't see (it reviewed validate↔helper, not the agent-prompt orchestration layer between them).

## HIGH — all-day payload broke at the agent-synthesis layer
The felix-admin-calendar clarification handler runs `validate_calendar_event` (AGENTS.md:116) then synthesizes the payload from its output (AGENTS.md:131). Its Input-payload contract required `start_rfc3339`/`end_rfc3339`, so a valid all-day payload (`start_date`/`end_date`) was mishandled/dropped **before reaching the helper** (which already handles all-day). The deterministic happy path (`route_calendar_event`→helper) was unaffected; the clarification/conversational path — exactly the #739/#780 scenario — was the break.
**Fix:** AGENTS.md now documents the start/end pair as EITHER timed (`start_rfc3339`+`end_rfc3339`) OR all-day (`start_date`+`end_date`), passed verbatim (the Verbatim pass-through rule then carries it). Trimmed redundant prose to stay under the 12,000-byte cap (→ 11,973).

## MEDIUM — explicit end-time silently dropped
`validate` let an explicit end take precedence for `end_dt` but decided all-day from `duration` + no-start-time alone. Repro: `start "June 14" + end "June 15 at 5pm" + duration "1 day"` → all-day payload dropping the 5pm.
**Fix:** an event is all-day only when NEITHER endpoint carries an explicit time; the Codex repro is now a regression test.

## Notes
- The `capture_to_main_calendar_payload.md` contract Codex also cited lives in `kitty-specs/` — **spec-kitty-managed, read-only per standing rules** — so it's left untouched; the runtime-authoritative surface is the AGENTS.md.
- **Deploy:** AGENTS.md → agent-prompt-sync to `felix-admin-calendar` (sub-agent, fresh session per dispatch → no gateway restart). Helper/validate → office2 self-pull.

## Gate
`make test` green (5649 passed, 42 skipped); doc/privacy/architecture validators pass.

Rebaseline: not required — AGENTS.md prose is not an audited surface (audit.sh hashes openclaw.json, not agent prompts, #621).