### PR TITLE
fix(#767): prefer authoritative last-backup.json in verify_restic_recent

### DIFF
--- a/scripts/deploy/lib/README.md
+++ b/scripts/deploy/lib/README.md
@@ -15,7 +15,7 @@ versioning policy and non-goals.
 | Module | Purpose | Public functions |
 |---|---|---|
 | `cron` | OpenClaw cron primitives — never touches the system cron table | `openclaw_cron_disable`, `openclaw_cron_enable`, `openclaw_cron_edit`, `openclaw_cron_list` |
-| `snapshot` | Restic backup-recency verification (fallback via daily log file) | `verify_restic_recent` |
+| `snapshot` | Restic backup-recency verification (authoritative `last-backup.json` state file; daily-log parse as fallback) | `verify_restic_recent` |
 | `verify` | File presence, stale-content, secret redaction | `verify_file_present`, `verify_no_stale_literal`, `redact_secrets` |
 | `manifest` | Manifest load + Draft 2020-12 schema validation; applied-seq math. `validate_manifest` also enforces the optional `expected_baselines` field (CLI-mutation deploys declare drifted baselines; names must be known security-monitor baselines and require `audited_surface: true`) via a non-exiting registry read — see `docs/runbooks/deploy/discipline.md`. | `load_manifest`, `validate_manifest`, `validate_manifest_file`, `next_applied_seq` |
 | `applied` | Applied-entry writer for `deploys/applied/<NNNN>-<name>.yaml` | `write_applied` |

--- a/scripts/deploy/lib/snapshot.py
+++ b/scripts/deploy/lib/snapshot.py
@@ -1,10 +1,45 @@
 """Restic backup-recency verification.
 
-The ``claude`` user on office2 cannot currently query the Restic repository
-directly (see the Felix charter "Deployment Constraints" section). The
-fallback signal is the daily backup log written by the Restic driver to
-``/data/services/backup/logs/backup-YYYY-MM-DD.log``. A "completed" line
-within the window is treated as evidence of a recent successful snapshot.
+The recency half of the Tier-2 destructive-deploy gate. Two signals, in
+priority order:
+
+1. **Authoritative state file** (``/data/services/backup/state/last-backup.json``,
+   written by the Restic driver on every run — #511). It carries
+   ``restic_exit_code`` (genuine success/failure of the backup step) and
+   ``snapshot_timestamp_utc`` / ``script_finished_at_utc`` (the exact instant).
+   This is preferred because it gives real success verification and an exact
+   UTC instant with no wall-clock/timezone guessing (#767).
+2. **Daily backup log** (``/data/services/backup/logs/backup-YYYY-MM-DD.log``) —
+   kept as defence-in-depth. Used only when the state file is absent or
+   malformed. A "completed" line within the window is treated as evidence of a
+   recent snapshot. This path infers success from a text marker and the instant
+   from a wall-clock stamp, so it is strictly weaker than the state file.
+
+Historically only the log path existed; the ``claude`` user on office2 cannot
+query the Restic repository directly (see the Felix charter "Deployment
+Constraints" section), which is why the driver-written state file — readable by
+``claude`` — is the right authoritative source rather than a live repo query.
+
+Success semantics: a restic exit code of ``0`` (clean) or ``3`` (snapshot
+created, some source files unreadable — still a restorable snapshot) counts as
+a successful backup. This matches the system-wide convention documented in
+``docs/design/architecture/data/service-inventory.json`` (#327),
+``docs/runbooks/restic-backup-ops.md``, and the governance pre-flight checklist,
+all of which treat ``restic_exit_code ∉ {0, 3}`` as an explicit failure.
+
+Recency anchor: on the state path the freshness instant is
+``snapshot_timestamp_utc`` **only** — the authoritative timestamp derived from
+``restic snapshots --latest 1 --json`` after the run. Per the same contract,
+``script_finished_at_utc`` is a *separate cron-finished witness*, not a snapshot
+instant; a state file that records a good exit code but a null/absent/unparseable
+``snapshot_timestamp_utc`` (the "backup ran but the snapshot query failed"
+signal) cannot authoritatively confirm a snapshot, so it falls back to the log
+path rather than being green-lit off the finish-witness. State timestamps must
+carry an explicit UTC marker (``Z`` or an offset); a naive timestamp is treated
+as malformed and falls back too (no timezone guessing on the authoritative
+path). A ``snapshot_timestamp_utc`` in the future beyond a small clock-skew
+tolerance is an explicit anomaly and fails the gate closed rather than reading
+as "very fresh".
 
 This module is a defence-in-depth check used by the applier for Tier 2
 deploys (per ``data-model.md`` apply orchestration); Tier 1 callers may also
@@ -14,14 +49,38 @@ opt in.
 from __future__ import annotations
 
 import datetime as _dt
+import json
 import re
 from pathlib import Path
 
 from . import LibResult
 
 DEFAULT_LOG_DIR = Path("/data/services/backup/logs")
+DEFAULT_STATE_PATH = Path("/data/services/backup/state/last-backup.json")
 LOG_PREFIX = "backup-"
 LOG_SUFFIX = ".log"
+
+# Restic exit codes that mean "a snapshot was successfully created":
+#   0 — clean run.
+#   3 — snapshot created but some source files could not be read (still a
+#       valid, restorable snapshot).
+# Any other code is an explicit failure. Canonical convention: see the module
+# docstring (service-inventory.json #327, restic-backup-ops.md, pre-flight
+# checklist). Keeping this as a named set keeps the gate consistent with every
+# other backup-health consumer in Felix.
+_RESTIC_OK_EXIT_CODES = frozenset({0, 3})
+
+# Authoritative recency anchor on the state path (#767). ``snapshot_timestamp_utc``
+# is the only field the backup-health contract treats as the snapshot instant;
+# ``script_finished_at_utc`` is a separate cron-finished witness (kept in details
+# for diagnostics, never used as the freshness anchor).
+_STATE_INSTANT_FIELD = "snapshot_timestamp_utc"
+
+# A state-file snapshot timestamp this far (or more) in the future is an
+# anomaly (corruption / clock skew), not a "very fresh" backup, and must fail
+# the gate closed. The tolerance absorbs benign sub-second/second same-host UTC
+# skew so a just-written snapshot is never spuriously rejected.
+_FUTURE_SKEW_TOLERANCE = _dt.timedelta(minutes=5)
 
 # Match a wide-but-bounded set of "completed" signatures the Restic driver
 # has emitted across versions. The check is greedy but case-insensitive and
@@ -50,6 +109,170 @@ _BRACKET_TIME_RE = re.compile(r"^\s*\[(?P<h>\d{2}):(?P<m>\d{2}):(?P<s>\d{2})\]")
 
 def _utc_now() -> _dt.datetime:
     return _dt.datetime.now(tz=_dt.timezone.utc)
+
+
+def _parse_iso_utc(raw: str, *, require_tz: bool = False) -> _dt.datetime | None:
+    """Parse an ISO-8601 instant. Returns ``None`` when unparseable.
+
+    When *require_tz* is False, a naive timestamp is assumed to be UTC (the
+    lenient log-path policy — the driver's wall-clock is UTC on office2). When
+    *require_tz* is True (the authoritative state path), a timestamp without an
+    explicit ``Z`` / offset is rejected — no timezone guessing (#767).
+    """
+    text = raw.strip()
+    if text.endswith("Z"):
+        text = text[:-1] + "+00:00"
+    try:
+        parsed = _dt.datetime.fromisoformat(text)
+    except ValueError:
+        return None
+    if parsed.tzinfo is None:
+        if require_tz:
+            return None
+        parsed = parsed.replace(tzinfo=_dt.timezone.utc)
+    return parsed
+
+
+def _pick_state_instant(data: dict) -> _dt.datetime | None:
+    """Return the authoritative snapshot instant from the state file.
+
+    Uses ``snapshot_timestamp_utc`` only, and requires an explicit UTC marker.
+    Returns ``None`` when the field is absent, null, non-string, naive, or
+    otherwise unparseable — the caller then falls back to the log path.
+    """
+    value = data.get(_STATE_INSTANT_FIELD)
+    if not isinstance(value, str) or not value:
+        return None
+    return _parse_iso_utc(value, require_tz=True)
+
+
+def _age_verdict(
+    instant: _dt.datetime,
+    now: _dt.datetime,
+    max_age_hours: int,
+    *,
+    source: str,
+    extra: dict,
+) -> LibResult:
+    """Build the ok / RESTIC_TOO_OLD LibResult from an instant + window."""
+    age = now - instant
+    age_hours = age.total_seconds() / 3600.0
+    window = _dt.timedelta(hours=max_age_hours)
+    common = {
+        "source": source,
+        "latest_completed_at": instant.isoformat(),
+        "age_hours": age_hours,
+        "max_age_hours": max_age_hours,
+        **extra,
+    }
+    if age <= window:
+        return LibResult(
+            ok=True,
+            summary=(
+                f"Restic snapshot completed {age_hours:.1f}h ago "
+                f"(within {max_age_hours}h window; source={source})"
+            ),
+            details=common,
+        )
+    return LibResult(
+        ok=False,
+        summary=(
+            f"Latest Restic snapshot is {age_hours:.1f}h old "
+            f"(exceeds {max_age_hours}h window; source={source})"
+        ),
+        details={"error_code": "RESTIC_TOO_OLD", **common},
+    )
+
+
+def _read_state_verdict(
+    state_path: Path,
+    max_age_hours: int,
+    now: _dt.datetime,
+) -> LibResult | None:
+    """Verdict from the authoritative state file, or ``None`` to fall back.
+
+    Returns:
+        * A ``LibResult`` (ok or explicit failure) when the state file is
+          present, well-formed, and carries a usable ``restic_exit_code`` +
+          instant.
+        * ``None`` when the file is absent, unreadable, malformed JSON, missing
+          an exit code, or missing every instant field — in which case the
+          caller falls back to the log-parsing path (defence-in-depth).
+
+    A state file that records an explicit restic *failure*
+    (``restic_exit_code ∉ {0, 3}``) returns ``ok=False`` and does **not** fall
+    through to the log path: an authoritative failure must never be masked by an
+    older "completed" log line (that would re-open the fail-open hole #767
+    closes).
+    """
+    try:
+        raw = state_path.read_text(encoding="utf-8")
+    except OSError:
+        return None  # absent / unreadable → fall back to logs
+    try:
+        data = json.loads(raw)
+    except (ValueError, TypeError):
+        return None  # malformed JSON → fall back to logs
+    if not isinstance(data, dict):
+        return None
+
+    exit_code = data.get("restic_exit_code")
+    if exit_code is None:
+        return None  # no success signal recorded → fall back to logs
+    # bool is an int subclass; reject it so True/False can't masquerade as 1/0.
+    if isinstance(exit_code, bool) or not isinstance(exit_code, int):
+        return None  # malformed exit code → fall back to logs
+    if exit_code not in _RESTIC_OK_EXIT_CODES:
+        return LibResult(
+            ok=False,
+            summary=(
+                f"Restic backup reported failure (restic_exit_code={exit_code}); "
+                "refusing to treat as a recent successful snapshot"
+            ),
+            details={
+                "error_code": "RESTIC_FAILED",
+                "source": "state",
+                "state_path": str(state_path),
+                "restic_exit_code": exit_code,
+            },
+        )
+
+    instant = _pick_state_instant(data)
+    if instant is None:
+        # exit ok but no authoritative snapshot instant (null/absent/naive/
+        # unparseable snapshot_timestamp_utc) → cannot confirm a snapshot from
+        # state; fall back to the log path (defence in depth).
+        return None
+
+    # script_finished_at_utc is a diagnostic witness only, never the anchor.
+    finished_witness = data.get("script_finished_at_utc")
+    extra = {
+        "state_path": str(state_path),
+        "restic_exit_code": exit_code,
+        "instant_field": _STATE_INSTANT_FIELD,
+        "script_finished_at_utc": finished_witness,
+    }
+
+    # An authoritative snapshot timestamp in the future (beyond benign skew) is
+    # an anomaly, not freshness — fail the gate closed rather than green-lighting
+    # a destructive deploy off an impossible instant.
+    if instant > now + _FUTURE_SKEW_TOLERANCE:
+        return LibResult(
+            ok=False,
+            summary=(
+                "Restic state snapshot_timestamp_utc is in the future "
+                f"({instant.isoformat()} > now {now.isoformat()}); "
+                "refusing to treat as a recent snapshot"
+            ),
+            details={
+                "error_code": "RESTIC_TIMESTAMP_IN_FUTURE",
+                "source": "state",
+                "latest_completed_at": instant.isoformat(),
+                **extra,
+            },
+        )
+
+    return _age_verdict(instant, now, max_age_hours, source="state", extra=extra)
 
 
 def _parse_log_date(path: Path) -> _dt.date | None:
@@ -127,48 +350,25 @@ def _candidate_logs(log_dir: Path) -> list[Path]:
     return [p for p in entries if _parse_log_date(p) is not None]
 
 
-def verify_restic_recent(
-    max_age_hours: int = 24,
-    log_dir: Path | str = DEFAULT_LOG_DIR,
+def _verify_via_logs(
+    max_age_hours: int,
+    log_dir: Path,
+    now: _dt.datetime,
 ) -> LibResult:
-    """Confirm the most recent Restic snapshot finished within *max_age_hours*.
-
-    The Restic repository cannot be queried directly from the ``claude``
-    user; this fallback reads the per-day backup log under *log_dir* and
-    looks for a "snapshot saved" / "backup completed" / "status: ok"
-    signature with a timestamp inside the window.
-
-    Returns ``LibResult(ok=True, ...)`` when the most recent completed line
-    is younger than *max_age_hours*. Otherwise returns ``ok=False`` with an
-    ``error_code`` of:
-
-    * ``LOG_DIR_MISSING`` — *log_dir* does not exist.
-    * ``NO_LOGS`` — no ``backup-YYYY-MM-DD.log`` files in *log_dir*.
-    * ``NO_COMPLETED_LINES`` — log files exist but none contain a completion
-      signature.
-    * ``RESTIC_TOO_OLD`` — completion exists but is older than the window.
-    """
-    if max_age_hours <= 0:
+    """Defence-in-depth fallback: infer recency from the daily backup log."""
+    if not log_dir.exists():
         return LibResult(
             ok=False,
-            summary="verify_restic_recent requires max_age_hours > 0",
-            details={"error_code": "INVALID_ARGUMENT"},
+            summary=f"Restic backup log directory not found: {log_dir}",
+            details={"error_code": "LOG_DIR_MISSING", "log_dir": str(log_dir)},
         )
 
-    log_dir_path = Path(log_dir)
-    if not log_dir_path.exists():
-        return LibResult(
-            ok=False,
-            summary=f"Restic backup log directory not found: {log_dir_path}",
-            details={"error_code": "LOG_DIR_MISSING", "log_dir": str(log_dir_path)},
-        )
-
-    candidates = _candidate_logs(log_dir_path)
+    candidates = _candidate_logs(log_dir)
     if not candidates:
         return LibResult(
             ok=False,
-            summary=f"No backup logs found in {log_dir_path}",
-            details={"error_code": "NO_LOGS", "log_dir": str(log_dir_path)},
+            summary=f"No backup logs found in {log_dir}",
+            details={"error_code": "NO_LOGS", "log_dir": str(log_dir)},
         )
 
     latest_completed: _dt.datetime | None = None
@@ -189,47 +389,65 @@ def verify_restic_recent(
             summary=f"No completed-snapshot line found in {len(candidates)} log(s)",
             details={
                 "error_code": "NO_COMPLETED_LINES",
-                "log_dir": str(log_dir_path),
+                "log_dir": str(log_dir),
                 "logs_scanned": [p.name for p in candidates],
             },
         )
 
-    now = _utc_now()
-    age = now - latest_completed
-    age_hours = age.total_seconds() / 3600.0
-    window = _dt.timedelta(hours=max_age_hours)
-    if age <= window:
-        return LibResult(
-            ok=True,
-            summary=(
-                f"Restic snapshot completed {age_hours:.1f}h ago "
-                f"(within {max_age_hours}h window)"
-            ),
-            details={
-                "log_path": str(inspected_path) if inspected_path else None,
-                "latest_completed_at": latest_completed.isoformat(),
-                "age_hours": age_hours,
-                "max_age_hours": max_age_hours,
-            },
-        )
-
-    return LibResult(
-        ok=False,
-        summary=(
-            f"Latest Restic snapshot is {age_hours:.1f}h old "
-            f"(exceeds {max_age_hours}h window)"
-        ),
-        details={
-            "error_code": "RESTIC_TOO_OLD",
-            "log_path": str(inspected_path) if inspected_path else None,
-            "latest_completed_at": latest_completed.isoformat(),
-            "age_hours": age_hours,
-            "max_age_hours": max_age_hours,
-        },
+    return _age_verdict(
+        latest_completed,
+        now,
+        max_age_hours,
+        source="log",
+        extra={"log_path": str(inspected_path) if inspected_path else None},
     )
 
 
-__all__ = ["verify_restic_recent", "DEFAULT_LOG_DIR"]
+def verify_restic_recent(
+    max_age_hours: int = 24,
+    log_dir: Path | str = DEFAULT_LOG_DIR,
+    state_path: Path | str = DEFAULT_STATE_PATH,
+) -> LibResult:
+    """Confirm the most recent Restic snapshot finished within *max_age_hours*.
+
+    Prefers the authoritative driver-written state file *state_path*
+    (``restic_exit_code`` for genuine success, ``snapshot_timestamp_utc`` /
+    ``script_finished_at_utc`` for the exact instant). Falls back to parsing the
+    per-day backup log under *log_dir* only when the state file is absent or
+    malformed.
+
+    Returns ``LibResult(ok=True, ...)`` when a successful snapshot is younger
+    than *max_age_hours*. ``details["source"]`` is ``"state"`` or ``"log"``.
+    Otherwise returns ``ok=False`` with an ``error_code`` of:
+
+    * ``INVALID_ARGUMENT`` — *max_age_hours* is not positive.
+    * ``RESTIC_FAILED`` — the state file records a restic failure
+      (``restic_exit_code ∉ {0, 3}``).
+    * ``RESTIC_TIMESTAMP_IN_FUTURE`` — the state file's
+      ``snapshot_timestamp_utc`` is in the future beyond clock-skew tolerance.
+    * ``RESTIC_TOO_OLD`` — a success exists but is older than the window.
+    * ``LOG_DIR_MISSING`` — (log fallback) *log_dir* does not exist.
+    * ``NO_LOGS`` — (log fallback) no ``backup-YYYY-MM-DD.log`` files.
+    * ``NO_COMPLETED_LINES`` — (log fallback) logs exist but none contain a
+      completion signature.
+    """
+    if max_age_hours <= 0:
+        return LibResult(
+            ok=False,
+            summary="verify_restic_recent requires max_age_hours > 0",
+            details={"error_code": "INVALID_ARGUMENT"},
+        )
+
+    now = _utc_now()
+
+    state_verdict = _read_state_verdict(Path(state_path), max_age_hours, now)
+    if state_verdict is not None:
+        return state_verdict
+
+    return _verify_via_logs(max_age_hours, Path(log_dir), now)
+
+
+__all__ = ["verify_restic_recent", "DEFAULT_LOG_DIR", "DEFAULT_STATE_PATH"]
 
 
 # ---------------------------------------------------------------------------
@@ -239,7 +457,7 @@ __all__ = ["verify_restic_recent", "DEFAULT_LOG_DIR"]
 
 
 def _cli_verify_restic_recent(*args: str) -> LibResult:
-    """CLI wrapper: positional ``[max_age_hours] [log_dir]`` (both optional)."""
+    """CLI wrapper: positional ``[max_age_hours] [log_dir] [state_path]`` (all optional)."""
     kwargs: dict = {}
     if len(args) >= 1 and args[0]:
         try:
@@ -252,6 +470,8 @@ def _cli_verify_restic_recent(*args: str) -> LibResult:
             )
     if len(args) >= 2 and args[1]:
         kwargs["log_dir"] = args[1]
+    if len(args) >= 3 and args[2]:
+        kwargs["state_path"] = args[2]
     return verify_restic_recent(**kwargs)
 
 

--- a/tests/deploy/test_snapshot.py
+++ b/tests/deploy/test_snapshot.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import datetime as _dt
+import json
 from pathlib import Path
 
 import pytest
@@ -17,6 +18,24 @@ def _write_log(log_dir: Path, date: str, body: str) -> Path:
     return path
 
 
+def _write_state(tmp_path: Path, payload: dict | str) -> Path:
+    """Write a ``last-backup.json``-shaped state file and return its path."""
+    path = tmp_path / "last-backup.json"
+    text = payload if isinstance(payload, str) else json.dumps(payload)
+    path.write_text(text, encoding="utf-8")
+    return path
+
+
+def _absent_state(tmp_path: Path) -> Path:
+    """A state_path guaranteed not to exist, to force the log-fallback path.
+
+    The default state_path is the real ``/data/services/backup/state/…`` file,
+    which exists on office2; log-oriented tests must pin an absent path so they
+    exercise the fallback deterministically regardless of host.
+    """
+    return tmp_path / "no-such-state.json"
+
+
 @pytest.fixture
 def freeze_now(monkeypatch):
     """Pin :func:`snapshot._utc_now` for deterministic age math."""
@@ -25,6 +44,11 @@ def freeze_now(monkeypatch):
         monkeypatch.setattr(snapshot, "_utc_now", lambda: when)
 
     return _install
+
+
+# ---------------------------------------------------------------------------
+# Log-fallback path (state file absent). All calls pin an absent state_path.
+# ---------------------------------------------------------------------------
 
 
 def test_returns_ok_when_recent_completed_line_within_window(tmp_path, freeze_now):
@@ -38,11 +62,14 @@ def test_returns_ok_when_recent_completed_line_within_window(tmp_path, freeze_no
     )
     _write_log(log_dir, "2026-06-12", body)
 
-    result = snapshot.verify_restic_recent(max_age_hours=24, log_dir=log_dir)
+    result = snapshot.verify_restic_recent(
+        max_age_hours=24, log_dir=log_dir, state_path=_absent_state(tmp_path)
+    )
 
     assert isinstance(result, LibResult)
     assert result.ok is True
     assert result.details["age_hours"] < 24
+    assert result.details["source"] == "log"
 
 
 def test_returns_too_old_when_completed_line_outside_window(tmp_path, freeze_now):
@@ -52,7 +79,9 @@ def test_returns_too_old_when_completed_line_outside_window(tmp_path, freeze_now
     body = "2026-06-10T03:00:00Z snapshot saved\n"  # 57h ago
     _write_log(log_dir, "2026-06-10", body)
 
-    result = snapshot.verify_restic_recent(max_age_hours=24, log_dir=log_dir)
+    result = snapshot.verify_restic_recent(
+        max_age_hours=24, log_dir=log_dir, state_path=_absent_state(tmp_path)
+    )
 
     assert result.ok is False
     assert result.details["error_code"] == "RESTIC_TOO_OLD"
@@ -61,7 +90,9 @@ def test_returns_too_old_when_completed_line_outside_window(tmp_path, freeze_now
 def test_returns_log_dir_missing_when_directory_absent(tmp_path):
     missing = tmp_path / "does-not-exist"
 
-    result = snapshot.verify_restic_recent(max_age_hours=24, log_dir=missing)
+    result = snapshot.verify_restic_recent(
+        max_age_hours=24, log_dir=missing, state_path=_absent_state(tmp_path)
+    )
 
     assert result.ok is False
     assert result.details["error_code"] == "LOG_DIR_MISSING"
@@ -71,7 +102,9 @@ def test_returns_no_logs_when_directory_empty(tmp_path):
     log_dir = tmp_path / "logs"
     log_dir.mkdir()
 
-    result = snapshot.verify_restic_recent(max_age_hours=24, log_dir=log_dir)
+    result = snapshot.verify_restic_recent(
+        max_age_hours=24, log_dir=log_dir, state_path=_absent_state(tmp_path)
+    )
 
     assert result.ok is False
     assert result.details["error_code"] == "NO_LOGS"
@@ -83,7 +116,9 @@ def test_returns_no_completed_lines_when_log_has_no_success_signature(tmp_path, 
     body = "2026-06-12T03:00:00Z starting restic backup\n2026-06-12T03:05:00Z error: repo unreachable\n"
     _write_log(log_dir, "2026-06-12", body)
 
-    result = snapshot.verify_restic_recent(max_age_hours=24, log_dir=log_dir)
+    result = snapshot.verify_restic_recent(
+        max_age_hours=24, log_dir=log_dir, state_path=_absent_state(tmp_path)
+    )
 
     assert result.ok is False
     assert result.details["error_code"] == "NO_COMPLETED_LINES"
@@ -95,13 +130,17 @@ def test_recognises_alternative_completed_signatures(tmp_path, freeze_now):
     body = "2026-06-12T11:30:00Z backup completed\n"
     _write_log(log_dir, "2026-06-12", body)
 
-    result = snapshot.verify_restic_recent(max_age_hours=24, log_dir=log_dir)
+    result = snapshot.verify_restic_recent(
+        max_age_hours=24, log_dir=log_dir, state_path=_absent_state(tmp_path)
+    )
 
     assert result.ok is True
 
 
 def test_rejects_zero_or_negative_max_age(tmp_path):
-    result = snapshot.verify_restic_recent(max_age_hours=0, log_dir=tmp_path)
+    result = snapshot.verify_restic_recent(
+        max_age_hours=0, log_dir=tmp_path, state_path=_absent_state(tmp_path)
+    )
     assert result.ok is False
     assert result.details["error_code"] == "INVALID_ARGUMENT"
 
@@ -112,7 +151,9 @@ def test_ignores_non_log_filenames(tmp_path, freeze_now):
     (log_dir / "README.md").write_text("not a log", encoding="utf-8")
     freeze_now(_dt.datetime(2026, 6, 12, 12, 0, 0, tzinfo=_dt.timezone.utc))
 
-    result = snapshot.verify_restic_recent(max_age_hours=24, log_dir=log_dir)
+    result = snapshot.verify_restic_recent(
+        max_age_hours=24, log_dir=log_dir, state_path=_absent_state(tmp_path)
+    )
 
     assert result.ok is False
     assert result.details["error_code"] == "NO_LOGS"
@@ -125,7 +166,9 @@ def test_picks_most_recent_log_when_multiple_present(tmp_path, freeze_now):
     _write_log(log_dir, "2026-06-10", "2026-06-10T03:00:00Z snapshot saved\n")  # stale
     _write_log(log_dir, "2026-06-12", "2026-06-12T11:00:00Z snapshot saved\n")  # recent
 
-    result = snapshot.verify_restic_recent(max_age_hours=24, log_dir=log_dir)
+    result = snapshot.verify_restic_recent(
+        max_age_hours=24, log_dir=log_dir, state_path=_absent_state(tmp_path)
+    )
 
     assert result.ok is True
     assert "2026-06-12" in result.details["log_path"]
@@ -156,7 +199,9 @@ def test_bracketed_time_only_line_uses_real_completion_instant(tmp_path, freeze_
     freeze_now(now)
     _write_log(log_dir, "2026-06-12", _REAL_LOG_BODY)  # last completed [03:00:14]
 
-    result = snapshot.verify_restic_recent(max_age_hours=24, log_dir=log_dir)
+    result = snapshot.verify_restic_recent(
+        max_age_hours=24, log_dir=log_dir, state_path=_absent_state(tmp_path)
+    )
 
     assert result.ok is True
     # 12:00:00 - 03:00:14 == 8.996h. Pre-fix this parsed as 23:59:59 EOD →
@@ -177,7 +222,9 @@ def test_bracketed_time_only_recent_snapshot_is_not_negative(tmp_path, freeze_no
     )
     _write_log(log_dir, "2026-06-12", body)
 
-    result = snapshot.verify_restic_recent(max_age_hours=24, log_dir=log_dir)
+    result = snapshot.verify_restic_recent(
+        max_age_hours=24, log_dir=log_dir, state_path=_absent_state(tmp_path)
+    )
 
     assert result.ok is True
     assert result.details["age_hours"] >= 0.0
@@ -193,7 +240,9 @@ def test_bracketed_time_only_too_old_is_detected(tmp_path, freeze_now):
     body = "=== Backup: 2026-06-12 ===\n[03:00:12] Backup completed successfully\n"
     _write_log(log_dir, "2026-06-12", body)  # ~57h before now
 
-    result = snapshot.verify_restic_recent(max_age_hours=24, log_dir=log_dir)
+    result = snapshot.verify_restic_recent(
+        max_age_hours=24, log_dir=log_dir, state_path=_absent_state(tmp_path)
+    )
 
     assert result.ok is False
     assert result.details["error_code"] == "RESTIC_TOO_OLD"
@@ -207,6 +256,288 @@ def test_unparseable_completed_line_still_falls_back_to_end_of_day(tmp_path, fre
     now = _dt.datetime(2026, 6, 12, 23, 0, 0, tzinfo=_dt.timezone.utc)
     freeze_now(now)
     _write_log(log_dir, "2026-06-12", "backup completed\n")  # no timestamp token
-    result = snapshot.verify_restic_recent(max_age_hours=24, log_dir=log_dir)
+    result = snapshot.verify_restic_recent(
+        max_age_hours=24, log_dir=log_dir, state_path=_absent_state(tmp_path)
+    )
     assert result.ok is True
     assert result.details["latest_completed_at"] == "2026-06-12T23:59:59+00:00"
+
+
+# ---------------------------------------------------------------------------
+# #767 — authoritative state-file path. Preferred over the log parse; gives
+# genuine success verification (restic_exit_code) and an exact UTC instant.
+# ---------------------------------------------------------------------------
+
+
+def _state_payload(
+    *,
+    exit_code: int | None = 0,
+    snapshot_ts: str | None = "2026-06-12T03:00:05Z",
+    finished_ts: str | None = "2026-06-12T03:00:13Z",
+) -> dict:
+    payload: dict = {"schema_version": 1}
+    if exit_code is not None:
+        payload["restic_exit_code"] = exit_code
+    if snapshot_ts is not None:
+        payload["snapshot_timestamp_utc"] = snapshot_ts
+    if finished_ts is not None:
+        payload["script_finished_at_utc"] = finished_ts
+    return payload
+
+
+def test_state_file_ok_within_window_uses_snapshot_timestamp(tmp_path, freeze_now):
+    now = _dt.datetime(2026, 6, 12, 12, 0, 0, tzinfo=_dt.timezone.utc)
+    freeze_now(now)
+    state = _write_state(tmp_path, _state_payload(exit_code=0))
+    # A stale LOG in the same call must be ignored — the state file wins.
+    log_dir = tmp_path / "logs"
+    _write_log(log_dir, "2026-06-01", "2026-06-01T03:00:00Z snapshot saved\n")
+
+    result = snapshot.verify_restic_recent(
+        max_age_hours=24, log_dir=log_dir, state_path=state
+    )
+
+    assert result.ok is True
+    assert result.details["source"] == "state"
+    assert result.details["restic_exit_code"] == 0
+    assert result.details["instant_field"] == "snapshot_timestamp_utc"
+    assert result.details["latest_completed_at"] == "2026-06-12T03:00:05+00:00"
+    assert result.details["age_hours"] == pytest.approx(8.999, abs=0.01)
+
+
+def test_state_file_exit_code_3_counts_as_success(tmp_path, freeze_now):
+    """restic exit 3 (snapshot created, some files unreadable) is a valid,
+    restorable snapshot — the system-wide {0, 3} convention."""
+    freeze_now(_dt.datetime(2026, 6, 12, 12, 0, 0, tzinfo=_dt.timezone.utc))
+    state = _write_state(tmp_path, _state_payload(exit_code=3))
+
+    result = snapshot.verify_restic_recent(
+        max_age_hours=24, log_dir=tmp_path / "logs", state_path=state
+    )
+
+    assert result.ok is True
+    assert result.details["restic_exit_code"] == 3
+
+
+def test_state_file_failure_exit_code_blocks_and_does_not_fall_through(tmp_path, freeze_now):
+    """An explicit restic failure must fail the gate — never masked by an
+    older 'completed' log line (the fail-open hole #767 closes)."""
+    freeze_now(_dt.datetime(2026, 6, 12, 12, 0, 0, tzinfo=_dt.timezone.utc))
+    state = _write_state(tmp_path, _state_payload(exit_code=1))
+    # A perfectly fresh, successful-looking log must NOT rescue a failed backup.
+    log_dir = tmp_path / "logs"
+    _write_log(log_dir, "2026-06-12", "2026-06-12T11:59:00Z snapshot saved\n")
+
+    result = snapshot.verify_restic_recent(
+        max_age_hours=24, log_dir=log_dir, state_path=state
+    )
+
+    assert result.ok is False
+    assert result.details["error_code"] == "RESTIC_FAILED"
+    assert result.details["source"] == "state"
+    assert result.details["restic_exit_code"] == 1
+
+
+def test_state_file_too_old_trips_restic_too_old(tmp_path, freeze_now):
+    now = _dt.datetime(2026, 6, 14, 12, 0, 0, tzinfo=_dt.timezone.utc)
+    freeze_now(now)
+    state = _write_state(
+        tmp_path,
+        _state_payload(
+            exit_code=0,
+            snapshot_ts="2026-06-12T03:00:05Z",  # ~57h old
+            finished_ts="2026-06-12T03:00:13Z",
+        ),
+    )
+
+    result = snapshot.verify_restic_recent(
+        max_age_hours=24, log_dir=tmp_path / "logs", state_path=state
+    )
+
+    assert result.ok is False
+    assert result.details["error_code"] == "RESTIC_TOO_OLD"
+    assert result.details["source"] == "state"
+
+
+def test_state_null_snapshot_ts_does_not_anchor_on_script_finished(tmp_path, freeze_now):
+    """#767 review: a good exit code but null snapshot_timestamp_utc must NOT be
+    green-lit off the script-finished witness (the backup-health contract treats
+    a null snapshot instant as unconfirmed). It falls back to the log path."""
+    now = _dt.datetime(2026, 6, 12, 12, 0, 0, tzinfo=_dt.timezone.utc)
+    freeze_now(now)
+    state = _write_state(
+        tmp_path,
+        _state_payload(exit_code=0, snapshot_ts=None, finished_ts="2026-06-12T03:00:13Z"),
+    )
+    log_dir = tmp_path / "logs"
+    _write_log(log_dir, "2026-06-12", "2026-06-12T11:00:00Z snapshot saved\n")
+
+    result = snapshot.verify_restic_recent(
+        max_age_hours=24, log_dir=log_dir, state_path=state
+    )
+
+    assert result.ok is True
+    assert result.details["source"] == "log"
+
+
+def test_state_null_snapshot_ts_and_no_log_fails(tmp_path, freeze_now):
+    """With a null snapshot instant AND no usable log, the gate fails closed —
+    the script-finished witness alone never authorizes the deploy."""
+    now = _dt.datetime(2026, 6, 12, 12, 0, 0, tzinfo=_dt.timezone.utc)
+    freeze_now(now)
+    state = _write_state(
+        tmp_path,
+        _state_payload(exit_code=0, snapshot_ts=None, finished_ts="2026-06-12T03:00:13Z"),
+    )
+
+    result = snapshot.verify_restic_recent(
+        max_age_hours=24, log_dir=tmp_path / "logs", state_path=state
+    )
+
+    assert result.ok is False
+    # Fell through to the log path, which then found no log dir → fails closed.
+    assert result.details["error_code"] == "LOG_DIR_MISSING"
+
+
+def test_state_future_snapshot_ts_fails_closed_no_fallthrough(tmp_path, freeze_now):
+    """#767 review: a snapshot_timestamp_utc in the future beyond skew must fail
+    closed (RESTIC_TIMESTAMP_IN_FUTURE), never read as 'very fresh', and must NOT
+    be rescued by a fresh log line."""
+    now = _dt.datetime(2026, 6, 12, 12, 0, 0, tzinfo=_dt.timezone.utc)
+    freeze_now(now)
+    state = _write_state(
+        tmp_path,
+        _state_payload(exit_code=0, snapshot_ts="2026-06-13T12:00:00Z"),  # +24h
+    )
+    log_dir = tmp_path / "logs"
+    _write_log(log_dir, "2026-06-12", "2026-06-12T11:59:00Z snapshot saved\n")
+
+    result = snapshot.verify_restic_recent(
+        max_age_hours=24, log_dir=log_dir, state_path=state
+    )
+
+    assert result.ok is False
+    assert result.details["error_code"] == "RESTIC_TIMESTAMP_IN_FUTURE"
+    assert result.details["source"] == "state"
+
+
+def test_state_small_future_skew_is_tolerated(tmp_path, freeze_now):
+    """Benign same-host sub-minute future skew is treated as fresh, not rejected."""
+    now = _dt.datetime(2026, 6, 12, 12, 0, 0, tzinfo=_dt.timezone.utc)
+    freeze_now(now)
+    state = _write_state(
+        tmp_path,
+        _state_payload(exit_code=0, snapshot_ts="2026-06-12T12:00:30Z"),  # +30s
+    )
+
+    result = snapshot.verify_restic_recent(
+        max_age_hours=24, log_dir=tmp_path / "logs", state_path=state
+    )
+
+    assert result.ok is True
+    assert result.details["source"] == "state"
+
+
+def test_state_naive_snapshot_ts_falls_back_to_log(tmp_path, freeze_now):
+    """#767 review: a naive (no Z/offset) state timestamp is malformed on the
+    authoritative path — no timezone guessing — and falls back to the log."""
+    now = _dt.datetime(2026, 6, 12, 12, 0, 0, tzinfo=_dt.timezone.utc)
+    freeze_now(now)
+    state = _write_state(
+        tmp_path,
+        _state_payload(exit_code=0, snapshot_ts="2026-06-12T03:00:05"),  # no Z
+    )
+    log_dir = tmp_path / "logs"
+    _write_log(log_dir, "2026-06-12", "2026-06-12T11:00:00Z snapshot saved\n")
+
+    result = snapshot.verify_restic_recent(
+        max_age_hours=24, log_dir=log_dir, state_path=state
+    )
+
+    assert result.ok is True
+    assert result.details["source"] == "log"
+
+
+def test_state_file_missing_falls_back_to_log(tmp_path, freeze_now):
+    now = _dt.datetime(2026, 6, 12, 12, 0, 0, tzinfo=_dt.timezone.utc)
+    freeze_now(now)
+    log_dir = tmp_path / "logs"
+    _write_log(log_dir, "2026-06-12", "2026-06-12T11:00:00Z snapshot saved\n")
+
+    result = snapshot.verify_restic_recent(
+        max_age_hours=24, log_dir=log_dir, state_path=tmp_path / "absent.json"
+    )
+
+    assert result.ok is True
+    assert result.details["source"] == "log"
+
+
+def test_state_file_malformed_json_falls_back_to_log(tmp_path, freeze_now):
+    now = _dt.datetime(2026, 6, 12, 12, 0, 0, tzinfo=_dt.timezone.utc)
+    freeze_now(now)
+    state = _write_state(tmp_path, "{ this is not json")
+    log_dir = tmp_path / "logs"
+    _write_log(log_dir, "2026-06-12", "2026-06-12T11:00:00Z snapshot saved\n")
+
+    result = snapshot.verify_restic_recent(
+        max_age_hours=24, log_dir=log_dir, state_path=state
+    )
+
+    assert result.ok is True
+    assert result.details["source"] == "log"
+
+
+def test_state_file_missing_exit_code_falls_back_to_log(tmp_path, freeze_now):
+    now = _dt.datetime(2026, 6, 12, 12, 0, 0, tzinfo=_dt.timezone.utc)
+    freeze_now(now)
+    state = _write_state(tmp_path, _state_payload(exit_code=None))
+    log_dir = tmp_path / "logs"
+    _write_log(log_dir, "2026-06-12", "2026-06-12T11:00:00Z snapshot saved\n")
+
+    result = snapshot.verify_restic_recent(
+        max_age_hours=24, log_dir=log_dir, state_path=state
+    )
+
+    assert result.ok is True
+    assert result.details["source"] == "log"
+
+
+def test_state_file_no_instant_falls_back_to_log(tmp_path, freeze_now):
+    """exit code says success but neither timestamp is parseable → fall back."""
+    now = _dt.datetime(2026, 6, 12, 12, 0, 0, tzinfo=_dt.timezone.utc)
+    freeze_now(now)
+    state = _write_state(
+        tmp_path, _state_payload(exit_code=0, snapshot_ts=None, finished_ts=None)
+    )
+    log_dir = tmp_path / "logs"
+    _write_log(log_dir, "2026-06-12", "2026-06-12T11:00:00Z snapshot saved\n")
+
+    result = snapshot.verify_restic_recent(
+        max_age_hours=24, log_dir=log_dir, state_path=state
+    )
+
+    assert result.ok is True
+    assert result.details["source"] == "log"
+
+
+def test_state_file_boolean_exit_code_is_rejected(tmp_path, freeze_now):
+    """A JSON ``true`` must not masquerade as exit 1 / ``false`` as exit 0."""
+    now = _dt.datetime(2026, 6, 12, 12, 0, 0, tzinfo=_dt.timezone.utc)
+    freeze_now(now)
+    state = _write_state(
+        tmp_path,
+        {
+            "schema_version": 1,
+            "restic_exit_code": False,
+            "snapshot_timestamp_utc": "2026-06-12T03:00:05Z",
+        },
+    )
+    log_dir = tmp_path / "logs"
+    _write_log(log_dir, "2026-06-12", "2026-06-12T11:00:00Z snapshot saved\n")
+
+    result = snapshot.verify_restic_recent(
+        max_age_hours=24, log_dir=log_dir, state_path=state
+    )
+
+    assert result.ok is True
+    assert result.details["source"] == "log"


### PR DESCRIPTION
## What

Harden `scripts/deploy/lib/snapshot.py::verify_restic_recent` (the recency half of the Tier-2 destructive-deploy gate) to prefer the authoritative driver-written state file `/data/services/backup/state/last-backup.json` over log-marker regex, closing the three fail-open residuals #665 surfaced.

## Behaviour

State file is preferred; log parse retained as defence-in-depth (used only when the state file is absent/malformed). `details["source"]` is `"state"` or `"log"`.

- **Success = `restic_exit_code ∈ {0, 3}`** — genuine success verification. An explicit failure → `RESTIC_FAILED`, and never falls through to a log line that could rescue it.
- **Instant = `snapshot_timestamp_utc` only** (authoritative anchor). Exact UTC instant, no wall-clock/tz guessing.
- **Future-timestamp guard** — a snapshot timestamp beyond a 5-min skew tolerance fails closed (`RESTIC_TIMESTAMP_IN_FUTURE`).
- Backward compatible — new `state_path` param appended; existing no-arg / positional callers unchanged.

## Judgment calls flagged for review (diverge from the issue's literal text)

1. **Success set `{0, 3}`, not the issue's literal `== 0`.** The repo-wide documented convention (service-inventory.json #327, restic-backup-ops.md, pre-flight checklist) treats `restic_exit_code ∉ {0, 3}` as failure; exit 3 = snapshot created, some files unreadable, still restorable. Chosen for system consistency.
2. **`script_finished_at_utc` is NOT used as a freshness anchor** (the issue lists it as an alternate instant). Codex review + the backup-health contract flag that a null `snapshot_timestamp_utc` means "snapshot unconfirmed" → falling back to the log path is the fail-closed, contract-consistent choice. `script_finished_at_utc` is retained in `details` for diagnostics.

Both are the safer / canonical direction; call them out if you'd prefer the strict literal reading.

## Review

Codex adversarial review (primary, full-stdout capture per the corrected #790 procedure) ran on the diff and found three items — future-timestamp fail-open, script_finished rescuing a null instant, naive-UTC acceptance — **all fixed in this PR** (with regression tests).

## Tests / gate

`make test` green (5663 passed); all three validators OK. 13 new state-path tests + existing log-path tests pinned to an absent `state_path` so they stay deterministic on office2 (where the real state file exists).

## Rebaseline

Not required — matches the `deploy-pipeline` audited surface but its `affected_baselines` is `[]` (no security-monitor baseline hashes `scripts/deploy/lib` sources). felix-deployer's observe-range reconciles the self-pull as a no-op.

Closes #767

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014FPqLqLe4pZyrSEEyeLM9H