### PR TITLE
feat(#784): felix-deployer triggers a backup before Tier-2 apply

### DIFF
--- a/docs/design/architecture/backup-and-recovery.md
+++ b/docs/design/architecture/backup-and-recovery.md
@@ -18,6 +18,20 @@ status: approved
 | Effective user | `root` (cron runs `sudo backup.sh`, so snapshots are `root:root`) |
 | Log | `/data/services/backup/logs/backup-YYYY-MM-DD.log` |
 
+### Triggers
+
+`backup.sh` runs from two places, both via the single-command NOPASSWD sudoers
+grant (`claude ALL=(root) NOPASSWD: /data/services/backup/scripts/backup.sh`):
+
+1. **Daily cron** — `claude`'s crontab, `0 4 * * *` (04:00 UTC).
+2. **Pre-deploy trigger (felix-deployer, #784)** — before applying a **Tier-2**
+   manifest, the applier runs `lib.snapshot.ensure_recent_backup`: it verifies a
+   successful snapshot within 24h and, if stale/failed, triggers `sudo
+   backup.sh`, waits, and re-verifies before the destructive change lands. If the
+   trigger or re-verify fails, the manifest is **not applied** (one ntfy alert;
+   manifest stays queued). This closes the gap where a Tier-2 deploy >24h after
+   the last backup could land without a fresh safety net.
+
 ### Backup Sources
 
 | Path | Contents |

--- a/docs/design/architecture/data/data-flows.json
+++ b/docs/design/architecture/data/data-flows.json
@@ -1400,8 +1400,8 @@
       "deployed_by": "pull-based-deploy-pipeline-01KTYQQS (#136)",
       "introduced_by": "pull-based-deploy-pipeline-01KTYQQS (#136)",
       "introduced_at": "2026-06-12",
-      "updated_by": "#136",
-      "last_updated_by": "#136",
+      "updated_by": "#136 + #784 (Tier-2 pre-deploy backup trigger step added)",
+      "last_updated_by": "#784",
       "source": "github.com/kentonium3/kg-automation (main branch)",
       "destination": "office2 (claude user, /home/claude/kg-automation)",
       "transport": "git pull (HTTPS via Tailscale exit node OR public internet)",
@@ -1431,9 +1431,15 @@
         },
         {
           "from": "felix-deployer (office2)",
+          "to": "sudo /data/services/backup/scripts/backup.sh",
+          "protocol": "subprocess (single-command NOPASSWD sudo)",
+          "description": "Tier-2 manifests only (#784): before the dry-run, lib.snapshot.ensure_recent_backup verifies a successful Restic snapshot within 24h and, if stale/failed, triggers backup.sh via the sanctioned NOPASSWD grant, waits, and re-verifies. On trigger or re-verify failure the manifest is NOT applied — a snapshot-phase failure is recorded, one ntfy alert is emitted, and the manifest stays queued."
+        },
+        {
+          "from": "felix-deployer (office2)",
           "to": "deploys/applied/ OR deploys/failed/",
-          "protocol": "file rename (atomic mv)",
-          "description": "On success the manifest moves to deploys/applied/<ts>-<name>.yaml; on failure to deploys/failed/<ts>-<name>.yaml"
+          "protocol": "file write / atomic mv",
+          "description": "On success the queued manifest is recorded as applied under deploys/applied/<NNNN>-<name>.yaml. On failure a failure RECORD is written to deploys/failed/<name>-<ts>.yaml (phase + error_summary) and the queued manifest REMAINS in deploys/queued/ — it is retried (and re-alerts) on the next tick until it succeeds or is removed."
         },
         {
           "from": "felix-deployer (office2)",

--- a/docs/runbooks/deploy/discipline.md
+++ b/docs/runbooks/deploy/discipline.md
@@ -276,8 +276,11 @@ One-line summary per module:
 - `cron` — OpenClaw cron management (`openclaw_cron_list`,
   `openclaw_cron_edit`, `openclaw_cron_add`). Never touches the system
   crontab — that path is closed and CI-enforced.
-- `snapshot` — Restic backup recency check
-  (`verify_restic_recent --max-age-hours <N>`); the canonical Tier 2 gate.
+- `snapshot` — Restic backup recency check + trigger. `verify_restic_recent`
+  confirms a successful snapshot within the window (authoritative
+  `last-backup.json`, log parse as fallback); `ensure_recent_backup` wraps it to
+  trigger `sudo backup.sh` and re-verify when stale (#784). The canonical Tier 2
+  gate.
 - `verify` — file-presence, executability, and content checks for both
   pre-flight (source exists locally) and post-flight (artifact landed on
   office2) verification.
@@ -384,7 +387,7 @@ change to kg-automation. The manifest discipline mirrors it:
 |---|---|
 | **Tier 0 — Hard Lock** | **Never executed via the pipeline.** Tier 0 deploys remain manual via `ssh office2-kgale`. The applier rejects any manifest with `tier: 0` at the tier guard. |
 | **Tier 1 — Verification Required** | Must include a `verification:` block with both `pre:` and `post:` commands proving connectivity / interface health. The applier runs both. |
-| **Tier 2 — Snapshot Required** | Must include a `verification:` block. The applier additionally invokes `lib.snapshot.verify_restic_recent --max-age-hours 24` before the dry-run regardless of what the manifest declares. |
+| **Tier 2 — Snapshot Required** | Must include a `verification:` block. Before the dry-run the applier invokes `lib.snapshot.ensure_recent_backup` (regardless of what the manifest declares): it verifies a successful Restic snapshot within 24h and, if the backup is stale/failed, **triggers the sanctioned `sudo backup.sh`, waits, and re-verifies** (#784). If the trigger or re-verify fails, the manifest is **not applied** — the applier records a `snapshot`-phase failure, emits one ntfy alert, and leaves the manifest queued. |
 | **Tier 3 — Standard** | Manifest + entrypoint script only. No mandatory `verification:` block (though `pre:` / `post:` commands are still encouraged where they catch real failures cheaply). |
 | **Tier 4 — Auto-Commit** | Manifest + entrypoint script only. Lightest path; suited to schema / metadata changes that touch deployed surfaces. |
 

--- a/scripts/deploy/lib/apply.py
+++ b/scripts/deploy/lib/apply.py
@@ -9,8 +9,9 @@ Phase strings (kept here as module-level constants so they cannot drift
 from the contract):
 
 * ``tier_guard`` — :func:`scripts.deploy.lib.tier.tier_guard` failed.
-* ``snapshot`` — :func:`scripts.deploy.lib.snapshot.verify_restic_recent`
-  failed (Tier 2 only).
+* ``snapshot`` — :func:`scripts.deploy.lib.snapshot.ensure_recent_backup`
+  failed (Tier 2 only): the backup was stale/failed and the trigger or
+  re-verify did not produce a fresh successful snapshot.
 * ``verification_pre`` — a ``manifest.verification.pre[*]`` command failed.
 * ``entrypoint_dry_run`` — ``<entrypoint> --dry-run`` failed; apply is
   aborted and the entrypoint is not re-invoked with ``--apply``.
@@ -178,7 +179,8 @@ def dry_run_then_apply_gate(
     The phases (in order) are:
 
     1. ``tier_guard`` — tier policy, mode=runtime.
-    2. ``snapshot`` — Restic recency, only when ``tier == 2``.
+    2. ``snapshot`` — Restic recency (``ensure_recent_backup``: verify, and if
+       stale trigger a backup + re-verify), only when ``tier == 2``.
     3. ``verification_pre`` — every ``verification.pre[]`` command must
        exit 0.
     4. ``entrypoint_dry_run`` — ``<entrypoint> --dry-run`` must exit 0;
@@ -215,9 +217,13 @@ def dry_run_then_apply_gate(
             PHASE_TIER_GUARD,
         )
 
-    # 2. snapshot (Tier 2 only)
+    # 2. snapshot (Tier 2 only). #784: don't merely verify — ensure. If the
+    # backup is stale/failed, trigger the sanctioned backup.sh, wait, and
+    # re-verify before applying. If the trigger or re-verify fails, this returns
+    # ok=False → the manifest is NOT applied and the caller's failure path emits
+    # one ntfy alert and leaves it queued.
     if tier_value == _SNAPSHOT_REQUIRED_TIER:
-        r = snapshot.verify_restic_recent()
+        r = snapshot.ensure_recent_backup()
         if not r.ok:
             return _with_phase(
                 LibResult(

--- a/scripts/deploy/lib/snapshot.py
+++ b/scripts/deploy/lib/snapshot.py
@@ -51,6 +51,8 @@ from __future__ import annotations
 import datetime as _dt
 import json
 import re
+import subprocess
+from collections.abc import Sequence
 from pathlib import Path
 
 from . import LibResult
@@ -59,6 +61,21 @@ DEFAULT_LOG_DIR = Path("/data/services/backup/logs")
 DEFAULT_STATE_PATH = Path("/data/services/backup/state/last-backup.json")
 LOG_PREFIX = "backup-"
 LOG_SUFFIX = ".log"
+
+# Sanctioned Restic backup trigger (#666 / #784). The ``claude`` user on office2
+# holds a single-command NOPASSWD sudoers grant for exactly this path
+# (``claude ALL=(root) NOPASSWD: /data/services/backup/scripts/backup.sh``), so
+# felix-deployer — which runs as ``claude`` — can self-trigger a backup before a
+# Tier-2 apply without any interactive prompt. Kept as an argv tuple (shell=False,
+# no injection surface) and overridable for tests.
+DEFAULT_BACKUP_TRIGGER_CMD: tuple[str, ...] = (
+    "sudo",
+    "/data/services/backup/scripts/backup.sh",
+)
+# backup.sh does a full Restic run; give it a generous ceiling but never hang the
+# deployer tick forever. On timeout the apply is blocked (fail-closed).
+_DEFAULT_BACKUP_TIMEOUT_SEC = 1800
+_BACKUP_STDERR_EXCERPT_MAX = 2000
 
 # Restic exit codes that mean "a snapshot was successfully created":
 #   0 — clean run.
@@ -447,7 +464,154 @@ def verify_restic_recent(
     return _verify_via_logs(max_age_hours, Path(log_dir), now)
 
 
-__all__ = ["verify_restic_recent", "DEFAULT_LOG_DIR", "DEFAULT_STATE_PATH"]
+# ---------------------------------------------------------------------------
+# Backup trigger (#784) — verify → trigger-if-stale → re-verify, so the
+# felix-deployer Tier-2 apply path can guarantee a recent successful snapshot
+# without depending on an agent being in the loop.
+# ---------------------------------------------------------------------------
+
+
+def _invoke_backup(backup_cmd: Sequence[str], timeout_sec: int) -> LibResult:
+    """Run the sanctioned backup trigger and return a LibResult.
+
+    ``shell=False`` (fixed argv, no injection surface). Any spawn failure,
+    non-zero exit, or timeout is a failure — the caller must then NOT apply.
+    """
+    argv = list(backup_cmd)
+    if not argv:
+        return LibResult(
+            ok=False,
+            summary="backup trigger command is empty",
+            details={"error_code": "BACKUP_TRIGGER_SPAWN_FAILED", "backup_cmd": argv},
+        )
+    try:
+        proc = subprocess.run(  # noqa: S603 - fixed argv, no shell
+            argv,
+            capture_output=True,
+            text=True,
+            check=False,
+            timeout=timeout_sec,
+        )
+    except subprocess.TimeoutExpired:
+        return LibResult(
+            ok=False,
+            summary=f"backup trigger timed out after {timeout_sec}s",
+            details={
+                "error_code": "BACKUP_TRIGGER_TIMEOUT",
+                "timeout_sec": timeout_sec,
+                "backup_cmd": argv,
+            },
+        )
+    except OSError as exc:  # FileNotFoundError, permission, etc.
+        return LibResult(
+            ok=False,
+            summary=f"backup trigger could not spawn {argv!r}: {exc}",
+            details={
+                "error_code": "BACKUP_TRIGGER_SPAWN_FAILED",
+                "backup_cmd": argv,
+                "error": str(exc),
+            },
+        )
+    if proc.returncode != 0:
+        stderr = proc.stderr or ""
+        return LibResult(
+            ok=False,
+            summary=f"backup trigger exited {proc.returncode}",
+            details={
+                "error_code": "BACKUP_TRIGGER_FAILED",
+                "returncode": proc.returncode,
+                "backup_cmd": argv,
+                "stderr_excerpt": stderr[:_BACKUP_STDERR_EXCERPT_MAX],
+            },
+        )
+    return LibResult(
+        ok=True,
+        summary="backup triggered successfully",
+        details={"returncode": 0, "backup_cmd": argv},
+    )
+
+
+def ensure_recent_backup(
+    max_age_hours: int = 24,
+    *,
+    log_dir: Path | str = DEFAULT_LOG_DIR,
+    state_path: Path | str = DEFAULT_STATE_PATH,
+    backup_cmd: Sequence[str] = DEFAULT_BACKUP_TRIGGER_CMD,
+    timeout_sec: int = _DEFAULT_BACKUP_TIMEOUT_SEC,
+) -> LibResult:
+    """Guarantee a recent successful Restic snapshot, triggering one if stale.
+
+    The Tier-2 change-control protocol requires a successful backup within
+    *max_age_hours* before a destructive deploy. This is the automated form of
+    the #666 agent flow:
+
+    1. :func:`verify_restic_recent` — if a fresh successful snapshot already
+       exists, return ``ok=True`` with ``details['triggered'] = False`` and do
+       **not** trigger a backup.
+    2. Otherwise (stale / failed / unconfirmed) run *backup_cmd*, wait for it to
+       finish, then re-verify.
+    3. Return the re-verify verdict with ``details['triggered'] = True``. If the
+       trigger process fails (spawn / non-zero / timeout) or the re-verify is
+       still not fresh, return ``ok=False`` — the caller MUST NOT apply (the
+       felix-deployer failure path then emits one ntfy alert and leaves the
+       manifest queued).
+
+    Idempotent by construction: a fresh backup short-circuits before any side
+    effect, so repeated calls within the window never re-trigger.
+    """
+    if max_age_hours <= 0:
+        return LibResult(
+            ok=False,
+            summary="ensure_recent_backup requires max_age_hours > 0",
+            details={"error_code": "INVALID_ARGUMENT"},
+        )
+
+    pre = verify_restic_recent(max_age_hours, log_dir=log_dir, state_path=state_path)
+    if pre.ok:
+        return LibResult(
+            ok=True,
+            summary=f"{pre.summary}; no backup trigger needed",
+            details={**pre.details, "triggered": False},
+        )
+
+    pre_error = pre.details.get("error_code")
+    trigger = _invoke_backup(backup_cmd, timeout_sec)
+    if not trigger.ok:
+        return LibResult(
+            ok=False,
+            summary=f"backup trigger failed; not applying ({trigger.summary})",
+            details={**trigger.details, "triggered": True, "pre_trigger_error": pre_error},
+        )
+
+    post = verify_restic_recent(max_age_hours, log_dir=log_dir, state_path=state_path)
+    if post.ok:
+        return LibResult(
+            ok=True,
+            summary=f"backup triggered and re-verified fresh: {post.summary}",
+            details={**post.details, "triggered": True},
+        )
+    return LibResult(
+        ok=False,
+        summary=(
+            "backup triggered but re-verify is still not fresh; not applying "
+            f"({post.summary})"
+        ),
+        details={
+            **post.details,
+            "triggered": True,
+            "reverify_failed": True,
+            "pre_trigger_error": pre_error,
+        },
+    )
+
+
+__all__ = [
+    "verify_restic_recent",
+    "ensure_recent_backup",
+    "DEFAULT_LOG_DIR",
+    "DEFAULT_STATE_PATH",
+    "DEFAULT_BACKUP_TRIGGER_CMD",
+]
 
 
 # ---------------------------------------------------------------------------
@@ -475,8 +639,33 @@ def _cli_verify_restic_recent(*args: str) -> LibResult:
     return verify_restic_recent(**kwargs)
 
 
+def _cli_ensure_recent_backup(*args: str) -> LibResult:
+    """CLI wrapper: positional ``[max_age_hours] [log_dir] [state_path]``.
+
+    Uses the sanctioned default backup trigger; intended for manual ops and the
+    deployer's Python call path (which invokes :func:`ensure_recent_backup`
+    directly). Triggering a real backup is a side effect — invoke deliberately.
+    """
+    kwargs: dict = {}
+    if len(args) >= 1 and args[0]:
+        try:
+            kwargs["max_age_hours"] = int(args[0])
+        except ValueError:
+            return LibResult(
+                ok=False,
+                summary=f"ensure_recent_backup: max_age_hours must be int, got {args[0]!r}",
+                details={"error_code": "INVALID_ARGUMENT"},
+            )
+    if len(args) >= 2 and args[1]:
+        kwargs["log_dir"] = args[1]
+    if len(args) >= 3 and args[2]:
+        kwargs["state_path"] = args[2]
+    return ensure_recent_backup(**kwargs)
+
+
 _CLI_FUNCS = {
     "verify_restic_recent": _cli_verify_restic_recent,
+    "ensure_recent_backup": _cli_ensure_recent_backup,
 }
 
 

--- a/tests/deploy/test_apply.py
+++ b/tests/deploy/test_apply.py
@@ -157,19 +157,22 @@ def test_phase_tier_guard_failure_on_missing_entrypoint(tmp_path):
 
 
 def test_phase_snapshot_failure_for_tier_2(tmp_path, monkeypatch):
+    """#784: the Tier-2 snapshot phase now goes through ensure_recent_backup.
+    When it can't produce a fresh backup, the apply is blocked at phase=snapshot.
+    """
     ep = _write_entrypoint(tmp_path)
     mani = _tier3_manifest(ep)
     mani["tier"] = 2
     mani["verification"] = {"pre": [], "post": []}
 
-    def _bad_snapshot(*args, **kwargs):
+    def _bad_ensure(*args, **kwargs):
         return LibResult(
             ok=False,
             summary="Restic too old",
             details={"error_code": "RESTIC_TOO_OLD"},
         )
 
-    monkeypatch.setattr(snapshot, "verify_restic_recent", _bad_snapshot)
+    monkeypatch.setattr(snapshot, "ensure_recent_backup", _bad_ensure)
 
     result = apply.dry_run_then_apply_gate(mani, "/fake/path.yaml")
 
@@ -188,12 +191,110 @@ def test_snapshot_not_invoked_for_non_tier_2(tmp_path, monkeypatch):
         sentinel["called"] = True
         return LibResult(ok=True, summary="x")
 
-    monkeypatch.setattr(snapshot, "verify_restic_recent", _spy)
+    monkeypatch.setattr(snapshot, "ensure_recent_backup", _spy)
 
     result = apply.dry_run_then_apply_gate(mani, "/fake/path.yaml")
 
     assert result.ok is True
     assert sentinel["called"] is False
+
+
+# ---------------------------------------------------------------------------
+# #784: Tier-2 pre-deploy backup trigger, exercised end-to-end through
+# dry_run_then_apply_gate. verify_restic_recent + _invoke_backup are stubbed at
+# the module level so no real `sudo backup.sh` is ever spawned.
+# ---------------------------------------------------------------------------
+
+
+def test_tier2_fresh_backup_applies_without_triggering(tmp_path, monkeypatch):
+    ep = _write_entrypoint(tmp_path)
+    mani = _tier3_manifest(ep)
+    mani["tier"] = 2
+    mani["verification"] = {"pre": [], "post": []}
+
+    monkeypatch.setattr(
+        snapshot,
+        "verify_restic_recent",
+        lambda *a, **k: LibResult(ok=True, summary="fresh", details={"source": "state"}),
+    )
+
+    def _boom(*args, **kwargs):  # trigger must NOT be called when already fresh
+        raise AssertionError("backup trigger invoked despite fresh backup")
+
+    monkeypatch.setattr(snapshot, "_invoke_backup", _boom)
+
+    result = apply.dry_run_then_apply_gate(mani, "/fake/path.yaml")
+
+    assert result.ok is True
+    assert result.details["phase"] == apply.PHASE_COMPLETE
+
+
+def test_tier2_stale_backup_triggers_then_applies(tmp_path, monkeypatch):
+    ep = _write_entrypoint(tmp_path)
+    mani = _tier3_manifest(ep)
+    mani["tier"] = 2
+    mani["verification"] = {"pre": [], "post": []}
+
+    calls = {"verify": 0, "trigger": 0}
+
+    def _verify(*args, **kwargs):
+        calls["verify"] += 1
+        # stale on the first (pre) check, fresh on the second (post-trigger).
+        if calls["verify"] == 1:
+            return LibResult(ok=False, summary="stale", details={"error_code": "RESTIC_TOO_OLD"})
+        return LibResult(ok=True, summary="fresh", details={"source": "state"})
+
+    def _trigger(backup_cmd, timeout_sec):
+        calls["trigger"] += 1
+        return LibResult(ok=True, summary="triggered", details={"returncode": 0})
+
+    monkeypatch.setattr(snapshot, "verify_restic_recent", _verify)
+    monkeypatch.setattr(snapshot, "_invoke_backup", _trigger)
+
+    result = apply.dry_run_then_apply_gate(mani, "/fake/path.yaml")
+
+    assert result.ok is True
+    assert result.details["phase"] == apply.PHASE_COMPLETE
+    assert calls["trigger"] == 1
+    assert calls["verify"] == 2
+
+
+def test_tier2_failed_trigger_blocks_apply(tmp_path, monkeypatch):
+    ep = _write_entrypoint(tmp_path)
+    mani = _tier3_manifest(ep)
+    mani["tier"] = 2
+    mani["verification"] = {"pre": [], "post": []}
+
+    entrypoint_called = {"hit": False}
+
+    def _verify(*args, **kwargs):
+        return LibResult(ok=False, summary="stale", details={"error_code": "RESTIC_TOO_OLD"})
+
+    def _trigger(backup_cmd, timeout_sec):
+        return LibResult(
+            ok=False,
+            summary="trigger failed",
+            details={"error_code": "BACKUP_TRIGGER_FAILED", "returncode": 1},
+        )
+
+    # If the entrypoint ever runs, the apply wasn't blocked — catch that.
+    real_run = apply._run_shell
+
+    def _guard_run(cmd, *a, **k):
+        entrypoint_called["hit"] = True
+        return real_run(cmd, *a, **k)
+
+    monkeypatch.setattr(snapshot, "verify_restic_recent", _verify)
+    monkeypatch.setattr(snapshot, "_invoke_backup", _trigger)
+    monkeypatch.setattr(apply, "_run_shell", _guard_run)
+
+    result = apply.dry_run_then_apply_gate(mani, "/fake/path.yaml")
+
+    assert result.ok is False
+    assert result.details["phase"] == apply.PHASE_SNAPSHOT
+    assert result.details["error_code"] == "BACKUP_TRIGGER_FAILED"
+    assert result.details["triggered"] is True
+    assert entrypoint_called["hit"] is False  # apply never reached
 
 
 # ---------------------------------------------------------------------------

--- a/tests/deploy/test_snapshot.py
+++ b/tests/deploy/test_snapshot.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import datetime as _dt
 import json
+import subprocess
 from pathlib import Path
 
 import pytest
@@ -541,3 +542,200 @@ def test_state_file_boolean_exit_code_is_rejected(tmp_path, freeze_now):
 
     assert result.ok is True
     assert result.details["source"] == "log"
+
+
+# ---------------------------------------------------------------------------
+# #784 — ensure_recent_backup: verify → trigger-if-stale → re-verify. The real
+# `sudo backup.sh` is never spawned here; the trigger is either injected via
+# `backup_cmd` (a harmless local command) or stubbed at the module level.
+# ---------------------------------------------------------------------------
+
+
+def test_ensure_fresh_backup_does_not_trigger(tmp_path, freeze_now, monkeypatch):
+    """A fresh successful state file short-circuits — no backup is triggered."""
+    now = _dt.datetime(2026, 6, 12, 12, 0, 0, tzinfo=_dt.timezone.utc)
+    freeze_now(now)
+    state = _write_state(tmp_path, _state_payload(exit_code=0))
+
+    def _boom(*args, **kwargs):
+        raise AssertionError("_invoke_backup called despite a fresh backup")
+
+    monkeypatch.setattr(snapshot, "_invoke_backup", _boom)
+
+    result = snapshot.ensure_recent_backup(
+        max_age_hours=24, log_dir=tmp_path / "logs", state_path=state
+    )
+
+    assert result.ok is True
+    assert result.details["triggered"] is False
+    assert result.details["source"] == "state"
+
+
+def test_ensure_stale_backup_triggers_then_reverifies_fresh(tmp_path, freeze_now, monkeypatch):
+    """Stale → trigger (injected harmless cmd) → the trigger makes the state
+    fresh → re-verify passes. We simulate the state transition by rewriting the
+    state file inside the injected trigger."""
+    now = _dt.datetime(2026, 6, 12, 12, 0, 0, tzinfo=_dt.timezone.utc)
+    freeze_now(now)
+    state = _write_state(
+        tmp_path, _state_payload(exit_code=0, snapshot_ts="2026-06-01T03:00:00Z")  # stale
+    )
+    triggered = {"count": 0}
+
+    def _fake_trigger(backup_cmd, timeout_sec):
+        triggered["count"] += 1
+        # emulate backup.sh writing a fresh state file
+        _write_state(tmp_path, _state_payload(exit_code=0, snapshot_ts="2026-06-12T11:59:00Z"))
+        return LibResult(ok=True, summary="triggered", details={"returncode": 0})
+
+    monkeypatch.setattr(snapshot, "_invoke_backup", _fake_trigger)
+
+    result = snapshot.ensure_recent_backup(
+        max_age_hours=24, log_dir=tmp_path / "logs", state_path=state
+    )
+
+    assert result.ok is True
+    assert result.details["triggered"] is True
+    assert result.details["source"] == "state"
+    assert triggered["count"] == 1
+
+
+def test_ensure_failed_trigger_blocks(tmp_path, freeze_now, monkeypatch):
+    """A failed trigger returns ok=False (apply must be blocked)."""
+    now = _dt.datetime(2026, 6, 12, 12, 0, 0, tzinfo=_dt.timezone.utc)
+    freeze_now(now)
+    state = _write_state(
+        tmp_path, _state_payload(exit_code=0, snapshot_ts="2026-06-01T03:00:00Z")  # stale
+    )
+
+    def _fail_trigger(backup_cmd, timeout_sec):
+        return LibResult(
+            ok=False,
+            summary="boom",
+            details={"error_code": "BACKUP_TRIGGER_FAILED", "returncode": 2},
+        )
+
+    monkeypatch.setattr(snapshot, "_invoke_backup", _fail_trigger)
+
+    result = snapshot.ensure_recent_backup(
+        max_age_hours=24, log_dir=tmp_path / "logs", state_path=state
+    )
+
+    assert result.ok is False
+    assert result.details["error_code"] == "BACKUP_TRIGGER_FAILED"
+    assert result.details["triggered"] is True
+    assert result.details["pre_trigger_error"] == "RESTIC_TOO_OLD"
+
+
+def test_ensure_trigger_ok_but_reverify_still_stale_blocks(tmp_path, freeze_now, monkeypatch):
+    """Trigger succeeds but re-verify is still not fresh (e.g. backup produced no
+    snapshot) → ok=False, apply blocked, reverify_failed flagged."""
+    now = _dt.datetime(2026, 6, 12, 12, 0, 0, tzinfo=_dt.timezone.utc)
+    freeze_now(now)
+    state = _write_state(
+        tmp_path, _state_payload(exit_code=0, snapshot_ts="2026-06-01T03:00:00Z")  # stale
+    )
+
+    def _noop_trigger(backup_cmd, timeout_sec):
+        return LibResult(ok=True, summary="triggered", details={"returncode": 0})
+
+    monkeypatch.setattr(snapshot, "_invoke_backup", _noop_trigger)
+
+    result = snapshot.ensure_recent_backup(
+        max_age_hours=24, log_dir=tmp_path / "logs", state_path=state
+    )
+
+    assert result.ok is False
+    assert result.details["error_code"] == "RESTIC_TOO_OLD"
+    assert result.details["triggered"] is True
+    assert result.details["reverify_failed"] is True
+
+
+def test_ensure_rejects_zero_max_age(tmp_path):
+    result = snapshot.ensure_recent_backup(
+        max_age_hours=0, log_dir=tmp_path / "logs", state_path=tmp_path / "s.json"
+    )
+    assert result.ok is False
+    assert result.details["error_code"] == "INVALID_ARGUMENT"
+
+
+def test_ensure_stale_triggers_real_local_command(tmp_path, freeze_now):
+    """End-to-end trigger path with a real (harmless) subprocess: `true` exits 0.
+    Re-verify then still stale (the state file is untouched) → blocked. Proves
+    _invoke_backup actually spawns and the wiring holds without stubbing it."""
+    now = _dt.datetime(2026, 6, 12, 12, 0, 0, tzinfo=_dt.timezone.utc)
+    freeze_now(now)
+    state = _write_state(
+        tmp_path, _state_payload(exit_code=0, snapshot_ts="2026-06-01T03:00:00Z")  # stale
+    )
+
+    result = snapshot.ensure_recent_backup(
+        max_age_hours=24,
+        log_dir=tmp_path / "logs",
+        state_path=state,
+        backup_cmd=["true"],
+    )
+
+    assert result.ok is False  # `true` doesn't refresh the state → still stale
+    assert result.details["triggered"] is True
+    assert result.details["reverify_failed"] is True
+
+
+def test_invoke_backup_nonzero_exit_is_failure():
+    result = snapshot._invoke_backup(["false"], timeout_sec=30)
+    assert result.ok is False
+    assert result.details["error_code"] == "BACKUP_TRIGGER_FAILED"
+    assert result.details["returncode"] != 0
+
+
+def test_invoke_backup_missing_binary_is_spawn_failure():
+    result = snapshot._invoke_backup(
+        ["/nonexistent/path/backup.sh"], timeout_sec=30
+    )
+    assert result.ok is False
+    assert result.details["error_code"] == "BACKUP_TRIGGER_SPAWN_FAILED"
+
+
+def test_invoke_backup_success():
+    result = snapshot._invoke_backup(["true"], timeout_sec=30)
+    assert result.ok is True
+    assert result.details["returncode"] == 0
+
+
+def test_invoke_backup_timeout_is_failure(monkeypatch):
+    """#784 review: a backup.sh that overruns the timeout must fail closed with
+    BACKUP_TRIGGER_TIMEOUT (this gates destructive Tier-2 deploys)."""
+
+    def _raise_timeout(*args, **kwargs):
+        raise subprocess.TimeoutExpired(cmd=args[0] if args else "backup", timeout=kwargs.get("timeout", 0))
+
+    monkeypatch.setattr(snapshot.subprocess, "run", _raise_timeout)
+
+    result = snapshot._invoke_backup(["/data/services/backup/scripts/backup.sh"], timeout_sec=1)
+
+    assert result.ok is False
+    assert result.details["error_code"] == "BACKUP_TRIGGER_TIMEOUT"
+    assert result.details["timeout_sec"] == 1
+
+
+def test_ensure_backup_timeout_blocks_apply(tmp_path, freeze_now, monkeypatch):
+    """A trigger timeout propagates as a snapshot-blocking failure from
+    ensure_recent_backup (triggered=True, ok=False)."""
+    now = _dt.datetime(2026, 6, 12, 12, 0, 0, tzinfo=_dt.timezone.utc)
+    freeze_now(now)
+    state = _write_state(
+        tmp_path, _state_payload(exit_code=0, snapshot_ts="2026-06-01T03:00:00Z")  # stale
+    )
+
+    def _raise_timeout(*args, **kwargs):
+        raise subprocess.TimeoutExpired(cmd="backup", timeout=1)
+
+    monkeypatch.setattr(snapshot.subprocess, "run", _raise_timeout)
+
+    result = snapshot.ensure_recent_backup(
+        max_age_hours=24, log_dir=tmp_path / "logs", state_path=state, timeout_sec=1
+    )
+
+    assert result.ok is False
+    assert result.details["error_code"] == "BACKUP_TRIGGER_TIMEOUT"
+    assert result.details["triggered"] is True


### PR DESCRIPTION
## What

Codify the pre-deploy backup trigger into the **automated** felix-deployer Tier-2 apply path (the #666 agent flow, minus the agent). Before applying a **Tier-2** manifest, the applier now *ensures* a fresh successful backup rather than merely verifying one.

## Behaviour (`snapshot.ensure_recent_backup`, wired into `apply.dry_run_then_apply_gate` step 2)

1. Verify via the #767-hardened `verify_restic_recent`. Fresh (<24h, successful) → proceed, no trigger (`triggered=False`).
2. Stale/failed → trigger `sudo /data/services/backup/scripts/backup.sh` (claude's single-command NOPASSWD grant), wait, re-verify.
3. Trigger fails OR re-verify still not fresh → `ok=False` at `phase=snapshot` → **manifest NOT applied**; felix-deployer writes a failure record, emits one ntfy alert, and leaves it queued (retried next tick).

Tier-1 manifests unaffected. `_invoke_backup` is `shell=False` (fixed argv); non-zero exit, spawn failure, empty command, and timeout are all fail-closed. Idempotent — a fresh backup short-circuits before any side effect.

## Review

Codex adversarial review (primary, full-stdout capture) — **no fail-open found**; the Tier-2 gate runs before pre-verify/dry-run/apply and returns immediately on failure. Its two Low findings are fixed in this PR:
- Added a `TimeoutExpired` test (timeout → `BACKUP_TRIGGER_TIMEOUT`, blocks apply).
- Corrected `data-flows.json`: a failed manifest writes a failure *record* under `deploys/failed/` and **stays queued** (retried) — it is not moved there (verified against `_tick.py`).

## Tests / gate

`make test` green (5677 passed); validators OK. The three issue scenarios (fresh→no trigger, stale→trigger→apply, failed-trigger→block) are exercised end-to-end through `dry_run_then_apply_gate` — a real `sudo backup.sh` is never spawned (trigger stubbed/injected everywhere).

## Docs / architecture

- `backup-and-recovery.md` — documents the two backup triggers (daily cron + deployer pre-deploy).
- `deploy/discipline.md` — Tier-2 gate is now trigger-if-stale.
- `data-flows.json` — added the deployer→`backup.sh` Tier-2 step; corrected the applied/failed step.

## Rebaseline

Not required — `scripts/deploy/lib` matches the `deploy-pipeline` audited surface but its `affected_baselines` is `[]`; felix-deployer's observe-range reconciles the self-pull as a no-op.

Closes #784

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014FPqLqLe4pZyrSEEyeLM9H