### PR TITLE
fix(#751): provenance precheck makes in-process someday/vikunja create idempotent

### DIFF
--- a/scripts/inbox/route_and_finalize.py
+++ b/scripts/inbox/route_and_finalize.py
@@ -132,15 +132,103 @@ def _invoke_mark_processed(source_path: str) -> "subprocess.CompletedProcess[str
 
 
 def _create_vikunja_task(
-    title: str, body: str, note_filename: str, project: str
+    title: str, body: str, note_filename: str, project: str, block_key: str
 ) -> int:
     """Create a ``q:schedule`` + no-due-date Vikunja task; return its id.
 
     Thin seam over ``route_someday.route_someday`` (the durable-landing creator)
     so the in-process ``someday`` / ``vikunja_task`` paths share one create
-    implementation and tests can monkeypatch this single call site.
+    implementation and tests can monkeypatch this single call site. ``block_key``
+    is written into the task's ``Block:`` provenance footer so a later tick can
+    find this exact block's task before re-creating it (#751).
     """
-    return route_someday.route_someday(title, body, note_filename, project)
+    return route_someday.route_someday(
+        title, body, note_filename, project, block_key=block_key
+    )
+
+
+def _iter_all_tasks(client: VikunjaClient) -> "list[dict]":
+    """Return every task via the paginated ``GET /tasks/all`` (client-side scan).
+
+    Vikunja caps ``/tasks/all`` at 50 per page and rejects several server-side
+    ``?filter=`` expressions (G6/G7), so the #751 provenance precheck reads the
+    full list and filters in Python. ``MAX_PAGES`` is a runaway-loop bound.
+    """
+    PAGE_SIZE = 50
+    MAX_PAGES = 200
+    out: list[dict] = []
+    for page in range(1, MAX_PAGES + 1):
+        batch = client.get("/tasks/all", params={"page": page, "per_page": PAGE_SIZE})
+        # Vikunja returns JSON ``null`` (not ``[]``) for an empty collection /
+        # exhausted page on this endpoint. Treat it as an empty page — the
+        # end of pagination — NOT a scan error: raising here would fail the
+        # precheck closed on an empty task list and strand the note (silent
+        # loss). A genuine HTTP failure surfaces as an exception from ``.get``.
+        if batch is None:
+            break
+        if not isinstance(batch, list):
+            raise VikunjaError(
+                f"GET /tasks/all page {page} returned non-list body: {type(batch).__name__!r}"
+            )
+        if not batch:
+            break
+        out.extend(b for b in batch if isinstance(b, dict))
+        if len(batch) < PAGE_SIZE:
+            break
+    else:
+        raise VikunjaError(
+            f"GET /tasks/all hit page cap ({MAX_PAGES}); refusing an unbounded scan"
+        )
+    return out
+
+
+def _match_provenance(
+    tasks: "list[dict]", note_filename: str, block_key: str
+) -> Optional[dict]:
+    """Return the lowest-id task carrying this note+block's provenance, or ``None``.
+
+    A match requires BOTH the exact ``Source: <note_filename>`` line AND the exact
+    ``Block: <block_key>`` line in the task description (line-anchored, like the
+    delegated provenance match — a substring test would false-match ``Inbox 1.md``
+    inside ``Source: Inbox 10.md``). Lowest-id-wins makes a (pathological)
+    pre-existing double-create converge on one task across ticks. Pure function
+    over an already-fetched task list (the network seam is :func:`_iter_all_tasks`).
+    """
+    source_line = f"Source: {note_filename}"
+    block_line = f"Block: {block_key}"
+    matches: list[dict] = []
+    for task in tasks:
+        if not isinstance(task, dict):
+            continue
+        description = task.get("description")
+        if not isinstance(description, str) or not description:
+            continue
+        lines = [ln.rstrip() for ln in description.splitlines()]
+        if source_line in lines and block_line in lines:
+            matches.append(task)
+    if not matches:
+        return None
+    matches.sort(key=lambda t: int(t.get("id", 0)))
+    return matches[0]
+
+
+def _find_existing_task_by_provenance(
+    note_filename: str, block_key: str
+) -> Optional[dict]:
+    """Return an existing task created for this exact note+block, or ``None``.
+
+    The #751 idempotency precheck: before an in-process ``someday`` /
+    ``vikunja_task`` create, scan all tasks for one whose description carries this
+    note+block's provenance. If a prior tick created the task but failed before
+    logging, this finds it so the block is reused (verified + logged) rather than
+    re-created — closing the create→verify/log-failure orphan window.
+
+    Raises ``VikunjaError`` / ``ConnectionError`` on a scan failure so the caller
+    can fail **closed** (never create when we could not check for an existing
+    task).
+    """
+    client = VikunjaClient()
+    return _match_provenance(_iter_all_tasks(client), note_filename, block_key)
 
 
 def _fetch_vikunja_task(task_id: int) -> dict:
@@ -316,19 +404,59 @@ def _adapt_calendar(
     )
 
 
+def _block_provenance_key(block: dict) -> str:
+    """The per-block provenance token embedded in the task's ``Block:`` footer.
+
+    ``<block_index>:<block_key_hash>`` — mirrors the routing-log idempotency key
+    (filename, block_index, block_hash) so two identical-content blocks in one
+    note (same hash, different index) map to two distinct tasks, and the token is
+    stable across ticks (the property the precheck relies on).
+    """
+    return f"{block.get('block_index')}:{_block_key_hash(block)}"
+
+
 def _create_and_verify_task(
     block: dict, note_filename: str, kind: str
 ) -> tuple[str, dict, Optional[dict]]:
-    """In-process create (someday / vikunja_task) then verify the id resolves."""
+    """In-process create (someday / vikunja_task) then verify the id resolves.
+
+    #751: before the create, run a provenance precheck — if a task for this exact
+    note+block already exists (a prior tick created it but failed before logging),
+    reuse it instead of creating a duplicate. The scan failing-closed (never
+    create when we could not check) preserves the no-double-create guarantee.
+    """
     payload = block.get("payload") if isinstance(block.get("payload"), dict) else {}
     title = payload.get("title")
     if not isinstance(title, str) or not title.strip():
         return "error", {"stage": "route", "error": "missing task title"}, None
     body = payload.get("body", "") if isinstance(payload.get("body", ""), str) else ""
     project = payload.get("project", "inbox") or "inbox"
+    block_key = _block_provenance_key(block)
+
+    # Provenance precheck (idempotency BEFORE the create side effect). A scan
+    # failure fails the block CLOSED — we never create a task we could not first
+    # check for, so a transient outage can never orphan a duplicate.
+    try:
+        existing = _find_existing_task_by_provenance(note_filename, block_key)
+    except (VikunjaError, ConnectionError, ValueError) as exc:
+        return "error", {"stage": "precheck", "error": str(exc)}, None
+
+    if existing is not None:
+        task_id = int(existing.get("id", 0))
+        if task_id <= 0:
+            return (
+                "error",
+                {"stage": "precheck", "error": "matched task has no usable id"},
+                None,
+            )
+        return (
+            "routed",
+            {"artifact": str(task_id), "deduped": True},
+            {"kind": kind, "destination": str(task_id), "vikunja_task_id": task_id},
+        )
 
     try:
-        task_id = _create_vikunja_task(title, body, note_filename, project)
+        task_id = _create_vikunja_task(title, body, note_filename, project, block_key)
     except route_someday.RouteSomedayError as exc:
         return "error", {"stage": "route", "error": str(exc)}, None
 

--- a/scripts/inbox/route_someday.py
+++ b/scripts/inbox/route_someday.py
@@ -168,6 +168,7 @@ def route_someday(
     body: str,
     note_filename: str,
     project: str = DEFAULT_PROJECT_NAME,
+    block_key: str | None = None,
 ) -> int:
     """Create a ``q:schedule`` + no-due-date task and return its id.
 
@@ -178,6 +179,15 @@ def route_someday(
     underlying Vikunja / network / registry failure) on any *hard* error path so
     the CLI ``main`` maps it to a single exit code + structured stderr. A soft
     label-attach failure does not raise — the task is already created.
+
+    When ``block_key`` is supplied, a second footer line ``Block: <block_key>``
+    is written below ``Source: <note_filename>`` so a caller can look the task up
+    by its originating note **and** the specific block within it (the #751
+    provenance precheck — makes an in-process create idempotent *before* the side
+    effect). The ``Source:`` line is left byte-for-byte intact so the delegated
+    provenance-match path (which matches the exact ``Source:`` line) is
+    unaffected. ``block_key`` defaults to ``None`` (no ``Block:`` line) so the
+    CLI and any legacy caller are unchanged.
     """
     try:
         client = VikunjaClient()
@@ -188,6 +198,8 @@ def route_someday(
     project_id = _resolve_destination_project_id(project)
 
     description = f"{body}\n\nSource: {note_filename}"
+    if block_key:
+        description = f"{description}\nBlock: {block_key}"
     # No due date: the "someday" state is important-but-not-date-committed.
     payload = {
         "title": title,
@@ -246,6 +258,15 @@ def _build_parser() -> argparse.ArgumentParser:
             f"the task in. Default: {DEFAULT_PROJECT_NAME!r} (the fall-through bucket)."
         ),
     )
+    parser.add_argument(
+        "--block-key",
+        default=None,
+        help=(
+            "Optional per-block provenance token; when set, a 'Block: <key>' "
+            "footer line is added below 'Source:' so the task can be looked up by "
+            "its originating block (the #751 idempotency precheck)."
+        ),
+    )
     return parser
 
 
@@ -267,6 +288,7 @@ def main(argv: list[str] | None = None) -> int:
             body=args.body,
             note_filename=args.note_filename,
             project=args.project,
+            block_key=args.block_key,
         )
     except RouteSomedayError as exc:
         _emit_error(str(exc))

--- a/tests/inbox/test_route_and_finalize.py
+++ b/tests/inbox/test_route_and_finalize.py
@@ -33,6 +33,17 @@ from scripts.inbox import routing_log as _routing_log
 # ---------------------------------------------------------------------------
 
 
+@pytest.fixture(autouse=True)
+def _no_existing_task(monkeypatch):
+    """#751: default the in-process provenance precheck to 'no existing task' so
+    the create path behaves as before. Tests that exercise the reconcile/reuse
+    path override this with their own store-scanning stub. (The delegated
+    vikunja_task path never calls the precheck.)"""
+    monkeypatch.setattr(
+        raf, "_find_existing_task_by_provenance", lambda *a, **k: None
+    )
+
+
 def _write_plan(tmp_path: Path, plan: dict | str, name: str = "plan.json") -> Path:
     target = tmp_path / name
     if isinstance(plan, str):
@@ -220,6 +231,243 @@ class TestSomeday:
         assert create_calls["n"] == 1, "must NOT re-create the task on retry"
         assert ok_mark.calls == ["/inbox/Note.md"]
         assert len(_log_rows(log_path)) == 1, "no duplicate routing-log row"
+
+    # -- #751: the create→verify / create→log failure windows ---------------
+    #
+    # These are the windows the routing-log skip does NOT cover: the create
+    # succeeds but the tick dies BEFORE the routing-log row is written (verify
+    # fails, or the log append itself fails). Without the provenance precheck the
+    # next tick re-creates → orphan. With it, the next tick finds the task the
+    # prior tick created and reuses it (no double-create).
+
+    def _install_store(self, monkeypatch):
+        """Wire the create + precheck seams to a shared in-memory Vikunja 'world'.
+
+        create appends a task whose description carries the SAME Source/Block
+        footer route_someday writes; the precheck runs the REAL line-anchored
+        matcher over the store. Returns (store, create_calls)."""
+        store: list[dict] = []
+        create_calls = {"n": 0}
+        next_id = {"v": 900}
+
+        def fake_create(title, body, note_filename, project, block_key):
+            create_calls["n"] += 1
+            next_id["v"] += 1
+            store.append(
+                {
+                    "id": next_id["v"],
+                    "description": f"{body}\n\nSource: {note_filename}\nBlock: {block_key}",
+                }
+            )
+            return next_id["v"]
+
+        def fake_find(note_filename, block_key):
+            return raf._match_provenance(store, note_filename, block_key)
+
+        monkeypatch.setattr(raf, "_create_vikunja_task", fake_create)
+        monkeypatch.setattr(raf, "_find_existing_task_by_provenance", fake_find)
+        return store, create_calls
+
+    def test_retry_no_double_create_after_verify_failure(
+        self, tmp_path, capsys, monkeypatch, log_path
+    ):
+        """Tick 1: create succeeds, VERIFY fails (task never logged). Tick 2: the
+        precheck finds the task tick 1 created and reuses it — no second create."""
+        store, create_calls = self._install_store(monkeypatch)
+        pf = _write_plan(tmp_path, self._plan())
+
+        # Tick 1: fetch returns a non-matching id → verify failure. The task IS
+        # created (and lands in `store`) but the block is never logged.
+        monkeypatch.setattr(raf, "_fetch_vikunja_task", lambda tid: {})
+        mark1 = _MarkSpy()
+        monkeypatch.setattr(raf, "_invoke_mark_processed", mark1)
+        code, out, _ = _run(
+            ["--source-path", "/inbox/Note.md", "--plan-file", str(pf)], capsys
+        )
+        assert code == 1
+        assert json.loads(out)["blocks"][0]["stage"] == "verify"
+        assert create_calls["n"] == 1
+        assert len(store) == 1  # the orphan-risk task exists
+        assert mark1.calls == []
+        assert _log_rows(log_path) == []
+
+        # Tick 2: verify now resolves. The precheck must find the tick-1 task and
+        # REUSE it (deduped) rather than create a second one.
+        monkeypatch.setattr(
+            raf, "_fetch_vikunja_task", lambda tid: {"id": tid}
+        )
+        mark2 = _MarkSpy()
+        monkeypatch.setattr(raf, "_invoke_mark_processed", mark2)
+        code, out, _ = _run(
+            ["--source-path", "/inbox/Note.md", "--plan-file", str(pf)], capsys
+        )
+        result = json.loads(out)
+        assert code == 0, out
+        assert result["status"] == "finalized"
+        assert result["blocks"][0].get("deduped") is True
+        assert create_calls["n"] == 1, "must NOT re-create; the tick-1 task is reused"
+        assert len(store) == 1, "no duplicate task created"
+        assert mark2.calls == ["/inbox/Note.md"]
+        rows = _log_rows(log_path)
+        assert len(rows) == 1
+        assert rows[0]["vikunja_task_id"] == 901
+
+    def test_retry_no_double_create_after_log_failure(
+        self, tmp_path, capsys, monkeypatch, log_path
+    ):
+        """Tick 1: create + verify succeed but the routing-log APPEND fails (block
+        never logged). Tick 2: the precheck finds the task and reuses it."""
+        store, create_calls = self._install_store(monkeypatch)
+        monkeypatch.setattr(raf, "_fetch_vikunja_task", lambda tid: {"id": tid})
+        pf = _write_plan(tmp_path, self._plan())
+
+        # Tick 1: force the routing-log append to fail AFTER create+verify.
+        real_append = raf.RoutingLogWriter.append
+
+        def boom_append(self, *a, **k):
+            raise OSError("disk full")
+
+        monkeypatch.setattr(raf.RoutingLogWriter, "append", boom_append)
+        mark1 = _MarkSpy()
+        monkeypatch.setattr(raf, "_invoke_mark_processed", mark1)
+        code, out, _ = _run(
+            ["--source-path", "/inbox/Note.md", "--plan-file", str(pf)], capsys
+        )
+        assert code == 1
+        assert json.loads(out)["blocks"][0]["stage"] == "log"
+        assert create_calls["n"] == 1
+        assert len(store) == 1
+        assert mark1.calls == []
+        assert _log_rows(log_path) == []
+
+        # Tick 2: log append works again. Precheck finds the tick-1 task → reuse.
+        monkeypatch.setattr(raf.RoutingLogWriter, "append", real_append)
+        mark2 = _MarkSpy()
+        monkeypatch.setattr(raf, "_invoke_mark_processed", mark2)
+        code, out, _ = _run(
+            ["--source-path", "/inbox/Note.md", "--plan-file", str(pf)], capsys
+        )
+        result = json.loads(out)
+        assert code == 0, out
+        assert result["status"] == "finalized"
+        assert result["blocks"][0].get("deduped") is True
+        assert create_calls["n"] == 1, "must NOT re-create; the tick-1 task is reused"
+        assert len(store) == 1
+        assert mark2.calls == ["/inbox/Note.md"]
+        assert len(_log_rows(log_path)) == 1
+
+    def test_precheck_scan_failure_fails_closed_no_create(
+        self, tmp_path, capsys, monkeypatch, log_path
+    ):
+        """If the precheck scan itself errors, the block fails CLOSED — no task is
+        created (never create when we could not first check for an existing one)."""
+        from scripts.common.vikunja_client import VikunjaError
+
+        def boom_find(note_filename, block_key):
+            raise VikunjaError("tasks/all unreachable")
+
+        created = {"n": 0}
+
+        def must_not_create(*a, **k):
+            created["n"] += 1
+            return 512
+
+        monkeypatch.setattr(raf, "_find_existing_task_by_provenance", boom_find)
+        monkeypatch.setattr(raf, "_create_vikunja_task", must_not_create)
+        mark = _MarkSpy()
+        monkeypatch.setattr(raf, "_invoke_mark_processed", mark)
+
+        pf = _write_plan(tmp_path, self._plan())
+        code, out, _ = _run(
+            ["--source-path", "/inbox/Note.md", "--plan-file", str(pf)], capsys
+        )
+        assert code == 1
+        assert json.loads(out)["blocks"][0]["stage"] == "precheck"
+        assert created["n"] == 0, "must NOT create when the precheck could not run"
+        assert mark.calls == []
+        assert _log_rows(log_path) == []
+
+
+# ===========================================================================
+# #751: the pure provenance matcher (_match_provenance)
+# ===========================================================================
+
+
+class TestMatchProvenance:
+    def _task(self, tid, note, block):
+        return {"id": tid, "description": f"body\n\nSource: {note}\nBlock: {block}"}
+
+    def test_matches_on_both_source_and_block(self):
+        tasks = [self._task(10, "Note.md", "0:hash0")]
+        m = raf._match_provenance(tasks, "Note.md", "0:hash0")
+        assert m is not None and m["id"] == 10
+
+    def test_no_match_when_block_key_differs(self):
+        tasks = [self._task(10, "Note.md", "0:hash0")]
+        assert raf._match_provenance(tasks, "Note.md", "1:hash1") is None
+
+    def test_no_match_when_source_differs(self):
+        tasks = [self._task(10, "Other.md", "0:hash0")]
+        assert raf._match_provenance(tasks, "Note.md", "0:hash0") is None
+
+    def test_source_is_line_anchored_not_substring(self):
+        # A task belonging to "Inbox 10.md" must not match "Inbox 1.md".
+        tasks = [self._task(10, "Inbox 10.md", "0:hash0")]
+        assert raf._match_provenance(tasks, "Inbox 1.md", "0:hash0") is None
+
+    def test_lowest_id_wins_on_duplicate(self):
+        tasks = [
+            self._task(30, "Note.md", "0:h"),
+            self._task(11, "Note.md", "0:h"),
+            self._task(22, "Note.md", "0:h"),
+        ]
+        m = raf._match_provenance(tasks, "Note.md", "0:h")
+        assert m["id"] == 11
+
+    def test_ignores_malformed_entries(self):
+        tasks = ["nope", {"id": 5}, {"id": 6, "description": None}]
+        assert raf._match_provenance(tasks, "Note.md", "0:h") is None
+
+
+class _PagedClient:
+    """Fake VikunjaClient returning a queued sequence of /tasks/all page bodies."""
+
+    def __init__(self, pages):
+        self._pages = list(pages)
+        self.calls = 0
+
+    def get(self, path, params=None, **kwargs):
+        assert path == "/tasks/all"
+        self.calls += 1
+        return self._pages.pop(0) if self._pages else []
+
+
+class TestIterAllTasks:
+    def test_null_body_on_page_one_is_empty_not_error(self):
+        """#751 review: Vikunja returns null for an empty collection — must be
+        treated as an empty page (end of pagination), NOT a scan error that would
+        fail the precheck closed and strand the note."""
+        client = _PagedClient([None])
+        assert raf._iter_all_tasks(client) == []
+
+    def test_null_after_full_page_terminates_with_that_page(self):
+        full = [{"id": i, "description": "x"} for i in range(50)]
+        client = _PagedClient([full, None])
+        result = raf._iter_all_tasks(client)
+        assert len(result) == 50
+        assert client.calls == 2
+
+    def test_partial_page_terminates(self):
+        client = _PagedClient([[{"id": 1, "description": "x"}]])
+        assert len(raf._iter_all_tasks(client)) == 1
+        assert client.calls == 1
+
+    def test_non_list_non_null_body_is_error(self):
+        from scripts.common.vikunja_client import VikunjaError
+
+        client = _PagedClient([{"unexpected": "dict"}])
+        with pytest.raises(VikunjaError):
+            raf._iter_all_tasks(client)
 
 
 # ===========================================================================

--- a/tests/inbox/test_route_someday.py
+++ b/tests/inbox/test_route_someday.py
@@ -152,6 +152,35 @@ def test_someday_lands_in_inbox_with_qschedule_and_no_due_date(monkeypatch, caps
     assert "task_id=555" in capsys.readouterr().out
 
 
+def test_block_key_adds_provenance_footer_line(monkeypatch):
+    """#751: a supplied block_key writes a 'Block: <key>' line below 'Source:'
+    (leaving the exact Source line intact for the delegated match)."""
+    client = _install(monkeypatch, FakeClient(create_response={"id": 555}))
+    rs.route_someday(
+        title="Try Iceland again",
+        body="Planning notes",
+        note_filename="2026-06-09-iceland.md",
+        block_key="3:abc123",
+    )
+    _, payload = client.create_calls[0]
+    lines = payload["description"].splitlines()
+    assert "Source: 2026-06-09-iceland.md" in lines
+    assert "Block: 3:abc123" in lines
+
+
+def test_no_block_key_omits_block_line(monkeypatch):
+    """Backward compat: no block_key → no 'Block:' line (CLI/legacy callers)."""
+    client = _install(monkeypatch, FakeClient(create_response={"id": 555}))
+    rs.route_someday(
+        title="Try Iceland again",
+        body="Planning notes",
+        note_filename="2026-06-09-iceland.md",
+    )
+    _, payload = client.create_calls[0]
+    assert "Block:" not in payload["description"]
+    assert "Source: 2026-06-09-iceland.md" in payload["description"]
+
+
 def test_attach_failure_still_creates_task_and_logs_loudly(monkeypatch, capsys):
     """The #715 403 case: attach fails, task is still created, route succeeds,
     and the degraded state is logged loudly (never silently swallowed)."""


### PR DESCRIPTION
## What

Close the create→verify / create→log failure window in `route_and_finalize` (#746) where an in-process `someday`/`vikunja_task` create that succeeds but whose block is never logged gets **re-created** on the next tick (orphan). Per Kent's decision, **option (a): a provenance-search precheck** (not a durable pending record).

## How

- `route_someday` gains an optional `block_key` → writes a `Block: <block_key>` footer line **below** the existing exact `Source: <note_filename>` line (left byte-for-byte intact, so the delegated provenance-match path is unaffected). New optional `--block-key` CLI arg; legacy callers unchanged.
- `_block_provenance_key(block)` = `<block_index>:<block_key_hash>` — mirrors the routing-log key (stable across ticks; two identical-content blocks with different indexes map to two tasks).
- `_find_existing_task_by_provenance` scans all tasks via paginated `GET /tasks/all` (Vikunja rejects server-side `?filter=`, G6/G7 — Kent accepted the full client-side scan) and returns the lowest-id task carrying BOTH the exact `Source:` and `Block:` lines (`_match_provenance`).
- `_create_and_verify_task` runs the precheck **before** create: existing → reuse (`deduped`, no create); scan error → fail the block **closed** (never create when we couldn't check); else create (with `block_key`) then verify.

## Review

Codex adversarial review (primary, full-stdout capture): **core no-double-create path sound**; its one **Medium** finding is fixed in this PR — `_iter_all_tasks` now treats a `null` `/tasks/all` body as an empty (exhausted) page rather than a hard scan error, so an empty task list can't fail the precheck closed and strand the note. Added pagination tests.

## Tests

`make test` green (5692 passed). New: create→verify-failure and create→log-failure retry across two ticks against a shared in-memory store assert **exactly one create** (no orphan); precheck-scan-error fails closed with no create; unit coverage for the line-anchored matcher (incl. `Inbox 1.md` vs `Source: Inbox 10.md` rejection), lowest-id-wins, pagination null/partial/error, and route_someday's `Block:` footer.

## Rebaseline

Not required — `scripts/inbox/**` is not an audited surface; no AGENTS.md touched (rides the office2 self-pull).

Closes #751

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014FPqLqLe4pZyrSEEyeLM9H