### PR TITLE
fix(#732): canonicalize _private privacy path across agent prompts + guard

### DIFF
--- a/scripts/openclaw/agents/felix-admin-habits/AGENTS.md
+++ b/scripts/openclaw/agents/felix-admin-habits/AGENTS.md
@@ -241,7 +241,7 @@ Log significant operational actions via `cd /home/claude/kg-automation && python
 
 ## Privacy — absolute rule
 
-NEVER read, process, route to, or reference `~/second-brain/notes/04-Growth/_private/`. Habits that originate from private context appear only as habit names — never with references to their source. This rule has no exceptions.
+NEVER read, process, route to, or reference `/home/kgale/second-brain/notes/04-Growth/_private/`. Habits that originate from private context appear only as habit names — never with references to their source. This rule has no exceptions.
 
 ---
 

--- a/scripts/openclaw/agents/felix-admin-tasker/AGENTS.md
+++ b/scripts/openclaw/agents/felix-admin-tasker/AGENTS.md
@@ -104,7 +104,7 @@ Before first use in a session, read both skills:
 ## Privacy — absolute rule
 
 **NEVER** read, process, route to, reference, or log any content in or from
-`~/second-brain/notes/04-Growth/_private/`. No exceptions. Not even in error
+`/home/kgale/second-brain/notes/04-Growth/_private/`. No exceptions. Not even in error
 logs. If task content references private growth work, process only the task
 description — never follow links into that directory.
 

--- a/scripts/openclaw/agents/felix-admin-tasker/TOOLS.md
+++ b/scripts/openclaw/agents/felix-admin-tasker/TOOLS.md
@@ -36,6 +36,6 @@ Central logging to `/home/kgale/second-brain/agents/logs/`.
 
 ## Restrictions
 
-- NEVER read, write, or reference `~/second-brain/notes/04-Growth/_private/` (path renumbered from `02-Growth/_private/` in mission 026 / #152)
+- NEVER read, write, or reference `/home/kgale/second-brain/notes/04-Growth/_private/` (path renumbered from `02-Growth/_private/` in mission 026 / #152)
 - NEVER log API tokens or credentials
 - NEVER create tasks without Kent's confirmation (while at Assisted level)

--- a/scripts/openclaw/agents/felix-admin-tasker/USER.md
+++ b/scripts/openclaw/agents/felix-admin-tasker/USER.md
@@ -31,6 +31,6 @@ entries — with the right project, labels, priority, due date, and description.
 
 ## Privacy boundary
 
-`~/second-brain/notes/04-Growth/_private/` is NEVER read, referenced, or logged.
+`/home/kgale/second-brain/notes/04-Growth/_private/` is NEVER read, referenced, or logged.
 Absolute rule, no exceptions. (Path renumbered from `02-Growth/_private/` in
 mission 026 / #152.)

--- a/scripts/openclaw/agents/felix-doc-auditor/AGENTS.md
+++ b/scripts/openclaw/agents/felix-doc-auditor/AGENTS.md
@@ -48,7 +48,7 @@ For each in-scope doc you may:
 - **Never** edit credential files (`.env`, `credentials.json`, similar) (C-002)
 - **Never** edit anything under `kitty-specs/` or `.kittify/` (C-002 / spec-kitty ownership)
 - **Never** read, write, reference, or log anything under
-  `~/second-brain/notes/04-Growth/_private/` (C-003)
+  `/home/kgale/second-brain/notes/04-Growth/_private/` (C-003)
 - **Never** edit a doc that isn't listed in the domain map (C-005). File a
   debt issue against the domain map if a domain is missing.
 - **Never** file debt issues outside the domain map without including the

--- a/scripts/openclaw/agents/felix-doc-auditor/SOUL.md
+++ b/scripts/openclaw/agents/felix-doc-auditor/SOUL.md
@@ -76,7 +76,7 @@ You communicate through three GitHub surfaces: pending-approval issues (Level 1 
 These are absolute — no exceptions, no edge cases, no "just checking."
 
 - **NEVER** read, write, route to, reference, or log anything under
-  `~/second-brain/notes/04-Growth/_private/`. That directory does not exist
+  `/home/kgale/second-brain/notes/04-Growth/_private/`. That directory does not exist
   as far as you are concerned.
 - **NEVER** edit `docs/constitution/FELIX-CONSTITUTION.md`. The Felix
   Constitution is governance — it changes only via explicit human decision.

--- a/scripts/openclaw/agents/felix-doc-auditor/TOOLS.md
+++ b/scripts/openclaw/agents/felix-doc-auditor/TOOLS.md
@@ -96,7 +96,7 @@ any of the following regardless of trigger source.
 
 ### Paths
 
-- **`~/second-brain/notes/04-Growth/_private/`** — never read, write,
+- **`/home/kgale/second-brain/notes/04-Growth/_private/`** — never read, write,
   reference, or log. Privacy boundary C-003.
 - **`docs/constitution/FELIX-CONSTITUTION.md`** — never edited (C-002).
   If an audit's scope appears to require a Constitution edit, file a debt

--- a/scripts/openclaw/agents/tests/test_validate_workspace.py
+++ b/scripts/openclaw/agents/tests/test_validate_workspace.py
@@ -70,6 +70,72 @@ def test_privacy_missing_entirely_fails(tmp_path: Path) -> None:
     assert "missing" in result.detail
 
 
+# --- Invariant D: privacy path canonical form (#732) --------------------------
+
+
+def test_privacy_path_canonical_form_passes(tmp_path: Path) -> None:
+    ws = _write(
+        tmp_path / "agent",
+        AGENTS_md="NEVER access `/home/kgale/second-brain/notes/04-Growth/_private/`\n## Output discipline\n",
+    )
+    assert _check(validate_workspace(ws), "privacy_path_canonical").ok
+
+
+def test_privacy_path_bare_form_passes(tmp_path: Path) -> None:
+    # A bare, HOME-prefix-free conceptual reference is not the ambiguous ``~`` form.
+    ws = _write(
+        tmp_path / "agent",
+        AGENTS_md="Absolute rule: `04-Growth/_private/` is never read.\n## Output discipline\n",
+    )
+    assert _check(validate_workspace(ws), "privacy_path_canonical").ok
+
+
+def test_privacy_path_tilde_form_fails(tmp_path: Path) -> None:
+    ws = _write(
+        tmp_path / "agent",
+        AGENTS_md="NEVER access `~/second-brain/notes/04-Growth/_private/`\n## Output discipline\n",
+    )
+    result = _check(validate_workspace(ws), "privacy_path_canonical")
+    assert not result.ok
+    assert "non-canonical" in result.detail
+    assert "AGENTS.md" in result.detail
+
+
+def test_privacy_path_tilde_in_any_md_fails(tmp_path: Path) -> None:
+    # Invariant D scans all *.md, not only the Invariant-A owner files.
+    ws = _write(
+        tmp_path / "agent",
+        AGENTS_md="04-Growth/_private/ never touch\n## Output discipline\n",
+        USER_md="`~/second-brain/notes/04-Growth/_private/` is NEVER read.\n",
+    )
+    result = _check(validate_workspace(ws), "privacy_path_canonical")
+    assert not result.ok
+    assert "USER.md" in result.detail
+
+
+def test_privacy_path_tilde_fails_whole_workspace(tmp_path: Path) -> None:
+    ws = _write(
+        tmp_path / "agent",
+        AGENTS_md="`~/second-brain/notes/04-Growth/_private/`\n## Output discipline\n",
+    )
+    assert not validate_workspace(ws).ok
+
+
+def test_privacy_path_unrelated_tilde_paths_not_flagged(tmp_path: Path) -> None:
+    # Invariant D targets only the _private privacy token, not every ``~`` path.
+    # Config/skill paths like ``~/.openclaw/...`` are correct for the claude runtime
+    # (``/home/claude/.openclaw`` exists) and must NOT be flagged.
+    ws = _write(
+        tmp_path / "agent",
+        AGENTS_md=(
+            "NEVER access `/home/kgale/second-brain/notes/04-Growth/_private/`\n"
+            "Skills live at `~/.openclaw/skills/`; config at `~/.config/felix/`.\n"
+            "## Output discipline\n"
+        ),
+    )
+    assert _check(validate_workspace(ws), "privacy_path_canonical").ok
+
+
 # --- Invariant B: output discipline (presence-or-annotation) ------------------
 
 
@@ -187,6 +253,7 @@ def test_live_capture_workspace_passes(repo_root: Path) -> None:
     root = repo_root / "scripts/openclaw/agents"
     report = next(r for r in validate_all(root) if r.workspace == "felix-admin-capture")
     assert _check(report, "privacy_boundary").ok, _check(report, "privacy_boundary").detail
+    assert _check(report, "privacy_path_canonical").ok, _check(report, "privacy_path_canonical").detail
     assert _check(report, "output_discipline").ok, _check(report, "output_discipline").detail
     assert _check(report, "runtime_env_assumptions").ok, _check(report, "runtime_env_assumptions").detail
 
@@ -196,3 +263,16 @@ def test_live_doc_auditor_excluded(repo_root: Path) -> None:
     root = repo_root / "scripts/openclaw/agents"
     names = {r.workspace for r in validate_all(root)}
     assert "felix-doc-auditor" not in names
+
+
+def test_live_fleet_privacy_path_canonical(repo_root: Path) -> None:
+    """Whole-fleet Invariant D (#732): no active workspace may carry the ambiguous
+    ``~/second-brain/...04-Growth/_private`` privacy form. This is the regression
+    guard that keeps the canonicalization permanent."""
+    root = repo_root / "scripts/openclaw/agents"
+    offenders = {
+        r.workspace: _check(r, "privacy_path_canonical").detail
+        for r in validate_all(root)
+        if not _check(r, "privacy_path_canonical").ok
+    }
+    assert not offenders, f"non-canonical privacy paths: {offenders}"

--- a/scripts/openclaw/agents/validate_workspace.py
+++ b/scripts/openclaw/agents/validate_workspace.py
@@ -11,6 +11,21 @@ workspace (they are intentionally per-agent, not inherited — see #553):
 * **Invariant B — Output Discipline**: an agent that emits user-facing WhatsApp
   carries the Output Discipline block in ``AGENTS.md``; an agent that does not
   carries the explicit ``no user-facing WhatsApp`` annotation. Presence-or-annotation.
+* **Invariant D — Privacy path canonical form** (#732): when the enforceable
+  privacy path is written with a HOME prefix, it must use the physical
+  ``/home/kgale/second-brain/notes/04-Growth/_private/`` — never the ambiguous
+  ``~/second-brain/...`` form. Agents run as the ``claude`` user on office2, where
+  ``~`` is ``/home/claude`` and there is no ``/home/claude/second-brain``; the vault
+  lives only at ``/home/kgale/second-brain`` (claude reaches it via the
+  ``secondbrain`` group). *In the office2 ``claude`` agent runtime* a ``~``-form
+  prohibition therefore names a nonexistent path and leaves the real private folder
+  uncovered. Bare ``04-Growth/_private`` conceptual references (no HOME prefix) are
+  unaffected — only the ``~`` HOME-relative form is non-canonical. This invariant is
+  scoped to agent-prompt files (``scripts/openclaw/agents/*``) ONLY; governance /
+  human-facing docs (the Constitution's C-003, ``CLAUDE.md``) intentionally retain the
+  ``~/second-brain/...`` conceptual form — correct for the Mac Claude Code runtime,
+  where ``~`` is the human's home and the vault is at ``~/second-brain``. Reconciling
+  that governance-vs-prompt representation split is tracked in #801.
 
 This is a repo/CI artifact — read-only, no deploy, no side effects.
 
@@ -34,6 +49,15 @@ from pathlib import Path
 
 #: Substring identifying the enforceable privacy boundary rule.
 PRIVACY_TOKEN = "04-Growth/_private"
+
+#: Canonical physical form of the enforceable privacy path in the office2 agent
+#: runtime (#732). ``~`` for the ``claude`` user is ``/home/claude`` (no vault); the
+#: vault lives only at ``/home/kgale/second-brain``.
+CANONICAL_PRIVATE_PATH = "/home/kgale/second-brain/notes/04-Growth/_private"
+
+#: The ambiguous HOME-relative form that resolves to a nonexistent path for the
+#: ``claude`` runtime and thus misprotects the boundary (Invariant D, #732).
+NONCANONICAL_PRIVATE_TOKEN = "~/second-brain/notes/04-Growth/_private"
 
 #: Case-insensitive marker for the Output Discipline block heading.
 OUTPUT_DISCIPLINE_TOKEN = "output discipline"
@@ -99,6 +123,30 @@ def check_privacy_boundary(workspace_dir: Path) -> CheckResult:
     )
 
 
+def check_privacy_path_canonical(workspace_dir: Path) -> CheckResult:
+    """Invariant D (#732): HOME-prefixed privacy paths use the physical /home/kgale form.
+
+    Scans every ``*.md`` in the workspace and fails if any carries the ambiguous
+    ``~/second-brain/notes/04-Growth/_private`` form. Bare ``04-Growth/_private``
+    conceptual references (no HOME prefix) and the canonical ``/home/kgale/...`` form
+    both pass — only the ``~`` HOME-relative form, which resolves to the nonexistent
+    ``/home/claude/second-brain`` for the ``claude`` runtime, is non-canonical.
+    """
+    offenders = [
+        md.name
+        for md in sorted(workspace_dir.glob("*.md"))
+        if NONCANONICAL_PRIVATE_TOKEN in _read(md)
+    ]
+    if offenders:
+        return CheckResult(
+            "privacy_path_canonical",
+            False,
+            f"non-canonical '~/second-brain/...' privacy path in {', '.join(offenders)} "
+            f"— use '{CANONICAL_PRIVATE_PATH}/'",
+        )
+    return CheckResult("privacy_path_canonical", True, "canonical or bare (no ~ HOME-relative form)")
+
+
 def check_output_discipline(workspace_dir: Path) -> CheckResult:
     """Invariant B: Output Discipline block present, or no-WhatsApp annotation present."""
     agents_text = _read(workspace_dir / "AGENTS.md").lower()
@@ -137,6 +185,7 @@ def validate_workspace(workspace_dir: Path) -> WorkspaceReport:
     """Run all invariant checks against one workspace directory."""
     checks = [
         check_privacy_boundary(workspace_dir),
+        check_privacy_path_canonical(workspace_dir),
         check_output_discipline(workspace_dir),
         check_runtime_env_assumptions(workspace_dir),
     ]


### PR DESCRIPTION
## What & why

Agents run as the `claude` user on office2, where `~` = `/home/claude` — and **`/home/claude/second-brain` does not exist** (the claude vault clone was decommissioned by #659). The vault lives only at `/home/kgale/second-brain` (claude reaches it via the `secondbrain` group); every real vault op across the fleet already uses that physical path. But the enforceable `04-Growth/_private` privacy prohibition was written two prefixed ways — canonical `/home/kgale/...` (4 agents) and ambiguous `~/second-brain/...` (7 occurrences). The `~/` form resolves to a **nonexistent** path for the claude runtime, leaving the real private folder uncovered (#732's stated worst case).

Physical path resolved by probing office2 (`whoami`/`$HOME`/`id`/vault stat) — not guessed.

## Changes

- **Canonicalize** the 7 `~/second-brain/notes/04-Growth/_private/` occurrences → `/home/kgale/second-brain/notes/04-Growth/_private/` (felix-doc-auditor TOOLS/SOUL/AGENTS, felix-admin-habits/AGENTS.md, felix-admin-tasker USER/TOOLS/AGENTS).
- **Left untouched** the ~9 bare `04-Growth/_private/` conceptual "absolute rule" statements — deliberate vault-relative phrasing, out of the issue's enumerated scope.
- **Guard (Invariant D)** in `validate_workspace.py` (`check_privacy_path_canonical`): flags the ambiguous `~/second-brain/...04-Growth/_private` form in any workspace `*.md` so it can't drift back. Scoped to agent prompts only — does **not** reach governance/human-facing docs (Constitution C-003, `CLAUDE.md`), which correctly retain the `~/` conceptual form for the Mac Claude Code runtime.
- **Tests** (+7): tilde-fails / canonical-passes / bare-passes / non-owner `*.md` scanned / whole-workspace bubble / whole-fleet live gate / unrelated `~` paths not flagged.

## Reconciliation with #752's CI checks

Both `validate_privacy_boundary.py` and `validate_workspace.py` Invariant A (`PRIVACY_TOKEN`) enforce only the `04-Growth/_private` **ordinal** — agnostic to the home-prefix. Flipping `~/`→`/home/kgale/` keeps them green; Invariant D adds the missing prefix enforcement (agent-prompt-scoped).

## Follow-up

**#801** — reconcile the governance-doc (`~/`) vs agent-prompt (`/home/kgale/`) representation split (a decision, no code change needed; surfaced for Kent).

## Gate

`make test` (5790 passed at pre-review state; +7 tests), `validate_docs`, `validate_privacy_boundary`, `validate_architecture_data`, env-guard all green locally. Adversarial review by reviewer-renata (no blockers; her SHOULD-FIX docstring-scoping + NICE-TO-HAVE negative test both applied).

**Rebaseline:** not required — edited agent prompts are an unmonitored audited surface (`audited-surfaces.json` `openclaw-agent-prompts` → `rebaseline_required: false`); `validate_workspace.py` + test are repo CI artifacts, not an audited surface.

Closes #732