### PR TITLE
docs+prompts(#796,#801): finalize weekly-report owner + document path-form split

### DIFF
--- a/docs/design/openclaw-workspace-authoring-standard.md
+++ b/docs/design/openclaw-workspace-authoring-standard.md
@@ -88,6 +88,16 @@ mechanically-checked home. `SOUL.md` may carry only a one-line behavioral **stan
 ("I work only where I'm invited"); the stance never substitutes for the enforceable
 rule. A workspace with the stance but no enforceable rule fails validation.
 
+**Path-representation convention (#732 / #801).** In agent prompts the enforceable
+privacy path is written as the **physical absolute path** `/home/kgale/second-brain/notes/04-Growth/_private/`
+— because agents run as the `claude` user on office2, where `~` resolves to
+`/home/claude` (no vault; the clone was retired by #659) and the vault is reachable
+only under `/home/kgale` via the `secondbrain` group. This is enforced by
+`validate_workspace` **Invariant D**. **Docs and governance files deliberately use
+the `~/second-brain/...` form instead** — that is correct for the human/Mac authoring
+context, not a drift. The two forms are context-correct by design; do not "unify"
+them (a `~/` path in a prompt is the #732 nonexistent-path bug the guard now rejects).
+
 ### Invariant B — Output Discipline
 
 Any agent that emits **user-facing WhatsApp** must carry the Output Discipline

--- a/docs/design/process-flows/habits.md
+++ b/docs/design/process-flows/habits.md
@@ -38,7 +38,7 @@ This is the single canonical explanation, crediting the missions that built it.
 | 48h auto-skip sweeper (idempotent, day-specific EOD-ET advance) | `habit-day-specific-scheduling-01KT48Y6` (FR-003, FR-005) |
 | JSONL is canonical history; comment is a UI mirror; weekly report reads the JSONL not `done_at` | ADR-0002 Phase 2; `trustworthy-weekly-habit-report-01KV4GZ7` ([#605](https://github.com/kentonium3/kg-automation/issues/605)) |
 | Deterministic weekly cron driver with truthful delivery confirmation | `deterministic-cron-hardening-01KXA4PX` ([#723](https://github.com/kentonium3/kg-automation/issues/723)) |
-| Weekly-report ownership decision (dedicated reporting agent; habits out-of-scope) | [#409](https://github.com/kentonium3/kg-automation/issues/409) |
+| Weekly-report ownership: deterministic `felix-habits-weekly` timer owns it; habits out-of-scope (dedicated LLM agent declined) | [#409](https://github.com/kentonium3/kg-automation/issues/409) / [#796](https://github.com/kentonium3/kg-automation/issues/796) |
 
 ## Actors & trigger
 
@@ -173,24 +173,22 @@ RECONCILE (reconcile_completions.py, cache-driven)
     `source="vikunja-ui"`; JSONL `complete` today with cache `done=false` → drift
     reported on stdout only.
 
-## Weekly reporting — ownership relocated ([#409](https://github.com/kentonium3/kg-automation/issues/409))
+## Weekly reporting — owned by the deterministic timer ([#409](https://github.com/kentonium3/kg-automation/issues/409) / [#723](https://github.com/kentonium3/kg-automation/issues/723))
 
-Weekly habit pattern reporting is **being moved out of `felix-admin-habits`.** Per
-the [#409](https://github.com/kentonium3/kg-automation/issues/409) decision
-(Kent, 2026-07-19), a **dedicated reporting agent** will own weekly pattern
-reports; the felix-admin-habits `SOUL.md` and `AGENTS.md` are being updated (via
-#409) to mark them out-of-scope. Until that change lands, the in-repo habits
-prompts still describe the weekly report as an agent job — this doc records the
-decided target so a future mission reads the intended end-state, not the transient.
-
-Current-state delivery mechanism: the deterministic **`felix-habits-weekly-driver`**
-cron (`scripts/habits/weekly_report_driver.py`, systemd `felix-habits-weekly.timer`,
-Mon 06:00 ET) runs `query_active_habits_weekly` in-process — reading
+Weekly habit pattern reporting is **not owned by `felix-admin-habits`** ([#409](https://github.com/kentonium3/kg-automation/issues/409)):
+the agent's `SOUL.md`/`AGENTS.md` mark it out-of-scope and the agent never
+generates a report. The **owner is the deterministic `felix-habits-weekly` timer**
+(`scripts/habits/weekly_report_driver.py`, systemd `felix-habits-weekly.timer`,
+Mon 06:00 ET), which runs `query_active_habits_weekly` in-process — reading
 `habits-history.jsonl` (not `done_at`, [#605](https://github.com/kentonium3/kg-automation/issues/605))
 — and delivers via `openclaw message send` with truthful delivery confirmation
-([#723](https://github.com/kentonium3/kg-automation/issues/723)). The report
-*content* pipeline is stable; only *agent ownership* moved. A follow-up issue
-tracks authoring the dedicated reporting agent that will own this responsibility.
+([#723](https://github.com/kentonium3/kg-automation/issues/723)).
+
+A dedicated **LLM** reporting agent was considered and **declined** (Kent,
+2026-07-19, [#796](https://github.com/kentonium3/kg-automation/issues/796)): the
+deterministic timer already produces a trustworthy report, and an LLM layer would
+reintroduce exactly the fabrication risk the #605 ratchet exists to prevent. The
+deterministic timer is the permanent owner.
 
 ## Implementing seams
 
@@ -252,7 +250,7 @@ stateDiagram-v2
   [#582](https://github.com/kentonium3/kg-automation/issues/582) (intentional
   authoring of the habits agent workspace).
 - **Ownership decision**: [#409](https://github.com/kentonium3/kg-automation/issues/409)
-  (weekly reports → dedicated reporting agent; see the weekly-reporting section).
+  (weekly reports → deterministic `felix-habits-weekly` timer; dedicated LLM agent declined; see the weekly-reporting section).
 - **Migration debt**: `scripts/habits/*` should adopt
   `scripts/common/et_datetime.py` ([#761](https://github.com/kentonium3/kg-automation/issues/761))
   to retire the inline ET copies.

--- a/scripts/openclaw/agents/felix-admin-habits/AGENTS.md
+++ b/scripts/openclaw/agents/felix-admin-habits/AGENTS.md
@@ -130,8 +130,9 @@ user timer (module `scripts.habits.weekly_report_driver`, Monday 06:00
 America/New_York, zero LLM turns — #723), which invokes the
 `scripts.habits.query_active_habits_weekly` helper directly and delivers the
 message itself. The prior `habits-weekly-report` openclaw cron on this agent was
-retired. Do NOT generate, render, or relay a weekly report. Any future move to a
-dedicated LLM reporting agent is tracked in #796.
+retired. Do NOT generate, render, or relay a weekly report. A dedicated LLM
+reporting agent was considered and declined (#796, 2026-07-19); the deterministic
+timer is the permanent owner.
 
 ---
 

--- a/scripts/openclaw/agents/felix-admin-habits/SOUL.md
+++ b/scripts/openclaw/agents/felix-admin-habits/SOUL.md
@@ -13,8 +13,9 @@ off the LLM-agent path to the deterministic `felix-habits-weekly` systemd timer
 (module `scripts.habits.weekly_report_driver`, Monday 06:00 America/New_York,
 zero LLM turns — #723), which invokes the `scripts.habits.query_active_habits_weekly`
 helper directly and delivers the message itself. Do NOT generate, render, or improvise
-a weekly report under any circumstance. Any future move to a dedicated LLM
-reporting agent is tracked in #796.
+a weekly report under any circumstance. A dedicated LLM reporting agent was
+considered and declined (#796, 2026-07-19); the deterministic timer is the
+permanent owner.
 
 ## Voice — write as Kent
 


### PR DESCRIPTION
Realizes the #796 and #801 decisions (Kent, 2026-07-19) in code.

**#796** — decided: keep the deterministic \`felix-habits-weekly\` timer as the weekly-report owner; no dedicated LLM agent (would reintroduce the #605 fabrication risk).
- \`habits.md\`: timer is the permanent owner; dedicated LLM agent considered + declined. Removed the transient "being moved / a dedicated agent will own" framing.
- \`felix-admin-habits\` SOUL.md + AGENTS.md: retarget the stale "#796 tracks a future dedicated agent" pointer to "considered and declined; timer is permanent owner."

**#801** — decided: keep both path forms, document the split.
- \`openclaw-workspace-authoring-standard.md\` Invariant A: prompts use physical \`/home/kgale/\` (office2 \`claude\` runtime; Invariant D-enforced, #732); docs use \`~/\` (human/Mac) — context-correct by design, not drift.

**Deploy:** the two habits prompts deploy via agent-prompt-sync (sub-agent, no gateway restart); rebaseline-exempt (#621). \`validate_docs\` + \`validate_architecture_data\` green; felix-admin-habits workspace passes.

Closes #796
Closes #801