### PR TITLE
fix(#811): single-source OpenClaw binary path via a resolution seam

### DIFF
--- a/deploys/queued/0021-openclaw-bin-seam.yaml
+++ b/deploys/queued/0021-openclaw-bin-seam.yaml
@@ -1,0 +1,40 @@
+schema_version: v1
+name: openclaw-bin-seam
+issue: kentonium3/kg-automation#811
+tier: 3
+entrypoint: scripts/deploy/deploy-openclaw-bin-seam.py
+audited_surface: false
+created_at: '2026-07-19T00:00:00Z'
+created_by: fix-811-openclaw-bin-seam
+apply_mode: manifest
+notes: |
+  Syncs the seam-migrated security-monitor audit.sh to its standalone office2
+  copy (kentonium3/kg-automation#811). The #811 OpenClaw binary-path resolution
+  seam (scripts/common/openclaw_bin.py) migration is otherwise
+  checkout-resident: the 4 systemd Python services (felix-trust-scan,
+  credential-health-check, agent-skill-sync, felix-habits-weekly) and the deploy
+  helpers run `python3 -m scripts.*` from WorkingDirectory=/home/claude/
+  kg-automation (the felix-deployer origin/main checkout), so the new seam module
+  + migrated callers go live on the next pull with no deploy action.
+
+  The one exception is scripts/office2/security-monitor/audit.sh, which runs from
+  a standalone copy at /data/services/security-monitor/scripts/audit.sh that a
+  git pull does not refresh. The entrypoint (deploy-openclaw-bin-seam.py
+  --dry-run / --apply) copies the checkout's audit.sh to that path and verifies
+  it is byte-identical. It mirrors the #653 precedent (commit c163c3be) that last
+  updated this file, but records the copy through the manifest pipeline rather
+  than by hand.
+
+  Tier 3 (a file copy into a claude-owned dir — no sudo, no Tier 0/1/2 action).
+
+  audited_surface: false — the deployed change touches NO hashed audited surface.
+  audit.sh (scripts/office2/security-monitor/*.sh) does not match any
+  audited-surfaces.json pattern (systemd-user-units covers scripts/office2/*.service
+  and scripts/office2/deploy/*.sh, not security-monitor/audit.sh); the change is
+  path-resolution only, so `openclaw cron list` output — and the openclaw-cron.txt
+  baseline — is unchanged. The only audited-path match in this commit is this
+  manifest itself (deploy-pipeline surface, whose affected_baselines is []).
+
+  Rebaseline: not required — no hashed baseline drifts (see above); the merge
+  commit records the equivalent `Rebaseline: not required` line for the #557 CI
+  soft-reminder that fires on the deploys/queued/*.yaml path match.

--- a/docs/design/architecture/data/service-inventory.json
+++ b/docs/design/architecture/data/service-inventory.json
@@ -844,7 +844,7 @@
         "timeout_seconds": 30,
         "grace_seconds": 900,
         "expected": "each listed OpenClaw cron enabled, lastRunStatus=ok, and fired by its nextRunAtMs (schedule-aware freshness)",
-        "note": "Probed via `openclaw cron list --json`: per-cron enabled + last-run status + schedule-aware freshness (nextRunAtMs). Replaces method:none (#722)."
+        "note": "Probed via `openclaw cron list --json`: per-cron enabled + last-run status + schedule-aware freshness (nextRunAtMs). Replaces method:none (#722). The `endpoint` carries the absolute openclaw path directly — a documented exception to the #811 binary-path seam: the canary systemd unit has no OPENCLAW_BIN/PATH and JSON data cannot import the seam; on a relocation these 3 endpoint strings change alongside the seam default."
       },
       "config_files": [
         {
@@ -951,7 +951,7 @@
         "timeout_seconds": 30,
         "grace_seconds": 900,
         "expected": "the listed OpenClaw cron enabled, lastRunStatus=ok, and fired by its nextRunAtMs (schedule-aware freshness for the daily morning check-in)",
-        "note": "Probed via `openclaw cron list --json`: per-cron enabled + last-run status + schedule-aware freshness (nextRunAtMs). Replaces method:none (#722). The habits-weekly-report cron was retired and removed from this list by #723 — its freshness is now tracked under the felix-habits-weekly service entry (tick-signal-file method)."
+        "note": "Probed via `openclaw cron list --json`: per-cron enabled + last-run status + schedule-aware freshness (nextRunAtMs). Replaces method:none (#722). The habits-weekly-report cron was retired and removed from this list by #723 — its freshness is now tracked under the felix-habits-weekly service entry (tick-signal-file method). The `endpoint` carries the absolute openclaw path directly — a documented exception to the #811 binary-path seam (canary unit has no OPENCLAW_BIN/PATH; JSON data cannot import the seam)."
       },
       "config_files": [
         {
@@ -1317,7 +1317,7 @@
         "timeout_seconds": 30,
         "grace_seconds": 900,
         "expected": "the OpenClaw cron enabled, lastRunStatus=ok, and fired by its nextRunAtMs (schedule-aware freshness)",
-        "note": "Probed via `openclaw cron list --json`: per-cron enabled + last-run status + schedule-aware freshness (nextRunAtMs). Replaces method:none (#722)."
+        "note": "Probed via `openclaw cron list --json`: per-cron enabled + last-run status + schedule-aware freshness (nextRunAtMs). Replaces method:none (#722). The `endpoint` carries the absolute openclaw path directly — a documented exception to the #811 binary-path seam: the canary systemd unit has no OPENCLAW_BIN/PATH and JSON data cannot import the seam; on a relocation these 3 endpoint strings change alongside the seam default."
       },
       "config_files": [
         {

--- a/docs/design/architecture/service-inventory.md
+++ b/docs/design/architecture/service-inventory.md
@@ -238,7 +238,7 @@ The helper does NOT trigger an openclaw restart.
 - **Deployed by**: F002
 - **Version**: OpenClaw 2026.7.1-2 (core + `@openclaw/whatsapp` 2026.7.1, lockstep-upgraded 2026-07-19)
 - **Installation**: `npm install -g openclaw@<version>` into the **claude user-space** npm prefix `/home/claude/.local` (**no sudo** — per #653 the core was relocated out of the root-owned `/usr/lib/node_modules/openclaw` into claude space; the root-global was removed 2026-07-19). Channel plugins upgrade in lockstep via `openclaw plugins update @openclaw/<plugin>@latest`. See [`openclaw-ecosystem-upgrade.md`](../../runbooks/openclaw-ecosystem-upgrade.md).
-- **Binary**: `/home/claude/.local/bin/openclaw` (sole install; bare `openclaw` resolves here only on a **login** shell — systemd-user units, cron, and non-login ssh must use the absolute path)
+- **Binary**: `/home/claude/.local/bin/openclaw` (sole install; bare `openclaw` resolves here only on a **login** shell — systemd-user units, cron, and non-login ssh must use the absolute path). Code resolves this via the seam [`scripts/common/openclaw_bin.py`](../../../scripts/common/openclaw_bin.py) — the single source of truth for the binary path (#811).
 - **Config**: `/home/claude/.openclaw/openclaw.json`
 - **Service level**: User-level systemd with lingering (not system-level)
 - **Config in repo**: `scripts/openclaw/openclaw-gateway.service`, `scripts/openclaw/install.sh`

--- a/docs/runbooks/openclaw-ecosystem-upgrade.md
+++ b/docs/runbooks/openclaw-ecosystem-upgrade.md
@@ -88,6 +88,14 @@ must be handed to Kent per the change-control hard lock.
 > claude-space `dist/index.js` by absolute path. (Bare `openclaw` works only in a
 > **login** shell, whose `.profile` puts `~/.local/bin` first — do not rely on that
 > for scripted/systemd/cron callers; those must use the absolute path.)
+>
+> **In code**, scripted callers resolve the binary through the seam
+> [`scripts/common/openclaw_bin.py`](../../scripts/common/openclaw_bin.py)
+> (`openclaw_bin()` / the `${OPENCLAW_BIN:=…}` shell convention), not a hardcoded
+> literal (#811) — that is the single place to change on the next relocation. The
+> interactive `ssh office2-claude '/home/claude/.local/bin/openclaw …'` commands
+> below are one-off operator commands (no seam import available over ssh), so they
+> use the absolute path directly.
 
 1. **Snapshot precondition (Tier 2).** Confirm a Restic backup within 24h exists
    (see [`security-baseline-ops.md`](<./security-baseline-ops.md>) /

--- a/docs/runbooks/openclaw-ops.md
+++ b/docs/runbooks/openclaw-ops.md
@@ -20,6 +20,18 @@ This runbook covers operations for the OpenClaw gateway service on office2.
 - **Binary**: `/home/claude/.local/bin/openclaw` (sole install). Bare `openclaw` resolves
   here only on a **login** shell; systemd-user units, cron, and non-login ssh have no
   `~/.local/bin` on PATH and must call the **absolute** path.
+  - **Canonical path source for code (#811)**: the resolution seam
+    [`scripts/common/openclaw_bin.py`](../../scripts/common/openclaw_bin.py) —
+    `openclaw_bin()` / `openclaw_argv()` (env `OPENCLAW_BIN` override → absolute
+    default). All Python subprocess callers import it; shell callers use the
+    `: "${OPENCLAW_BIN:=…}"` convention (`audit.sh`, `anthropic-rotate.sh`). A
+    future relocation is a one-line change in the seam. **Documented exceptions**
+    (not routed through the seam): the felix-deployer PATH-safe cron primitives
+    (`scripts/deploy/lib/cron.py`, `deploy-deterministic-monitoring-checks.py`),
+    two already-applied one-shot cron deploy scripts, and the 3 canary
+    `openclaw-cron-state` `endpoint` strings in `service-inventory.json`
+    (executed by a shell in a unit with no `OPENCLAW_BIN`/PATH). The guard test
+    `tests/common/test_openclaw_bin_seam.py` enforces this.
 - **Config**: `/home/claude/.openclaw/openclaw.json`
 - **Per-agent auth (2026.6+)**: `~/.openclaw/agents/<id>/agent/openclaw-agent.sqlite`
   (replaces the legacy `auth-profiles.json` file-based store; see

--- a/scripts/canary/probes.py
+++ b/scripts/canary/probes.py
@@ -599,10 +599,11 @@ def _probe_openclaw_cron(
 ) -> ProbeResult:
     """OpenClaw cron-state probe (#722).
 
-    Runs the ``endpoint`` command (``/usr/bin/openclaw cron list --json`` — an
-    absolute path because the canary's systemd unit has no ``PATH``), parses its
-    JSON, and delegates to :func:`_evaluate_openclaw_crons` for the service's
-    mapped ``crons``.
+    Runs the ``endpoint`` command (an absolute ``openclaw cron list --json`` —
+    the endpoint string carries the absolute path from service-inventory.json
+    because the canary's systemd unit has no ``PATH``; see the seam exception in
+    scripts/common/openclaw_bin.py), parses its JSON, and delegates to
+    :func:`_evaluate_openclaw_crons` for the service's mapped ``crons``.
 
     Fail-open (INV-D): a non-zero exit (gateway unreachable / CLI error) or
     unparseable output returns ``evaluable=False`` → the caller maps it to

--- a/scripts/common/openclaw_bin.py
+++ b/scripts/common/openclaw_bin.py
@@ -1,0 +1,72 @@
+"""Single source of truth for the OpenClaw binary path (kentonium3/kg-automation#811).
+
+Resolves "where is the openclaw binary" in ONE place so a future relocation
+(a different npm prefix, containerization, a per-host path difference) is a
+one-line change here instead of an edit at every subprocess call site.
+
+Resolution order:
+
+1. env ``OPENCLAW_BIN`` (non-blank) — the override for tests, a relocation, or
+   a per-host path;
+2. :data:`DEFAULT_OPENCLAW_BIN` — the sole install location after the #653
+   root-global removal deleted ``/usr/bin/openclaw`` and moved OpenClaw fully
+   into claude user space.
+
+**Why absolute-by-default.** Every runtime consumer runs in a PATH-less context
+— systemd-user units, cron, and non-login ``sg docker -c`` shells all lack
+``~/.local/bin`` on ``PATH`` — so a bare ``openclaw`` raises
+``FileNotFoundError`` (or, via ``shutil.which``, resolves to ``None`` and fails
+silently). That is the #653 failure class this seam exists to eliminate.
+
+Library-tier per Felix Constitution Directive 6 /
+``docs/design/helper-script-conventions.md``: pure, importable, no file I/O and
+no network on import or call. Resolution happens at **call time** so an
+``OPENCLAW_BIN`` set before the process starts always wins.
+
+Documented exceptions that intentionally do NOT route through this seam (they
+are PATH-safe by design or are inert historical artifacts): the felix-deployer
+cron primitives (``scripts/deploy/lib/cron.py``,
+``scripts/deploy/deploy-deterministic-monitoring-checks.py``) which run only
+under felix-deployer's PATH; the two already-applied one-shot cron deploy
+scripts; and the canary ``endpoint`` command strings in
+``service-inventory.json`` (executed by a shell in a unit with no
+``OPENCLAW_BIN``/PATH). See ``docs/runbooks/openclaw-ops.md``.
+"""
+from __future__ import annotations
+
+import os
+
+__all__ = [
+    "DEFAULT_OPENCLAW_BIN",
+    "OPENCLAW_BIN_ENV",
+    "openclaw_bin",
+    "openclaw_argv",
+]
+
+#: The sole OpenClaw install location on office2 (claude user space, #653).
+DEFAULT_OPENCLAW_BIN = "/home/claude/.local/bin/openclaw"
+
+#: Environment variable that overrides the default (relocation / per-host / tests).
+OPENCLAW_BIN_ENV = "OPENCLAW_BIN"
+
+
+def openclaw_bin() -> str:
+    """Return the resolved OpenClaw binary path.
+
+    ``OPENCLAW_BIN`` wins when set to a non-blank value; otherwise the absolute
+    :data:`DEFAULT_OPENCLAW_BIN`. A blank/whitespace-only override is ignored
+    (an empty string must never be returned as a "path"). Never returns blank.
+    """
+    override = os.environ.get(OPENCLAW_BIN_ENV)
+    if override and override.strip():
+        return override
+    return DEFAULT_OPENCLAW_BIN
+
+
+def openclaw_argv(*args: str) -> list[str]:
+    """Return ``[openclaw_bin(), *args]`` for ``subprocess.run(..., shell=False)``.
+
+    Convenience for the common case of building an argv list whose first element
+    is the resolved binary, e.g. ``openclaw_argv("cron", "list", "--json")``.
+    """
+    return [openclaw_bin(), *args]

--- a/scripts/deploy/deploy-habits-weekly-driver.py
+++ b/scripts/deploy/deploy-habits-weekly-driver.py
@@ -97,13 +97,14 @@ if str(_REPO_ROOT) not in sys.path:
 
 from scripts.common.alert_bus import emit  # noqa: E402
 from scripts.common.alert_bus.model import Alert, Severity  # noqa: E402
+from scripts.common.openclaw_bin import openclaw_bin  # noqa: E402
 from scripts.deploy.lib import cron as cron_lib  # noqa: E402
 
 # --------------------------------------------------------------------------- #
 # Grounded constants.
 # --------------------------------------------------------------------------- #
 
-_OPENCLAW_BIN = "/home/claude/.local/bin/openclaw"
+_OPENCLAW_BIN = openclaw_bin()
 _PYTHON3_BIN = "/usr/bin/python3"
 
 _UNIT_SOURCE_DIR = _REPO_ROOT / "scripts" / "office2"

--- a/scripts/deploy/deploy-openclaw-bin-seam.py
+++ b/scripts/deploy/deploy-openclaw-bin-seam.py
@@ -1,0 +1,116 @@
+#!/usr/bin/env python3
+"""Deploy entrypoint — sync the seam-migrated ``audit.sh`` to its office2 copy (#811).
+
+The OpenClaw binary-path seam (``scripts/common/openclaw_bin.py``) migration is
+otherwise **checkout-resident**: the 4 systemd Python services and the deploy
+helpers run ``python3 -m scripts.*`` from ``WorkingDirectory=/home/claude/
+kg-automation`` (the felix-deployer origin/main checkout), so they go live on the
+next ``git pull`` with no deploy action. The one exception is
+``scripts/office2/security-monitor/audit.sh``, which runs from a **standalone
+copy** at ``/data/services/security-monitor/scripts/audit.sh`` — a ``git pull``
+does not refresh it.
+
+This entrypoint copies the checkout's ``audit.sh`` to that deployed path and
+verifies the copy is byte-identical. The change is path-resolution only (adopting
+the ``: "${OPENCLAW_BIN:=…}"`` seam convention in place of a hardcoded literal), so
+``openclaw cron list`` output — and thus the ``openclaw-cron.txt`` baseline — is
+unchanged. It mirrors the #653 precedent (commit ``c163c3be``) that last updated
+this file, but records the copy through the manifest pipeline rather than by hand.
+
+Tier 3 (a file copy into a claude-owned dir — no sudo, no Tier 0/1/2 action).
+
+CLI contract (per docs/runbooks/deploy/discipline.md):
+
+* ``--dry-run`` — print the planned copy (source, target, exists/differs). NO
+  side effects on office2.
+* ``--apply``   — copy + verify byte-identical. Idempotent in effect (a re-run
+  re-copies the identical bytes and re-verifies — same success outcome).
+
+Exit codes
+----------
+* 0 — dry-run printed; OR apply succeeded (target byte-identical to source).
+* 1 — apply failed (source missing, copy error, or post-copy mismatch).
+* 2 — usage error (missing / wrong-shaped mode argument).
+
+Invocation note: felix-deployer invokes entrypoints by file path
+(``subprocess.run([path, "--dry-run"], shell=False)``), NOT via ``python3 -m``.
+This script imports only stdlib, so no sys.path shim is required.
+"""
+from __future__ import annotations
+
+import argparse
+import filecmp
+import json
+import os
+import shutil
+import stat
+import sys
+from pathlib import Path
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+_SOURCE = _REPO_ROOT / "scripts" / "office2" / "security-monitor" / "audit.sh"
+_TARGET = Path("/data/services/security-monitor/scripts/audit.sh")
+
+
+def _emit(outcome: str, **fields: object) -> None:
+    """Print one structured line for the felix-deployer log."""
+    payload = {"entrypoint": "deploy-openclaw-bin-seam", "outcome": outcome, **fields}
+    sys.stdout.write(json.dumps(payload, sort_keys=True) + "\n")
+
+
+def _dry_run() -> int:
+    if not _SOURCE.is_file():
+        _emit("dry_run_error", error=f"source not found: {_SOURCE}")
+        return 1
+    target_exists = _TARGET.exists()
+    differs = not (target_exists and filecmp.cmp(_SOURCE, _TARGET, shallow=False))
+    _emit(
+        "dry_run",
+        source=str(_SOURCE),
+        target=str(_TARGET),
+        target_exists=target_exists,
+        would_copy=differs,
+    )
+    return 0
+
+
+def _apply() -> int:
+    if not _SOURCE.is_file():
+        _emit("apply_error", error=f"source not found: {_SOURCE}")
+        return 1
+    try:
+        _TARGET.parent.mkdir(parents=True, exist_ok=True)
+        shutil.copy2(_SOURCE, _TARGET)
+        # audit.sh is invoked directly (`sg docker -c .../audit.sh`), so it MUST
+        # stay executable. copy2 only preserves the *source* mode, so ensure +x
+        # on the target explicitly rather than trusting the checkout's bits.
+        current = _TARGET.stat().st_mode
+        _TARGET.chmod(current | stat.S_IXUSR | stat.S_IXGRP | stat.S_IXOTH)
+    except OSError as exc:
+        _emit("apply_error", error=f"copy failed: {exc}", target=str(_TARGET))
+        return 1
+    # Verify byte-identical + executable (the deterministic post-conditions).
+    if not filecmp.cmp(_SOURCE, _TARGET, shallow=False):
+        _emit("apply_error", error="post-copy mismatch", target=str(_TARGET))
+        return 1
+    if not os.access(_TARGET, os.X_OK):
+        _emit("apply_error", error="target not executable after copy", target=str(_TARGET))
+        return 1
+    _emit("applied", source=str(_SOURCE), target=str(_TARGET))
+    return 0
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    mode = parser.add_mutually_exclusive_group(required=True)
+    mode.add_argument("--dry-run", action="store_true", help="print planned copy; no side effects")
+    mode.add_argument("--apply", action="store_true", help="copy + verify audit.sh")
+    try:
+        args = parser.parse_args(argv)
+    except SystemExit:
+        return 2
+    return _apply() if args.apply else _dry_run()
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/habits/weekly_report_driver.py
+++ b/scripts/habits/weekly_report_driver.py
@@ -26,8 +26,8 @@ Behavior (contract steps)
 3. Compose ``"<attribution>\\n\\n" + report_body``. The report portion is
    byte-identical to the helper's output (FR-005).
 4. Deliver via ``openclaw message send --channel whatsapp --target <E.164>
-   --message <message> --json`` (absolute ``/home/claude/.local/bin/openclaw`` — systemd
-   units have no ``PATH``).
+   --message <message> --json`` (binary path from the seam
+   ``scripts/common/openclaw_bin.py`` — systemd units have no ``PATH``).
 5. Confirm delivery: ``delivery_confirmed=True`` **only** when the C1
    predicate holds (exit 0 AND a non-empty ``messageId`` AND
    ``dryRun == False``). Otherwise write a ``failure`` tick and return
@@ -75,6 +75,7 @@ from datetime import datetime, timezone
 from pathlib import Path
 from typing import Callable, Optional
 
+from scripts.common.openclaw_bin import openclaw_bin
 from scripts.habits import query_active_habits_weekly as weekly_helper
 
 # --------------------------------------------------------------------------- #
@@ -103,9 +104,9 @@ SELF_TEST_TICK_PATH = DEFAULT_TICK_PATH.with_name(
     "self-test-" + DEFAULT_TICK_PATH.name
 )
 
-#: Absolute path — systemd units have no ``PATH`` (recurring deploy gotcha;
-#: see the canary probes' ``openclaw cron list`` invocation for precedent).
-OPENCLAW_BIN = "/home/claude/.local/bin/openclaw"
+#: Resolved by the seam (scripts/common/openclaw_bin.py) — systemd units have no
+#: ``PATH`` (recurring deploy gotcha), so the absolute path is required (#811).
+OPENCLAW_BIN = openclaw_bin()
 
 
 # --------------------------------------------------------------------------- #
@@ -207,7 +208,7 @@ def send_message(
 ) -> SendResult:
     """Deliver ``message`` via ``openclaw message send --json`` (production effect).
 
-    Uses the absolute ``/home/claude/.local/bin/openclaw`` (systemd units have no ``PATH``).
+    Uses the seam-resolved openclaw path (systemd units have no ``PATH``).
     ``dry_run`` appends ``--dry-run`` so ``--self-test`` never sends a real
     message while still exercising the full CLI round-trip.
     """

--- a/scripts/obsidian/sync-heartbeat.py
+++ b/scripts/obsidian/sync-heartbeat.py
@@ -22,6 +22,14 @@ import sys
 from datetime import datetime, timezone
 from pathlib import Path
 
+# Hyphenated filename → only runnable by script path, so the repo root is not on
+# sys.path unless we put it there ourselves — required for the seam import below.
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+if str(_REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(_REPO_ROOT))
+
+from scripts.common.openclaw_bin import openclaw_bin  # noqa: E402
+
 logging.basicConfig(
     level=logging.INFO,
     format="%(asctime)s [sync-heartbeat] %(levelname)s %(message)s",
@@ -120,7 +128,7 @@ def send_alert(message: str, dry_run: bool = False) -> bool:
     try:
         result = subprocess.run(
             [
-                "openclaw", "agent",
+                openclaw_bin(), "agent",
                 "--agent", OPENCLAW_AGENT,
                 "--message", message,
                 "--deliver",

--- a/scripts/office2/security-monitor/audit.sh
+++ b/scripts/office2/security-monitor/audit.sh
@@ -24,6 +24,11 @@
 
 # --- Configuration ---
 BASE_DIR="/data/services/security-monitor"
+# OpenClaw binary path — the shell arm of the resolution seam
+# (scripts/common/openclaw_bin.py). Overridable via OPENCLAW_BIN; defaults to the
+# sole claude-space install. This script runs from crontab (minimal PATH) and via
+# non-login `sg docker -c`, neither of which has ~/.local/bin on PATH (#653/#811).
+: "${OPENCLAW_BIN:=/home/claude/.local/bin/openclaw}"
 BASELINE_DIR="$BASE_DIR/baselines"
 LOG_DIR="$BASE_DIR/logs"
 DATE=$(date +%Y-%m-%d)
@@ -224,11 +229,10 @@ rm -f "$tmp"
 # diffs (lastDelivered, nextRunAtMs, etc.) don't trigger false positives.
 log "Scanning OpenClaw cron config..."
 tmp=$(mktemp)
-# Absolute claude-space path: this runs from crontab (minimal PATH) and via
-# non-login `sg docker -c`, neither of which has ~/.local/bin on PATH. Bare
-# `openclaw` here silently captured an empty list after the #653 root-global
-# removal (deleted /usr/bin/openclaw) → false daily drift on openclaw-cron.txt.
-/home/claude/.local/bin/openclaw cron list --json 2>/dev/null \
+# Binary path via the seam convention ($OPENCLAW_BIN, set above): a bare
+# `openclaw` here silently captured an empty list in the PATH-less cron/`sg
+# docker -c` context → false daily drift on openclaw-cron.txt (#653/#811).
+"$OPENCLAW_BIN" cron list --json 2>/dev/null \
     | jq -S '[.jobs[] | {name, enabled, agentId, schedule, timeoutSeconds: .payload.timeoutSeconds, deliveryMode: .delivery.mode, failureAlert: (.failureAlert // null)}] | sort_by(.name)' \
         > "$tmp" 2>/dev/null \
     || echo "no-openclaw" > "$tmp"

--- a/scripts/openclaw/agents/skills_snapshot.py
+++ b/scripts/openclaw/agents/skills_snapshot.py
@@ -11,8 +11,9 @@ Emit a stable, diffable report so a scoping change can be verified as a clean
 before/after diff. The boundary-critical check is surfaced explicitly: which
 agents can see `gog` (must be calendar-only after scoping).
 
-Runs on office2 (needs the `openclaw` CLI on PATH). Self-contained — no
-scripts.* imports, so it is safe to run by script path or `-m`.
+Runs on office2. The openclaw binary path is resolved by the seam
+(scripts/common/openclaw_bin.py); a repo-root sys.path shim (below) lets this
+run safely by script path or `-m`.
 
 Usage:
   python3 scripts/openclaw/agents/skills_snapshot.py            # human report, all agents
@@ -30,6 +31,16 @@ import os
 import re
 import subprocess
 import sys
+from pathlib import Path
+
+# This oracle may be invoked by script path (``python3 scripts/openclaw/agents/
+# skills_snapshot.py``), so the repo root is not on sys.path unless we put it
+# there ourselves — required for the ``scripts.common.openclaw_bin`` seam import.
+_REPO_ROOT = Path(__file__).resolve().parents[3]
+if str(_REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(_REPO_ROOT))
+
+from scripts.common.openclaw_bin import openclaw_argv  # noqa: E402
 
 DEFAULT_CONFIG = os.path.expanduser("~/.openclaw/openclaw.json")
 SKILL_NAME_RE = re.compile(r"^[a-z0-9][a-z0-9_-]+$")
@@ -50,11 +61,11 @@ def discover_agents(config_path: str) -> list[str]:
 def query_agent(agent_id: str) -> dict:
     """Run `openclaw skills check --agent <id>` and parse visible skills + counts."""
     proc = subprocess.run(
-        # Absolute claude-space path: agent-skill-sync.service has no PATH
-        # override, so the systemd-user default PATH lacks ~/.local/bin. Bare
-        # `openclaw` broke after the #653 root-global removal deleted
-        # /usr/bin/openclaw.
-        ["/home/claude/.local/bin/openclaw", "skills", "check", "--agent", agent_id],
+        # Binary path via the seam (scripts/common/openclaw_bin.py):
+        # agent-skill-sync.service has no PATH override, so the systemd-user
+        # default PATH lacks ~/.local/bin and a bare `openclaw` would fail
+        # (#653/#811).
+        openclaw_argv("skills", "check", "--agent", agent_id),
         capture_output=True,
         text=True,
     )

--- a/scripts/openclaw/enforcement/notification.py
+++ b/scripts/openclaw/enforcement/notification.py
@@ -8,6 +8,7 @@ import logging
 import subprocess
 
 from scripts.common.alert_bus import Alert, Severity, emit
+from scripts.common.openclaw_bin import openclaw_bin
 
 logger = logging.getLogger(__name__)
 
@@ -139,7 +140,7 @@ def send_whatsapp(
     try:
         result = subprocess.run(
             [
-                "openclaw", "agent",
+                openclaw_bin(), "agent",
                 "--agent", agent,
                 "--message", message,
                 "--deliver",

--- a/scripts/openclaw/heartbeat_gate/escalator.py
+++ b/scripts/openclaw/heartbeat_gate/escalator.py
@@ -32,6 +32,8 @@ import subprocess
 from dataclasses import dataclass
 from typing import Optional
 
+from scripts.common.openclaw_bin import openclaw_bin
+
 
 __all__ = [
     "DEFAULT_TIMEOUT_SECONDS",
@@ -65,7 +67,7 @@ def escalate(
     reason: str,
     *,
     timeout_seconds: int = DEFAULT_TIMEOUT_SECONDS,
-    openclaw_binary: str = "openclaw",
+    openclaw_binary: Optional[str] = None,
 ) -> EscalationResult:
     """Wake the expensive-tier path with ``reason`` as context.
 
@@ -83,7 +85,11 @@ def escalate(
     timeout_seconds:
         Per-subprocess timeout. Default 30s.
     openclaw_binary:
-        Override hook for tests; production uses ``openclaw`` from PATH.
+        Override hook for tests. When ``None`` (production default) the path
+        is resolved by the seam (:func:`scripts.common.openclaw_bin.openclaw_bin`)
+        to the absolute install — felix-heartbeat-gate.service has no ``PATH``,
+        so a bare ``openclaw`` resolved to ``None`` via ``shutil.which`` and the
+        escalation silently never fired (#653/#811, H3).
 
     Returns
     -------
@@ -99,16 +105,21 @@ def escalate(
         # shows up in the ledger rather than silently passing.
         return EscalationResult(error="empty reason supplied to escalator")
 
-    # Verify the binary exists before exec. ``shutil.which`` returns
-    # None if not on PATH; surface a clear error instead of a confusing
-    # FileNotFoundError later.
-    if shutil.which(openclaw_binary) is None:
+    # Resolve via the seam by default (absolute path) so the check below passes
+    # in the PATH-less unit; an explicit override (tests) still wins.
+    binary = openclaw_binary or openclaw_bin()
+
+    # Verify the binary exists before exec. ``shutil.which`` returns None if the
+    # path/name does not resolve to an executable; surface a clear error instead
+    # of a confusing FileNotFoundError later. (An absolute path resolves here as
+    # long as it is executable.)
+    if shutil.which(binary) is None:
         return EscalationResult(
-            error=f"openclaw binary not found on PATH: {openclaw_binary}"
+            error=f"openclaw binary not found: {binary}"
         )
 
     cmd = [
-        openclaw_binary,
+        binary,
         "system",
         "event",
         "--mode",

--- a/scripts/openclaw/heartbeat_gate/run.py
+++ b/scripts/openclaw/heartbeat_gate/run.py
@@ -42,8 +42,8 @@ CLI flags
 - ``--heartbeat-md PATH``     operator's contract file.
 - ``--last-decision PATH``    atomic-write target for tick decision.
 - ``--ledger PATH``           append-only JSONL ledger.
-- ``--openclaw-binary PATH``  override hook for tests; production uses
-  ``openclaw`` on PATH.
+- ``--openclaw-binary PATH``  override hook for tests; production resolves the
+  path via the seam (scripts/common/openclaw_bin.py).
 - ``--dry-run``               skip the escalator; print SUMMARY only.
   The ledger is NOT written when ``--dry-run`` is set, so dry-run
   never pollutes the production decision file.
@@ -146,7 +146,7 @@ def run_tick(
     heartbeat_md_path: Path,
     last_decision_path: Path,
     ledger_path: Path,
-    openclaw_binary: str = "openclaw",
+    openclaw_binary: Optional[str] = None,
     dry_run: bool = False,
     now: Optional[datetime] = None,
     escalator_fn: Optional[Any] = None,
@@ -363,8 +363,12 @@ def _build_parser() -> argparse.ArgumentParser:
     )
     parser.add_argument(
         "--openclaw-binary",
-        default="openclaw",
-        help="openclaw CLI binary name or path (default: openclaw on PATH)",
+        default=None,
+        help=(
+            "openclaw CLI binary name or path (default: resolved by the seam "
+            "scripts/common/openclaw_bin.py to the absolute install; "
+            "felix-heartbeat-gate.service has no PATH)"
+        ),
     )
     parser.add_argument(
         "--dry-run",
@@ -434,7 +438,7 @@ def _emergency_fallback_write(
     last_decision_path: Path,
     ledger_path: Path,
     error_text: str,
-    openclaw_binary: str,
+    openclaw_binary: Optional[str],
     dry_run: bool,
 ) -> None:
     """Write a minimal fallback ledger entry after an unhandled exception.

--- a/scripts/openclaw/heartbeat_gate/tests/test_escalator.py
+++ b/scripts/openclaw/heartbeat_gate/tests/test_escalator.py
@@ -32,7 +32,13 @@ def test_escalate_success_returns_event_id(
     _patch_which(monkeypatch, present=True)
 
     def fake_run(cmd, **kwargs):  # type: ignore[no-untyped-def]
-        assert cmd[0:5] == ["openclaw", "system", "event", "--mode", "now"]
+        # H3 (#811): with NO explicit binary, argv[0] must be the seam-resolved
+        # absolute path — never bare "openclaw" (which fails PATH-lessly under
+        # felix-heartbeat-gate.service). The guard cannot catch this
+        # param-default pattern, so this assertion is the regression fence.
+        assert cmd[0] == _escalator.openclaw_bin()
+        assert cmd[0] == "/home/claude/.local/bin/openclaw"
+        assert cmd[1:5] == ["system", "event", "--mode", "now"]
         assert "--json" in cmd
         assert "--text" in cmd
         return subprocess.CompletedProcess(
@@ -119,7 +125,7 @@ def test_escalate_binary_not_on_path(
     _patch_which(monkeypatch, present=False)
     result = escalate("reason")
     assert result.escalated_event_id is None
-    assert result.error and "not found on PATH" in result.error
+    assert result.error and "not found" in result.error
 
 
 def test_escalate_subprocess_nonzero_exit(

--- a/scripts/security/credential_health_check/signals.py
+++ b/scripts/security/credential_health_check/signals.py
@@ -14,6 +14,8 @@ from dataclasses import dataclass
 from datetime import timedelta
 from typing import Callable, Optional
 
+from scripts.common.openclaw_bin import openclaw_argv
+
 from .manifest import Credential
 
 
@@ -121,11 +123,11 @@ def whatsapp_session_signal(
     """Detect not-connected or stale WhatsApp session."""
     try:
         result = subprocess.run(
-            # Absolute claude-space path: this runs under
-            # credential-health-check.service which has no PATH override, so the
-            # systemd-user default PATH lacks ~/.local/bin. Bare `openclaw` broke
-            # after the #653 root-global removal deleted /usr/bin/openclaw.
-            ["/home/claude/.local/bin/openclaw", "channels", "status"],
+            # Binary path via the seam (scripts/common/openclaw_bin.py): this
+            # runs under credential-health-check.service which has no PATH
+            # override, so the systemd-user default PATH lacks ~/.local/bin and a
+            # bare `openclaw` would fail (#653/#811).
+            openclaw_argv("channels", "status"),
             capture_output=True,
             text=True,
             timeout=10,

--- a/scripts/sync/send_whatsapp.py
+++ b/scripts/sync/send_whatsapp.py
@@ -17,6 +17,8 @@ import subprocess
 import sys
 from dataclasses import dataclass
 
+from scripts.common.openclaw_bin import openclaw_bin
+
 
 # ---------------------------------------------------------------------------
 # Constants
@@ -77,7 +79,9 @@ def send(
     - subprocess exit 0 → SendResult(True, 0, None)
     - subprocess exit nonzero → SendResult(False, exit_code, stderr_text)
     - TimeoutExpired → SendResult(False, -1, "timeout after Ns")
-    - FileNotFoundError → SendResult(False, -2, "openclaw binary not found on PATH")
+    - FileNotFoundError → SendResult(False, -2, "openclaw binary not found ...")
+
+    The binary path is resolved by the seam (scripts/common/openclaw_bin.py).
     """
     if dry_run:
         sys.stderr.write(
@@ -88,7 +92,7 @@ def send(
     try:
         result = subprocess.run(
             [
-                "openclaw", "agent",
+                openclaw_bin(), "agent",
                 "--agent", agent,
                 "--message", message,
                 "--deliver",
@@ -109,7 +113,7 @@ def send(
         return SendResult(
             success=False,
             exit_code=-2,
-            stderr="openclaw binary not found on PATH",
+            stderr=f"openclaw binary not found at {openclaw_bin()}",
         )
 
     if result.returncode == 0:

--- a/scripts/trust/cron_drift_detector.py
+++ b/scripts/trust/cron_drift_detector.py
@@ -25,6 +25,7 @@ import json
 import subprocess
 from dataclasses import dataclass
 
+from scripts.common.openclaw_bin import openclaw_argv
 from scripts.trust.cron_baseline import ApprovedCron
 
 # Closed set of finding kinds (mirrors the token-constant pattern in
@@ -35,11 +36,11 @@ KIND_SCHEDULE_MISMATCH = "schedule_mismatch"
 KIND_ENABLED_MISMATCH = "enabled_mismatch"
 
 # Fixed argv for the live-enumeration subprocess (no shell, never `exec` —
-# matches the felix-health-check runner style). Absolute claude-space path:
-# felix-trust-scan.service has no PATH override, so the systemd-user default
-# PATH lacks ~/.local/bin. After the #653 root-global removal deleted
-# /usr/bin/openclaw, bare `openclaw` raised FileNotFoundError → the scan failed.
-OPENCLAW_CRON_LIST_ARGV = ["/home/claude/.local/bin/openclaw", "cron", "list", "--json"]
+# matches the felix-health-check runner style). The binary path is resolved by
+# the seam (scripts/common/openclaw_bin.py): felix-trust-scan.service has no
+# PATH override, so the systemd-user default PATH lacks ~/.local/bin and a bare
+# `openclaw` would raise FileNotFoundError → the scan would fail (#653/#811).
+OPENCLAW_CRON_LIST_ARGV = openclaw_argv("cron", "list", "--json")
 SUBPROCESS_TIMEOUT_SECONDS = 30
 
 

--- a/tests/canary/test_probes.py
+++ b/tests/canary/test_probes.py
@@ -607,7 +607,7 @@ def _cron_list(*jobs):
 def _cron_hc(crons, **overrides):
     hc = {
         "method": "openclaw-cron-state",
-        "endpoint": "/usr/bin/openclaw cron list --json",
+        "endpoint": "/home/claude/.local/bin/openclaw cron list --json",
         "crons": crons,
         "timeout_seconds": 30,
         "grace_seconds": 900,
@@ -790,7 +790,7 @@ def test_openclaw_cron_no_jobs_key_is_unevaluable():
 
 def test_openclaw_cron_no_crons_configured_is_unevaluable():
     hc = {"method": "openclaw-cron-state",
-          "endpoint": "/usr/bin/openclaw cron list --json"}
+          "endpoint": "/home/claude/.local/bin/openclaw cron list --json"}
     result = run_probe(hc, NOW, http_get=_boom, run_cmd=_boom, read_state=_boom)
     assert not result.evaluable and "no crons" in result.evidence
 

--- a/tests/common/test_openclaw_bin.py
+++ b/tests/common/test_openclaw_bin.py
@@ -1,0 +1,66 @@
+"""Unit tests for the OpenClaw binary-path seam (#811).
+
+Covers the resolution contract: env override wins when non-blank, the absolute
+default otherwise, a blank/whitespace override falls through, and the
+``openclaw_argv`` convenience shape. The seam is pure (no I/O, no network), so
+these are plain in-process assertions with ``monkeypatch`` on the environment.
+"""
+from __future__ import annotations
+
+from scripts.common import openclaw_bin as ob
+
+
+def test_default_when_env_unset(monkeypatch):
+    monkeypatch.delenv(ob.OPENCLAW_BIN_ENV, raising=False)
+    assert ob.openclaw_bin() == ob.DEFAULT_OPENCLAW_BIN
+    assert ob.DEFAULT_OPENCLAW_BIN == "/home/claude/.local/bin/openclaw"
+
+
+def test_env_override_wins(monkeypatch):
+    monkeypatch.setenv(ob.OPENCLAW_BIN_ENV, "/opt/openclaw/bin/openclaw")
+    assert ob.openclaw_bin() == "/opt/openclaw/bin/openclaw"
+
+
+def test_blank_override_falls_through_to_default(monkeypatch):
+    for blank in ("", "   ", "\t"):
+        monkeypatch.setenv(ob.OPENCLAW_BIN_ENV, blank)
+        assert ob.openclaw_bin() == ob.DEFAULT_OPENCLAW_BIN
+
+
+def test_openclaw_argv_prepends_resolved_bin(monkeypatch):
+    monkeypatch.delenv(ob.OPENCLAW_BIN_ENV, raising=False)
+    assert ob.openclaw_argv("cron", "list", "--json") == [
+        ob.DEFAULT_OPENCLAW_BIN,
+        "cron",
+        "list",
+        "--json",
+    ]
+
+
+def test_openclaw_argv_no_args(monkeypatch):
+    monkeypatch.delenv(ob.OPENCLAW_BIN_ENV, raising=False)
+    assert ob.openclaw_argv() == [ob.DEFAULT_OPENCLAW_BIN]
+
+
+def test_openclaw_argv_honors_override(monkeypatch):
+    monkeypatch.setenv(ob.OPENCLAW_BIN_ENV, "/usr/local/bin/openclaw")
+    assert ob.openclaw_argv("channels", "status") == [
+        "/usr/local/bin/openclaw",
+        "channels",
+        "status",
+    ]
+
+
+def test_seam_imports_are_stdlib_only():
+    """The seam must stay library-tier: it imports only ``os`` (+ __future__)."""
+    import ast
+    from pathlib import Path
+
+    tree = ast.parse(Path(ob.__file__).read_text(encoding="utf-8"))
+    modules: set[str] = set()
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            modules.update(alias.name for alias in node.names)
+        elif isinstance(node, ast.ImportFrom):
+            modules.add(node.module or "")
+    assert modules == {"os", "__future__"}, f"unexpected seam imports: {modules}"

--- a/tests/common/test_openclaw_bin_seam.py
+++ b/tests/common/test_openclaw_bin_seam.py
@@ -1,0 +1,375 @@
+"""Repo-wide guard: every OpenClaw *binary* invocation routes through the seam (#811).
+
+On office2 every runtime consumer runs PATH-less (systemd-user units, cron,
+non-login ``sg docker -c``), so a hardcoded ``/home/claude/.local/bin/openclaw``
+(brittle: breaks on the next relocation) or a bare ``openclaw`` argv[0] (breaks
+PATH-lessly, silently) is a regression. The single source of truth is
+``scripts/common/openclaw_bin.py`` (``openclaw_bin()`` / ``openclaw_argv()``); the
+shell arm is the ``: "${OPENCLAW_BIN:=…}"`` convention.
+
+This is the durable regression fence (mirrors ``tests/common/test_no_bare_astimezone.py``).
+It applies two complementary rules over ``scripts/**`` (excluding the seam, test
+files, and the documented allowlist):
+
+* **Rule 1 (path literal, .py + .sh):** no line may contain the absolute
+  ``/home/claude/.local/bin/openclaw`` or the removed ``/usr/bin/openclaw`` —
+  except the shell ``${OPENCLAW_BIN:=…}``/``:-…}`` convention line. (All
+  explanatory comments/docstrings were scrubbed to reference the seam, so this
+  is false-positive-free.)
+* **Rule 2 (bare argv[0], .py, AST):** no ``subprocess.{run,Popen,call,
+  check_call,check_output}`` call may have an argv whose first element resolves
+  to a bare ``"openclaw"`` or an openclaw path — inline (``["openclaw", …]``) or
+  via a module/local variable (``_OPENCLAW = "openclaw"``; ``cmd = ["openclaw",
+  …]; run(cmd)``). Variable resolution is intentionally module-wide (last write
+  wins) so a guard errs toward catching. Non-argv[0] uses (npm package name,
+  ``OPENCLAW_SERVICE_NAMES`` set) are naturally ignored.
+
+**Known limitations** (documented, not enforced here):
+
+* A *function-parameter default* (``def f(bin="openclaw"): subprocess.run([bin,
+  …])``) is beyond a static guard's reach. The heartbeat-gate escalator is that
+  shape; its regression fence is the targeted assertion in
+  ``scripts/openclaw/heartbeat_gate/tests/test_escalator.py`` (``cmd[0] ==
+  openclaw_bin()``), not this guard.
+* A **shell** bare ``openclaw <subcmd>`` (no path literal) is not caught — Rule 1
+  (.sh) matches only absolute path literals. The recurring PATH-less runtime
+  shell callers (``audit.sh``) use the ``${OPENCLAW_BIN:=…}`` convention; the
+  remaining bare-``openclaw`` ``.sh`` instances are out-of-scope one-shot
+  retirement/install scripts that run under felix-deployer's PATH.
+"""
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+_REPO_ROOT = Path(__file__).resolve().parent.parent.parent
+_SCRIPTS_ROOT = _REPO_ROOT / "scripts"
+
+_PATH_LITERALS = ("/home/claude/.local/bin/openclaw", "/usr/bin/openclaw")
+
+#: The seam itself (defines the default) + the documented bare-``openclaw``
+#: exceptions: felix-deployer PATH-safe callers and the two already-applied
+#: one-shot cron deploy scripts. Repo-relative POSIX paths.
+_ALLOWLIST = frozenset(
+    {
+        "scripts/common/openclaw_bin.py",
+        "scripts/deploy/lib/cron.py",
+        "scripts/deploy/deploy-deterministic-monitoring-checks.py",
+        "scripts/deploy/reschedule-felix-admin-habits-weekly-cron.py",
+        "scripts/deploy/restore-tz-on-habits-weekly-report-cron.py",
+    }
+)
+
+_SUBPROCESS_FUNCS = frozenset({"run", "Popen", "call", "check_call", "check_output"})
+
+
+# ---------------------------------------------------------------------------
+# Scope helpers
+# ---------------------------------------------------------------------------
+
+
+def _is_test_path(rel_posix: str) -> bool:
+    return "/tests/" in rel_posix or Path(rel_posix).name.startswith("test_") or Path(
+        rel_posix
+    ).name == "conftest.py"
+
+
+def _excluded(rel_posix: str) -> bool:
+    return rel_posix in _ALLOWLIST or _is_test_path(rel_posix)
+
+
+def _iter_files(suffix: str) -> list[Path]:
+    return sorted(
+        p
+        for p in _SCRIPTS_ROOT.rglob(f"*{suffix}")
+        if not _excluded(p.relative_to(_REPO_ROOT).as_posix())
+    )
+
+
+def _is_openclaw_binary_str(value: object) -> bool:
+    """True if ``value`` names the openclaw binary when used as argv[0]."""
+    if not isinstance(value, str):
+        return False
+    return value == "openclaw" or value.rstrip("/").endswith("/openclaw")
+
+
+# ---------------------------------------------------------------------------
+# Rule 1 — path literal (.py + .sh)
+# ---------------------------------------------------------------------------
+
+
+def _is_shell_convention_line(line: str) -> bool:
+    stripped = line.strip()
+    return stripped.startswith(': "${OPENCLAW_BIN:') or "${OPENCLAW_BIN:=" in line or (
+        "${OPENCLAW_BIN:-" in line
+    )
+
+
+def _path_literal_findings(rel_posix: str, source: str) -> list[str]:
+    findings: list[str] = []
+    for lineno, line in enumerate(source.splitlines(), start=1):
+        if not any(lit in line for lit in _PATH_LITERALS):
+            continue
+        if rel_posix.endswith(".sh") and _is_shell_convention_line(line):
+            continue
+        findings.append(
+            f"{rel_posix}:{lineno}: hardcoded openclaw path literal — resolve via "
+            f"the seam (scripts/common/openclaw_bin.py) or the ${{OPENCLAW_BIN:=…}} "
+            f"shell convention"
+        )
+    return findings
+
+
+# ---------------------------------------------------------------------------
+# Rule 2 — bare argv[0] (.py, AST)
+# ---------------------------------------------------------------------------
+
+
+def _base_name(node: ast.AST) -> str | None:
+    """Return the leftmost Name id of an attribute/name chain (e.g. subprocess)."""
+    while isinstance(node, ast.Attribute):
+        node = node.value
+    return node.id if isinstance(node, ast.Name) else None
+
+
+def _list_first_elt(node: ast.AST) -> ast.AST | None:
+    if isinstance(node, (ast.List, ast.Tuple)) and node.elts:
+        return node.elts[0]
+    return None
+
+
+def _collect_subprocess_refs(tree: ast.AST) -> tuple[set[str], set[str]]:
+    """Return (module aliases bound to ``subprocess``, directly-imported func names).
+
+    Handles ``import subprocess`` / ``import subprocess as sp`` (alias → matched
+    as the receiver of ``.run``/…) and ``from subprocess import run, Popen``
+    (name → matched as a bare call). Closes the alias/direct-import blind spot.
+    """
+    aliases: set[str] = set()
+    direct: set[str] = set()
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            for alias in node.names:
+                if alias.name == "subprocess":
+                    aliases.add(alias.asname or "subprocess")
+        elif isinstance(node, ast.ImportFrom) and node.module == "subprocess":
+            for alias in node.names:
+                if alias.name in _SUBPROCESS_FUNCS:
+                    direct.add(alias.asname or alias.name)
+    return aliases, direct
+
+
+def _collect_name_bindings(tree: ast.AST) -> tuple[dict[str, object], dict[str, ast.AST]]:
+    """Module-wide (last-write-wins) maps: name→str value, name→list-first-elt node."""
+    str_vars: dict[str, object] = {}
+    list_first: dict[str, ast.AST] = {}
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Assign):
+            continue
+        for target in node.targets:
+            if not isinstance(target, ast.Name):
+                continue
+            if isinstance(node.value, ast.Constant):
+                str_vars[target.id] = node.value.value
+            first = _list_first_elt(node.value)
+            if first is not None:
+                list_first[target.id] = first
+    return str_vars, list_first
+
+
+def _argv0_is_openclaw(
+    first_arg: ast.AST,
+    str_vars: dict[str, object],
+    list_first: dict[str, ast.AST],
+) -> bool:
+    # subprocess.run("…string…", shell=True) — check the first shell token
+    if isinstance(first_arg, ast.Constant):
+        value = first_arg.value
+        if isinstance(value, str) and value.split():
+            return _is_openclaw_binary_str(value.split()[0])
+        return False
+    # subprocess.run(["openclaw", …]) / (( "openclaw", … ))
+    elt0 = _list_first_elt(first_arg)
+    if elt0 is not None:
+        if isinstance(elt0, ast.Constant) and _is_openclaw_binary_str(elt0.value):
+            return True
+        if isinstance(elt0, ast.Name) and _is_openclaw_binary_str(str_vars.get(elt0.id)):
+            return True
+        return False
+    # subprocess.run(CMD)  where CMD is a Name bound to a list or the binary string
+    if isinstance(first_arg, ast.Name):
+        if _is_openclaw_binary_str(str_vars.get(first_arg.id)):
+            return True
+        bound_first = list_first.get(first_arg.id)
+        if isinstance(bound_first, ast.Constant) and _is_openclaw_binary_str(
+            bound_first.value
+        ):
+            return True
+        if isinstance(bound_first, ast.Name) and _is_openclaw_binary_str(
+            str_vars.get(bound_first.id)
+        ):
+            return True
+    return False
+
+
+def _bare_argv_findings(rel_posix: str, source: str) -> list[str]:
+    try:
+        tree = ast.parse(source)
+    except SyntaxError:
+        return []
+    str_vars, list_first = _collect_name_bindings(tree)
+    aliases, direct = _collect_subprocess_refs(tree)
+    findings: list[str] = []
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Call):
+            continue
+        func = node.func
+        # subprocess.run(...) / sp.run(...)  — attribute call on a subprocess alias
+        is_attr_call = (
+            isinstance(func, ast.Attribute)
+            and func.attr in _SUBPROCESS_FUNCS
+            and _base_name(func) in aliases
+        )
+        # run(...) / check_output(...)  — a name directly imported from subprocess
+        is_direct_call = isinstance(func, ast.Name) and func.id in direct
+        if not (is_attr_call or is_direct_call):
+            continue
+        if not node.args:
+            continue
+        if _argv0_is_openclaw(node.args[0], str_vars, list_first):
+            findings.append(
+                f"{rel_posix}:{node.lineno}: subprocess argv[0] is a bare/hardcoded "
+                f"openclaw — use openclaw_bin()/openclaw_argv() from the seam"
+            )
+    return findings
+
+
+# ---------------------------------------------------------------------------
+# Full-tree scan
+# ---------------------------------------------------------------------------
+
+
+def _scan_all() -> list[str]:
+    findings: list[str] = []
+    for path in _iter_files(".py"):
+        rel = path.relative_to(_REPO_ROOT).as_posix()
+        src = path.read_text(encoding="utf-8")
+        findings.extend(_path_literal_findings(rel, src))
+        findings.extend(_bare_argv_findings(rel, src))
+    for path in _iter_files(".sh"):
+        rel = path.relative_to(_REPO_ROOT).as_posix()
+        findings.extend(_path_literal_findings(rel, path.read_text(encoding="utf-8")))
+    return findings
+
+
+# ---------------------------------------------------------------------------
+# The gate
+# ---------------------------------------------------------------------------
+
+
+def test_all_openclaw_binary_callers_route_through_seam():
+    findings = _scan_all()
+    assert not findings, (
+        "OpenClaw binary invocation not routed through the seam (#811). Use "
+        "scripts/common/openclaw_bin.py (openclaw_bin()/openclaw_argv()) or the "
+        "${OPENCLAW_BIN:=…} shell convention, or add a documented allowlist entry:\n  "
+        + "\n  ".join(findings)
+    )
+
+
+def test_scan_actually_covers_files():
+    """Guard the guard: a broken glob that scanned nothing would be vacuously green."""
+    rels = {p.relative_to(_REPO_ROOT).as_posix() for p in _iter_files(".py")}
+    shels = {p.relative_to(_REPO_ROOT).as_posix() for p in _iter_files(".sh")}
+    assert "scripts/trust/cron_drift_detector.py" in rels
+    assert "scripts/sync/send_whatsapp.py" in rels
+    assert "scripts/office2/security-monitor/audit.sh" in shels
+    # Exclusions actually exclude.
+    assert "scripts/common/openclaw_bin.py" not in rels
+    assert "scripts/deploy/lib/cron.py" not in rels
+
+
+# --- positive controls (a reintroduced regression MUST fire) ---------------
+
+
+def test_positive_inline_list():
+    src = "import subprocess\nsubprocess.run(['openclaw', 'cron', 'list'])\n"
+    assert _bare_argv_findings("x.py", src)
+
+
+def test_positive_module_var_indirection():
+    src = "import subprocess\n_OPENCLAW = 'openclaw'\nsubprocess.run([_OPENCLAW, 'x'])\n"
+    assert _bare_argv_findings("x.py", src)
+
+
+def test_positive_local_list_var_indirection():
+    src = (
+        "import subprocess\n"
+        "def f():\n"
+        "    cmd = ['openclaw', 'system', 'event']\n"
+        "    subprocess.run(cmd)\n"
+    )
+    assert _bare_argv_findings("x.py", src)
+
+
+def test_positive_subprocess_alias_import():
+    src = "import subprocess as sp\nsp.run(['openclaw', 'cron', 'list'])\n"
+    assert _bare_argv_findings("x.py", src)
+
+
+def test_positive_from_subprocess_direct_import():
+    src = "from subprocess import run\nrun(['openclaw', 'agent'])\n"
+    assert _bare_argv_findings("x.py", src)
+
+
+def test_positive_absolute_path_argv():
+    src = "import subprocess\nsubprocess.run(['/home/claude/.local/bin/openclaw', 'x'])\n"
+    assert _bare_argv_findings("x.py", src)
+
+
+def test_positive_shell_true_string():
+    src = "import subprocess\nsubprocess.run('/usr/bin/openclaw cron list', shell=True)\n"
+    assert _bare_argv_findings("x.py", src)
+
+
+def test_positive_path_literal_in_py():
+    src = 'X = "/home/claude/.local/bin/openclaw"\n'
+    assert _path_literal_findings("x.py", src)
+
+
+def test_positive_path_literal_in_sh_noncomment():
+    src = "/home/claude/.local/bin/openclaw cron list\n"
+    assert _path_literal_findings("x.sh", src)
+
+
+# --- negative controls (legitimate code must NOT fire) ---------------------
+
+
+def test_negative_seam_helpers():
+    src = (
+        "import subprocess\n"
+        "from scripts.common.openclaw_bin import openclaw_argv, openclaw_bin\n"
+        "subprocess.run(openclaw_argv('cron', 'list'))\n"
+        "subprocess.run([openclaw_bin(), 'agent'])\n"
+    )
+    assert _bare_argv_findings("x.py", src) == []
+
+
+def test_negative_npm_package_name_at_index_2():
+    src = "import subprocess\nsubprocess.run(['npm', 'install', 'openclaw'])\n"
+    assert _bare_argv_findings("x.py", src) == []
+
+
+def test_negative_service_name_set():
+    src = "OPENCLAW_SERVICE_NAMES = frozenset({'openclaw', 'openclaw-gateway'})\n"
+    assert _bare_argv_findings("x.py", src) == []
+
+
+def test_negative_shell_convention_line():
+    src = ': "${OPENCLAW_BIN:=/home/claude/.local/bin/openclaw}"\n'
+    assert _path_literal_findings("x.sh", src) == []
+
+
+def test_negative_dollar_openclaw_bin_call():
+    src = '"$OPENCLAW_BIN" cron list --json\n'
+    assert _path_literal_findings("x.sh", src) == []

--- a/tests/deploy/test_deploy_openclaw_bin_seam.py
+++ b/tests/deploy/test_deploy_openclaw_bin_seam.py
@@ -1,0 +1,133 @@
+"""Tests for scripts/deploy/deploy-openclaw-bin-seam.py + its manifest (#811).
+
+The entrypoint copies the checkout's security-monitor audit.sh to its standalone
+office2 copy and verifies byte-identity. These tests exercise the deterministic
+copy/verify + the CLI contract (dry-run / apply / usage error) against tmp paths,
+so they never touch the real /data path.
+"""
+from __future__ import annotations
+
+import importlib.util
+import json
+import pathlib
+import sys
+
+import pytest
+import yaml
+
+_REPO_ROOT = pathlib.Path(__file__).resolve().parents[2]
+_ENTRYPOINT_PATH = _REPO_ROOT / "scripts" / "deploy" / "deploy-openclaw-bin-seam.py"
+_MANIFEST_QUEUED = _REPO_ROOT / "deploys" / "queued" / "0021-openclaw-bin-seam.yaml"
+
+
+def _load_entrypoint():
+    if str(_REPO_ROOT) not in sys.path:
+        sys.path.insert(0, str(_REPO_ROOT))
+    spec = importlib.util.spec_from_file_location("deploy_openclaw_bin_seam", _ENTRYPOINT_PATH)
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+_mod = _load_entrypoint()
+
+
+def _capsys_json(capsys) -> dict:
+    out = capsys.readouterr().out.strip().splitlines()
+    return json.loads(out[-1])
+
+
+# --- CLI contract ----------------------------------------------------------
+
+
+def test_no_mode_is_usage_error():
+    assert _mod.main([]) == 2
+
+
+def test_both_modes_is_usage_error():
+    assert _mod.main(["--dry-run", "--apply"]) == 2
+
+
+# --- dry-run ---------------------------------------------------------------
+
+
+def test_dry_run_reports_copy_needed(monkeypatch, tmp_path, capsys):
+    src = tmp_path / "audit.sh"
+    src.write_text("echo hi\n")
+    monkeypatch.setattr(_mod, "_SOURCE", src)
+    monkeypatch.setattr(_mod, "_TARGET", tmp_path / "deployed" / "audit.sh")
+    assert _mod.main(["--dry-run"]) == 0
+    payload = _capsys_json(capsys)
+    assert payload["outcome"] == "dry_run"
+    assert payload["target_exists"] is False
+    assert payload["would_copy"] is True
+
+
+def test_dry_run_missing_source_fails(monkeypatch, tmp_path, capsys):
+    monkeypatch.setattr(_mod, "_SOURCE", tmp_path / "nope.sh")
+    assert _mod.main(["--dry-run"]) == 1
+    assert _capsys_json(capsys)["outcome"] == "dry_run_error"
+
+
+# --- apply -----------------------------------------------------------------
+
+
+def test_apply_copies_and_verifies(monkeypatch, tmp_path, capsys):
+    src = tmp_path / "audit.sh"
+    src.write_text("#!/usr/bin/env bash\n: \"${OPENCLAW_BIN:=/x}\"\n")
+    src.chmod(0o755)
+    target = tmp_path / "deployed" / "audit.sh"  # parent does not exist yet
+    monkeypatch.setattr(_mod, "_SOURCE", src)
+    monkeypatch.setattr(_mod, "_TARGET", target)
+
+    assert _mod.main(["--apply"]) == 0
+    assert _capsys_json(capsys)["outcome"] == "applied"
+    assert target.read_text() == src.read_text()
+    # Executable bit preserved (copy2).
+    assert target.stat().st_mode & 0o111
+
+
+def test_apply_forces_executable_from_nonexec_source(monkeypatch, tmp_path, capsys):
+    """audit.sh is invoked directly, so the target must be +x even if the repo
+    source is not executable (the #811 code-review HIGH: copy2 preserves the
+    source's non-exec mode)."""
+    src = tmp_path / "audit.sh"
+    src.write_text("echo hi\n")
+    src.chmod(0o644)  # deliberately NOT executable
+    target = tmp_path / "deployed" / "audit.sh"
+    monkeypatch.setattr(_mod, "_SOURCE", src)
+    monkeypatch.setattr(_mod, "_TARGET", target)
+
+    assert _mod.main(["--apply"]) == 0
+    assert _capsys_json(capsys)["outcome"] == "applied"
+    assert target.stat().st_mode & 0o111, "target must be executable after apply"
+
+
+def test_apply_is_idempotent(monkeypatch, tmp_path, capsys):
+    src = tmp_path / "audit.sh"
+    src.write_text("echo hi\n")
+    target = tmp_path / "deployed" / "audit.sh"
+    monkeypatch.setattr(_mod, "_SOURCE", src)
+    monkeypatch.setattr(_mod, "_TARGET", target)
+    assert _mod.main(["--apply"]) == 0
+    assert _mod.main(["--apply"]) == 0  # second run: still success, no error
+    assert _capsys_json(capsys)["outcome"] == "applied"
+
+
+def test_apply_missing_source_fails(monkeypatch, tmp_path, capsys):
+    monkeypatch.setattr(_mod, "_SOURCE", tmp_path / "nope.sh")
+    monkeypatch.setattr(_mod, "_TARGET", tmp_path / "deployed" / "audit.sh")
+    assert _mod.main(["--apply"]) == 1
+    assert _capsys_json(capsys)["outcome"] == "apply_error"
+
+
+# --- manifest --------------------------------------------------------------
+
+
+def test_manifest_shape():
+    m = yaml.safe_load(_MANIFEST_QUEUED.read_text())
+    assert m["schema_version"] == "v1"
+    assert m["tier"] == 3
+    assert m["audited_surface"] is False
+    assert m["entrypoint"] == "scripts/deploy/deploy-openclaw-bin-seam.py"
+    assert m["issue"] == "kentonium3/kg-automation#811"

--- a/tests/sync/test_send_whatsapp.py
+++ b/tests/sync/test_send_whatsapp.py
@@ -49,9 +49,10 @@ class TestArgumentOrder:
         mock_run.return_value = subprocess.CompletedProcess(args=[], returncode=0, stdout="", stderr="")
         sw.send(message="msg", recipient="+15551234567")
         called_args = mock_run.call_args[0][0]
-        # Exact precedence per contracts/whatsapp-send.md.
+        # Exact precedence per contracts/whatsapp-send.md. argv[0] is the
+        # seam-resolved openclaw path (#811), not a bare "openclaw".
         assert called_args == [
-            "openclaw", "agent",
+            sw.openclaw_bin(), "agent",
             "--agent", "main",
             "--message", "msg",
             "--deliver",


### PR DESCRIPTION
## What

Single-source the OpenClaw binary path behind a resolution seam
(`scripts/common/openclaw_bin.py` — `openclaw_bin()` / `openclaw_argv()`), so a
future relocation is a one-line change instead of an edit at every subprocess
call site. Mirrors the #748 vikunja-reference-seam.

Closes #811.

## Why it grew past "~7 sites"

Adversarial plan review (reviewer-renata + Codex) proved the issue's "~7 sites"
was an undercount. True population = **9 live binary callers**, all migrated:
`cron_drift_detector`, `credential_health_check/signals`, `skills_snapshot`
(+shim), `habits/weekly_report_driver`, `deploy-habits-weekly-driver`,
`sync/send_whatsapp` (#507), `openclaw/enforcement/notification`,
`obsidian/sync-heartbeat` (+shim), `heartbeat_gate/escalator` + `run`.

## Bonus bug fix (H3)

`felix-heartbeat-gate.service` sets no `PATH`, so the escalator's
`shutil.which("openclaw")` returned `None` and the **expensive-tier (Sonnet) wake
silently never fired** — the exact #653 PATH-less failure class. The escalator
default now resolves via the seam (absolute path), so escalation works.

## Guard + exceptions

`tests/common/test_openclaw_bin_seam.py` fails on any new hardcoded/bare openclaw
invocation outside the seam (AST argv[0] with subprocess-alias + variable
indirection, plus a path-literal backstop). Documented, allowlisted exceptions:
the felix-deployer PATH-safe cron primitives, two applied one-shot deploy
scripts, and the 3 canary `endpoint` strings in `service-inventory.json`.

## Deploy

- The 9 Python callers are checkout-resident (`python3 -m` from the felix-deployer
  origin/main checkout) → **live on the next pull**, no deploy action.
- `audit.sh` runs from a standalone copy at
  `/data/services/security-monitor/scripts/`; manifest
  `deploys/queued/0021-openclaw-bin-seam.yaml` + entrypoint
  `deploy-openclaw-bin-seam.py` copy+verify it (repo `audit.sh` is `+x`; the
  entrypoint enforces the executable bit on the target).
- **Rebaseline: not required** — the deployed change touches no hashed audited
  surface (`audit.sh` matches no `audited-surfaces.json` pattern; path-resolution
  only, so `openclaw cron list` output + the `openclaw-cron.txt` baseline are
  unchanged). Only audited-path match is the manifest itself (`deploy-pipeline`,
  `affected_baselines: []`).

## Review + tests

Two plan reviews (NEEDS-REWORK → SHIP-WITH-FIXES) and two code reviews
(reviewer-renata **SHIP-AS-IS**, Codex **SHIP-WITH-FIXES** — the one HIGH, the
`audit.sh` executable bit, fixed). All findings folded. Full suite: **5566
passed, 42 skipped, 1 xfailed**.

## Live-verify plan (post-merge / post-deploy)

- `felix-trust-scan`, `credential-health-check`, `agent-skill-sync`,
  `felix-habits-weekly` → clean tick.
- **H3:** trigger `felix-heartbeat-gate` ESCALATE → no "not found on PATH"; wake fires.
- `audit.sh` via `sg docker -c` → `openclaw-cron.txt` non-empty, no false drift.
