### PR TITLE
fix(#815): resolve bin-seam manifest from queued-or-applied in test

### DIFF
--- a/tests/deploy/test_deploy_openclaw_bin_seam.py
+++ b/tests/deploy/test_deploy_openclaw_bin_seam.py
@@ -20,6 +20,16 @@ _ENTRYPOINT_PATH = _REPO_ROOT / "scripts" / "deploy" / "deploy-openclaw-bin-seam
 _MANIFEST_QUEUED = _REPO_ROOT / "deploys" / "queued" / "0021-openclaw-bin-seam.yaml"
 
 
+def _resolve_manifest_path() -> pathlib.Path:
+    """queued pre-deploy, applied/<NNNN>-... once felix-deployer relocates it."""
+    if _MANIFEST_QUEUED.exists():
+        return _MANIFEST_QUEUED
+    applied = sorted(
+        (_REPO_ROOT / "deploys" / "applied").glob("*-openclaw-bin-seam.yaml")
+    )
+    return applied[-1] if applied else _MANIFEST_QUEUED
+
+
 def _load_entrypoint():
     if str(_REPO_ROOT) not in sys.path:
         sys.path.insert(0, str(_REPO_ROOT))
@@ -125,7 +135,7 @@ def test_apply_missing_source_fails(monkeypatch, tmp_path, capsys):
 
 
 def test_manifest_shape():
-    m = yaml.safe_load(_MANIFEST_QUEUED.read_text())
+    m = yaml.safe_load(_resolve_manifest_path().read_text())
     assert m["schema_version"] == "v1"
     assert m["tier"] == 3
     assert m["audited_surface"] is False


### PR DESCRIPTION
## What

`tests/deploy/test_deploy_openclaw_bin_seam.py::test_manifest_shape` read `deploys/queued/0021-openclaw-bin-seam.yaml` by hard-coded path. felix-deployer **applied** that manifest on main at 2026-07-20 02:44 UTC (commit `8877476`), relocating it to `deploys/applied/` — so the test has been red on every push since (this is #815).

## Fix

Add the `_resolve_manifest_path()` helper (queued pre-deploy → newest `deploys/applied/*-openclaw-bin-seam.yaml` post-deploy) that the sibling deploy tests already use (`test_deploy_openclaw_update_check`, `_felix_canary`, `_habits_weekly_driver`), and read the manifest through it. The applied record still carries every asserted field (`schema_version`/`tier`/`audited_surface`/`entrypoint`/`issue`); felix-deployer only *adds* `applied_at`/`rebaseline`.

The #811 test was the lone omission of this established convention — no other deploy test has the latent break (audited all readers of real-repo manifests).

## Gate

- `make test` → 5890 passed, 0 failed (was 1 failed / 5888 passed)
- `validate_docs` / `validate_privacy_boundary` / `validate_architecture_data` → all clean

Test-only. **Rebaseline: not required** — `tests/**` is not an audited surface.

Closes #815

🤖 Generated with [Claude Code](https://claude.com/claude-code)