### PR TITLE
fix(#808): add TOOLS.md to openclaw-agent-prompts audited-surface patterns

### DIFF
--- a/docs/design/architecture/data/audited-surfaces.json
+++ b/docs/design/architecture/data/audited-surfaces.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.0",
-  "last_updated": "2026-07-19",
-  "updated_by": "felix-admin-cron-path-fix-01KWQTY3 (#656) + finalize-inbox-file-01KW8MSQ (#325, #621 correction) + pull-based-deploy-pipeline-01KTYQQS (#136) + #557-rebaseline-workflow + openclaw-skills-sync-01KXW1DQ (#775: scripts/openclaw/deploy/*.{service,timer} + scripts/deploy/*.sh)",
+  "last_updated": "2026-07-20",
+  "updated_by": "felix-admin-cron-path-fix-01KWQTY3 (#656) + finalize-inbox-file-01KW8MSQ (#325, #621 correction) + pull-based-deploy-pipeline-01KTYQQS (#136) + #557-rebaseline-workflow + openclaw-skills-sync-01KXW1DQ (#775: scripts/openclaw/deploy/*.{service,timer} + scripts/deploy/*.sh) + #808 (add TOOLS.md to openclaw-agent-prompts patterns — matches deploy_agent_prompts.py IN_SCOPE_FILENAMES)",
   "description": "Repo-side inputs whose changes alter the office2 security-monitor baselines. When a commit modifies any matching path, the rebaseline procedure in security-baseline-ops.md should be triggered after the change deploys, otherwise the daily audit will alert as drift. Consumed by tooling/scripts/check_audited_surface_drift.py (CI soft-reminder) and referenced by docs/design/architecture/change-control.md + spec-kitty charter quality gates.",
   "rebaseline_runbook": "docs/runbooks/security-baseline-ops.md",
   "rebaseline_command": "ssh office2-claude 'rm /data/services/security-monitor/baselines/* && sg docker -c /data/services/security-monitor/scripts/audit.sh'",
@@ -14,6 +14,7 @@
       "patterns": [
         "scripts/openclaw/agents/*/AGENTS.md",
         "scripts/openclaw/agents/*/SOUL.md",
+        "scripts/openclaw/agents/*/TOOLS.md",
         "scripts/openclaw/agents/*/IDENTITY.md",
         "scripts/openclaw/agents/*/USER.md",
         "scripts/openclaw/agents/*/GOVERNANCE.md"


### PR DESCRIPTION
## What

The `openclaw-agent-prompts` surface in `audited-surfaces.json` is defined as *the files the 5-min agent-prompt-sync timer copies to office2*, but its `patterns` list **omitted `TOOLS.md`** — even though `scripts/openclaw/deploy/deploy_agent_prompts.py` syncs it (`IN_SCOPE_FILENAMES = {AGENTS, IDENTITY, SOUL, TOOLS, USER}.md`). A `TOOLS.md` edit to a live workspace was therefore not matched by its own surface (this is #808).

## Fix

Add `scripts/openclaw/agents/*/TOOLS.md` to the pattern list so the inventory matches the deploy authority (7 live `TOOLS.md` files exist and are synced). Pure data-correctness; no behavior change today (surface is `rebaseline_required: false`), but closes the latent detection gap flagged for if the surface ever gains monitoring semantics (#621).

## Observation (not changed here — flagging for a call)

While confirming the list per the issue's "confirm the others are complete": the patterns also include `scripts/openclaw/agents/*/GOVERNANCE.md`, but `deploy_agent_prompts.py` **excludes** `GOVERNANCE.md` from sync (`EXCLUDED_GOVERNANCE`). `main/GOVERNANCE.md` exists in-repo but is manually maintained on office2, not sync-deployed. By this surface's own "files the sync timer copies" definition, `GOVERNANCE.md` arguably doesn't belong — but it *is* a real workspace file, so removing it is a monitoring-intent judgment, not an unambiguous correctness fix. Left as-is; can file a follow-up if you want the patterns to exactly equal `IN_SCOPE_FILENAMES`.

## Gate
- JSON valid; `validate_architecture_data` / `validate_docs` / `validate_privacy_boundary` → all clean.

Data-only (Tier 4). **Rebaseline: not required** — audited-surfaces.json is not a hashed baseline.

Closes #808

🤖 Generated with [Claude Code](https://claude.com/claude-code)