### PR TITLE
fix(#819): remove dead gog liveness probe from credential-manifest

### DIFF
--- a/docs/design/architecture/data/credential-manifest.json
+++ b/docs/design/architecture/data/credential-manifest.json
@@ -193,12 +193,7 @@
       "expiry_notes": "Holds OAuth refresh tokens. Refresh tokens have no fixed expiry but are revoked by: password change on the linked Google account, 6+ months inactivity, Google security review, or manual revocation at myaccount.google.com/permissions. Re-mint via `gog auth add <email> --services ... --remote` per the runbook.",
       "created_date": "2026-05-13",
       "last_reviewed": "2026-05-13",
-      "liveness_probe": {
-        "enabled": true,
-        "gog_account": "kentgale@gmail.com",
-        "keyring_file": "/home/claude/.config/gogcli/keyring/_gogcli_key_v1_dG9rZW46ZGVmYXVsdDprZW50Z2FsZUBnbWFpbC5jb20",
-        "recovery_command": "ssh -t office2-claude /home/claude/kg-automation/scripts/security/gog-reauth.sh"
-      }
+      "liveness_probe_removed": "2026-07-20 (#819): gog is decommissioned (#629) with no consumer, so the probe (`gog calendar options`) errored every run — 'no TTY available for keyring file backend password prompt' — leaving credential-health-check errors=1 each cycle and masking real probe errors. Probe block removed to silence the false error; the credential entry itself stays for the full #629 gog decommission."
     },
     {
       "name": "openclaw-gateway-env",


### PR DESCRIPTION
## What

`gog-credentials-keyring` in `credential-manifest.json` carried a `liveness_probe` that ran `gog calendar options` every credential-health / liveness cycle. gog is decommissioned (#629 — no consumer), and on headless office2 the probe can only fail:

```
gog exited 1: … no TTY available for keyring file backend password prompt; set GOG_KEYRING_PASSWORD
```

So every cycle ended `errors=1` **solely** from this dead probe — masking any real probe error in the count (surfaced during #816 live-verify).

## Fix

Remove the `liveness_probe` block so the credential is liveness-skipped (`reason=no liveness_probe block`, per `manifest.py:159`). The credential entry itself **stays** — full gog decommission is tracked in #629. A `liveness_probe_removed` breadcrumb records the why.

## Verify (local)

```
$ python3 -m scripts.security.credential_health_check --manifest … --dry-run --liveness-only
… liveness_skipped … name=gog-credentials-keyring reason=no liveness_probe block
… cycle_end … credentials_evaluated=18 … errors=0
```

Will confirm `errors=0` live on office2 post-merge (credential-health-check was itself just resurrected in #816).

## Gate
- 142 credential/manifest/liveness tests pass; `validate_architecture_data` / `validate_docs` / `validate_privacy_boundary` clean.

Data-only. **Rebaseline: not required** — credential-manifest.json is not a hashed audited surface.

Closes #819

🤖 Generated with [Claude Code](https://claude.com/claude-code)