### PR TITLE
fix(#805): accept Output Discipline block in SOUL.md, not only AGENTS.md (Option B)

### DIFF
--- a/docs/design/openclaw-workspace-authoring-standard.md
+++ b/docs/design/openclaw-workspace-authoring-standard.md
@@ -101,12 +101,23 @@ them (a `~/` path in a prompt is the #732 nonexistent-path bug the guard now rej
 ### Invariant B — Output Discipline
 
 Any agent that emits **user-facing WhatsApp** must carry the Output Discipline
-(Hard Rules) block in `AGENTS.md` (the canonical source is felix-admin-capture's
-block). An agent that does **not** emit user-facing WhatsApp must instead carry an
-explicit annotation — the literal marker **`no user-facing WhatsApp`** — so the
-absence is a deliberate, declared choice rather than an oversight. The validation
-check is **presence-or-annotation**: block present *or* annotation present passes;
-neither fails.
+(Hard Rules) block (the canonical source is felix-admin-capture's block).
+`AGENTS.md` is the **preferred home** — it is where the fleet keeps the block and
+where an auditor looks first (`grep '## Output discipline' */AGENTS.md`). The block
+is also **accepted in `SOUL.md`**, because OpenClaw loads it into the agent's system
+context too, so the discipline genuinely governs the running agent wherever the block
+sits (#805). A block found in `SOUL.md` passes but is annotated *(preferred home is
+AGENTS.md)* in the report so a canonical relocation can be tracked per-agent (e.g.
+`felix-admin-calendar`'s block lives in `SOUL.md` today; relocation is owned by
+#635's workspace-authoring mission). `TOOLS.md` is **not** accepted — it is a
+tool-reference file, not a home for a behavioral output rule. The check matches the
+`## Output discipline` heading (not a bare phrase in prose), and this Invariant B
+acceptance of `SOUL.md` is deliberately more permissive than Invariant A, which
+holds the privacy red-line to a higher bar (enforceable home only). An agent that does **not** emit user-facing
+WhatsApp must instead carry an explicit annotation — the literal marker
+**`no user-facing WhatsApp`** — so the absence is a deliberate, declared choice
+rather than an oversight. The validation check is **presence-or-annotation**: block
+present (in any prompt file) *or* annotation present passes; neither fails.
 
 ## Principle 4 — Filtered, not identical (USER.md)
 

--- a/scripts/openclaw/agents/tests/test_validate_workspace.py
+++ b/scripts/openclaw/agents/tests/test_validate_workspace.py
@@ -147,6 +147,56 @@ def test_output_discipline_block_passes(tmp_path: Path) -> None:
     assert _check(validate_workspace(ws), "output_discipline").ok
 
 
+def test_output_discipline_block_in_soul_passes(tmp_path: Path) -> None:
+    """#805: the block is accepted in SOUL.md (OpenClaw loads all prompt files),
+    but the detail flags AGENTS.md as the preferred home for discoverability."""
+    ws = _write(
+        tmp_path / "agent",
+        AGENTS_md="04-Growth/_private/\nSome routing rules.\n",
+        SOUL_md="## Output discipline\nHard rule #1 ...\n",
+    )
+    result = _check(validate_workspace(ws), "output_discipline")
+    assert result.ok
+    assert "SOUL.md" in result.detail
+    assert "preferred home is AGENTS.md" in result.detail
+
+
+def test_output_discipline_block_in_tools_not_accepted(tmp_path: Path) -> None:
+    """TOOLS.md is a tool-reference file, not a home for a behavioral output
+    rule — a block there does NOT satisfy Invariant B (#805 scoped to AGENTS/SOUL)."""
+    ws = _write(
+        tmp_path / "agent",
+        AGENTS_md="04-Growth/_private/\nSome routing rules.\n",
+        TOOLS_md="## Output discipline\nHard rule #1 ...\n",
+    )
+    result = _check(validate_workspace(ws), "output_discipline")
+    assert not result.ok
+    assert "missing" in result.detail
+
+
+def test_output_discipline_prose_mention_does_not_false_pass(tmp_path: Path) -> None:
+    """Anchored to the ## heading: a bare phrase in prose must not satisfy it."""
+    ws = _write(
+        tmp_path / "agent",
+        AGENTS_md="04-Growth/_private/\nThis agent controls its output discipline tightly.\n",
+    )
+    assert not _check(validate_workspace(ws), "output_discipline").ok
+
+
+def test_output_discipline_agents_md_preferred_when_in_both(tmp_path: Path) -> None:
+    """AGENTS.md wins the report even if the block also appears in SOUL.md —
+    no 'preferred home' note when it is already in AGENTS.md."""
+    ws = _write(
+        tmp_path / "agent",
+        AGENTS_md="04-Growth/_private/\n## Output discipline\nrules\n",
+        SOUL_md="## Output discipline\ncopy\n",
+    )
+    result = _check(validate_workspace(ws), "output_discipline")
+    assert result.ok
+    assert "AGENTS.md" in result.detail
+    assert "preferred home" not in result.detail
+
+
 def test_no_whatsapp_annotation_passes(tmp_path: Path) -> None:
     ws = _write(
         tmp_path / "agent",

--- a/scripts/openclaw/agents/validate_workspace.py
+++ b/scripts/openclaw/agents/validate_workspace.py
@@ -9,8 +9,9 @@ workspace (they are intentionally per-agent, not inherited — see #553):
   never-touch rule is present in the workspace's enforceable home (``AGENTS.md`` or
   ``TOOLS.md``). A SOUL-only stance does not satisfy it.
 * **Invariant B — Output Discipline**: an agent that emits user-facing WhatsApp
-  carries the Output Discipline block in ``AGENTS.md``; an agent that does not
-  carries the explicit ``no user-facing WhatsApp`` annotation. Presence-or-annotation.
+  carries the Output Discipline block in a deployed prompt file (``AGENTS.md``
+  preferred, ``SOUL.md`` accepted — #805); an agent that does not carries the
+  explicit ``no user-facing WhatsApp`` annotation. Presence-or-annotation.
 * **Invariant D — Privacy path canonical form** (#732): when the enforceable
   privacy path is written with a HOME prefix, it must use the physical
   ``/home/kgale/second-brain/notes/04-Growth/_private/`` — never the ambiguous
@@ -59,8 +60,19 @@ CANONICAL_PRIVATE_PATH = "/home/kgale/second-brain/notes/04-Growth/_private"
 #: ``claude`` runtime and thus misprotects the boundary (Invariant D, #732).
 NONCANONICAL_PRIVATE_TOKEN = "~/second-brain/notes/04-Growth/_private"
 
-#: Case-insensitive marker for the Output Discipline block heading.
-OUTPUT_DISCIPLINE_TOKEN = "output discipline"
+#: Case-insensitive marker for the Output Discipline block. Anchored to the ``##``
+#: heading form (every real block is authored as ``## Output discipline``) so a
+#: stray mention of the phrase in prose cannot false-pass the invariant.
+OUTPUT_DISCIPLINE_TOKEN = "## output discipline"
+
+#: Prompt files scanned for the Output Discipline block, in preference order.
+#: AGENTS.md is the fleet-canonical home; SOUL.md is accepted because OpenClaw
+#: loads it into the agent context too, so a block there enforces the discipline
+#: on the live agent (#805, Invariant B — felix-admin-calendar's block lives in
+#: SOUL.md today, canonical relocation owned by #635). Deliberately narrower than
+#: Invariant A's privacy owner set: TOOLS.md is a tool-reference file, not a home
+#: for a behavioral output rule, so it is not scanned here.
+OUTPUT_DISCIPLINE_OWNER_FILES = ("AGENTS.md", "SOUL.md")
 
 #: Case-insensitive annotation an agent uses to declare it emits no user-facing WhatsApp.
 NO_WHATSAPP_ANNOTATION = "no user-facing whatsapp"
@@ -148,10 +160,21 @@ def check_privacy_path_canonical(workspace_dir: Path) -> CheckResult:
 
 
 def check_output_discipline(workspace_dir: Path) -> CheckResult:
-    """Invariant B: Output Discipline block present, or no-WhatsApp annotation present."""
-    agents_text = _read(workspace_dir / "AGENTS.md").lower()
-    if OUTPUT_DISCIPLINE_TOKEN in agents_text:
-        return CheckResult("output_discipline", True, "Output Discipline block present in AGENTS.md")
+    """Invariant B: Output Discipline block present, or no-WhatsApp annotation present.
+
+    The block is accepted in AGENTS.md (preferred) or SOUL.md, because OpenClaw
+    loads both into the agent's system context so the discipline genuinely governs
+    the running agent wherever the block sits (#805). A block found in SOUL.md
+    passes but is annotated so it stays discoverable and a canonical relocation
+    can be tracked per-agent (e.g. felix-admin-calendar → SOUL.md today, relocation
+    owned by #635). This is intentionally more permissive than Invariant A (privacy),
+    which rejects a SOUL-only stance: a privacy red-line is held to a higher bar
+    (must live in an enforceable-rule home), whereas output formatting is softer.
+    """
+    for fname in OUTPUT_DISCIPLINE_OWNER_FILES:
+        if OUTPUT_DISCIPLINE_TOKEN in _read(workspace_dir / fname).lower():
+            note = "" if fname == "AGENTS.md" else " (preferred home is AGENTS.md)"
+            return CheckResult("output_discipline", True, f"Output Discipline block present in {fname}{note}")
     # Presence-or-annotation: an explicit no-WhatsApp declaration satisfies the invariant.
     for md in sorted(workspace_dir.glob("*.md")):
         if NO_WHATSAPP_ANNOTATION in _read(md).lower():
@@ -159,7 +182,8 @@ def check_output_discipline(workspace_dir: Path) -> CheckResult:
     return CheckResult(
         "output_discipline",
         False,
-        f"missing — no Output Discipline block in AGENTS.md and no '{NO_WHATSAPP_ANNOTATION}' annotation",
+        f"missing — no Output Discipline block in {'/'.join(OUTPUT_DISCIPLINE_OWNER_FILES)} "
+        f"and no '{NO_WHATSAPP_ANNOTATION}' annotation",
     )
 
 


### PR DESCRIPTION
## What

`felix-admin-calendar` failed `validate_workspace`'s Invariant B (Output Discipline) even though its block **genuinely exists**, well-adapted, in **SOUL.md** (bare-`IDLE` no-op, JSON-envelope-to-caller, `Sent by felix-admin-calendar:<model>` identity line, all 3 hard rules). OpenClaw loads `AGENTS.md` + `SOUL.md` into the agent's system context, so the block governs the running agent wherever it sits — `check_output_discipline` only scanning `AGENTS.md` was a **false negative**.

## Decision (Option B, Kent's call)

Broaden the scan to accept the block in `AGENTS.md` (**preferred**) or `SOUL.md`. The canonical relocation to `AGENTS.md` + AGENTS↔TOOLS rebalance is **deferred to #635's calendar workspace-authoring mission** (Option A). A block found in `SOUL.md` passes but is annotated *(preferred home is AGENTS.md)* so it stays discoverable and #635 can track the relocation.

Calendar's report line now: `output_discipline: Output Discipline block present in SOUL.md (preferred home is AGENTS.md)`.

## Post-review hardening (reviewer-renata)

- **Anchor** the match to the `## Output discipline` heading (was a bare substring) so a stray mention in prose can't false-pass — hardens `AGENTS.md` too.
- **Drop speculative `TOOLS.md`** from the scan (a tool-reference file isn't a home for a behavioral output rule); test asserts it is *not* accepted.
- Note the **intentional divergence** from Invariant A (privacy rejects a SOUL-only stance; output-discipline accepts it — softer bar).
- Fix the stale module docstring.

## Gate
- +4 tests (SOUL pass+note, TOOLS not-accepted, prose-no-false-pass, AGENTS-wins-when-both). Full suite **5894 passed**; validators clean; **6/6 workspaces pass**.

No office2 deploy (CI/pre-commit tool). **Rebaseline: not required** — `validate_workspace.py` is not an audited surface.

Closes #805

🤖 Generated with [Claude Code](https://claude.com/claude-code)