### PR TITLE
feat(#818): baseline systemd user unit-file CONTENTS in the security monitor

### DIFF
--- a/deploys/queued/0022-systemd-unit-content-baseline.yaml
+++ b/deploys/queued/0022-systemd-unit-content-baseline.yaml
@@ -1,0 +1,41 @@
+schema_version: v1
+name: systemd-unit-content-baseline
+issue: kentonium3/kg-automation#818
+tier: 3
+entrypoint: scripts/deploy/deploy-security-monitor-audit.py
+audited_surface: false
+created_at: '2026-07-20T00:00:00Z'
+created_by: feat-818-unit-content-baseline
+apply_mode: manifest
+notes: |
+  Syncs the updated security-monitor audit.sh to its standalone office2 copy
+  (/data/services/security-monitor/scripts/audit.sh) for kentonium3/kg-automation#818.
+
+  #818 adds section 6d to audit.sh: a `systemd-user-unit-contents.txt` baseline
+  that captures the functional (comment/whitespace-normalized) CONTENT of each
+  ~/.config/systemd/user unit file. The existing 6b/6c baselines track enabled
+  unit NAMES and the file inventory (paths + type) but NOT the file contents, so
+  a change to ExecStart/Environment INSIDE an existing enabled unit — the #816
+  class that hid a dead service ~6 weeks — was invisible to the daily audit.
+
+  Additive and self-healing: the new baseline AUTO-CREATES on the first audit run
+  after deploy (check_baseline creates a missing baseline with no alert); the 14
+  existing baselines are unchanged. audit.sh is not itself a hashed audited
+  surface, so no rebaseline of existing baselines is required. The paired repo
+  change bumps expected_baseline_count 14 -> 15 in audited-surfaces.json so the
+  felix-deployer rebaseline count-check (rebaseline.py) stays consistent once the
+  15th baseline exists.
+
+  Tier 3 (a file copy into a claude-owned dir - no sudo, no Tier 0/1/2 action).
+  audited_surface: false - audit.sh (scripts/office2/security-monitor/*.sh) does
+  not match any audited-surfaces.json pattern (systemd-user-units covers
+  scripts/office2/*.service and scripts/office2/deploy/*.sh, not security-monitor/
+  audit.sh); the only audited-path match in this commit is this manifest itself
+  (deploy-pipeline surface, affected_baselines []).
+
+  deploy-security-monitor-audit.py is the canonical audit.sh syncer (generic
+  copy+verify), superseding the mission-named deploy-openclaw-bin-seam.py (#811)
+  for future audit.sh syncs.
+
+  Rebaseline: not required - no hashed baseline drifts; the 15th baseline
+  auto-creates on the next audit run.

--- a/docs/design/architecture/data/audited-surfaces.json
+++ b/docs/design/architecture/data/audited-surfaces.json
@@ -1,12 +1,12 @@
 {
   "schema_version": "1.0",
   "last_updated": "2026-07-20",
-  "updated_by": "felix-admin-cron-path-fix-01KWQTY3 (#656) + finalize-inbox-file-01KW8MSQ (#325, #621 correction) + pull-based-deploy-pipeline-01KTYQQS (#136) + #557-rebaseline-workflow + openclaw-skills-sync-01KXW1DQ (#775: scripts/openclaw/deploy/*.{service,timer} + scripts/deploy/*.sh) + #808 (add TOOLS.md to openclaw-agent-prompts patterns — matches deploy_agent_prompts.py IN_SCOPE_FILENAMES)",
+  "updated_by": "felix-admin-cron-path-fix-01KWQTY3 (#656) + finalize-inbox-file-01KW8MSQ (#325, #621 correction) + pull-based-deploy-pipeline-01KTYQQS (#136) + #557-rebaseline-workflow + openclaw-skills-sync-01KXW1DQ (#775: scripts/openclaw/deploy/*.{service,timer} + scripts/deploy/*.sh) + #808 (add TOOLS.md to openclaw-agent-prompts patterns — matches deploy_agent_prompts.py IN_SCOPE_FILENAMES) + #818 (expected_baseline_count 14→15 — audit.sh adds the systemd-user-unit-contents.txt content baseline)",
   "description": "Repo-side inputs whose changes alter the office2 security-monitor baselines. When a commit modifies any matching path, the rebaseline procedure in security-baseline-ops.md should be triggered after the change deploys, otherwise the daily audit will alert as drift. Consumed by tooling/scripts/check_audited_surface_drift.py (CI soft-reminder) and referenced by docs/design/architecture/change-control.md + spec-kitty charter quality gates.",
   "rebaseline_runbook": "docs/runbooks/security-baseline-ops.md",
   "rebaseline_command": "ssh office2-claude 'rm /data/services/security-monitor/baselines/* && sg docker -c /data/services/security-monitor/scripts/audit.sh'",
   "rebaseline_verification": "ssh office2-claude 'ls /data/services/security-monitor/baselines/ | wc -l && tail -5 /data/services/security-monitor/logs/audit-$(date +%Y-%m-%d).log'",
-  "expected_baseline_count": 14,
+  "expected_baseline_count": 15,
   "audited_surfaces": [
     {
       "id": "openclaw-agent-prompts",
@@ -51,7 +51,8 @@
       "affected_baselines": [
         "enabled-services.txt",
         "systemd-user-units.txt",
-        "systemd-user-dropins.txt"
+        "systemd-user-dropins.txt",
+        "systemd-user-unit-contents.txt"
       ],
       "deploy_path": "scripts/office2/deploy/<service>.sh (operator-invoked) or deploys/queued/<name>.yaml (felix-deployer, e.g. 0006-gateway-pythonpath-dropin.yaml)",
       "rebaseline_required": true

--- a/docs/runbooks/security-baseline-ops.md
+++ b/docs/runbooks/security-baseline-ops.md
@@ -41,10 +41,23 @@ This runbook is the canonical procedure. Service-specific runbooks
 | Docker images | `docker-images.txt` |
 | Listening ports | `listening-ports.txt` |
 | Enabled systemd services (system + user) | `enabled-services.txt`, `systemd-user-units.txt`, `systemd-user-dropins.txt` |
+| Systemd user unit-file **contents** (functional, normalized — #818) | `systemd-user-unit-contents.txt` |
 | SSH `authorized_keys` | `ssh-keys.txt` |
 | `/etc/hosts` (hash) | `hosts-hash.txt` |
 | Crontabs | `crontabs.txt` |
 | OpenClaw cron + config | `openclaw-cron.txt`, `openclaw-config.txt` |
+
+> **Names vs contents (#818).** `systemd-user-units.txt` tracks enabled unit
+> *names* and `systemd-user-dropins.txt` the file *inventory* (paths + type), but
+> neither hashes a unit file's *contents* — so a change to `ExecStart` /
+> `Environment` *inside* an existing enabled unit (a stale or tampered body, the
+> #816 class) was invisible. `systemd-user-unit-contents.txt` closes that gap by
+> baselining each unit file's functional content (comments + blank lines +
+> trailing whitespace normalized out, mirroring the #817 unit-drift canon), so a
+> directive change trips the daily audit. It **auto-creates** on the first run
+> after deploy — no manual reset — and complements the #817 deployed-vs-repo
+> canary (that compares to the repo; this compares to the last approved baseline,
+> so it also covers tamper and non-repo-managed units).
 
 ## Automatic rebaseline (felix-deployer)
 

--- a/scripts/deploy/deploy-security-monitor-audit.py
+++ b/scripts/deploy/deploy-security-monitor-audit.py
@@ -1,0 +1,112 @@
+#!/usr/bin/env python3
+"""Deploy entrypoint — sync the checkout's security-monitor ``audit.sh`` to its
+standalone office2 copy.
+
+``scripts/office2/security-monitor/audit.sh`` runs daily (3AM cron, ``sg docker``)
+from a **standalone copy** at ``/data/services/security-monitor/scripts/audit.sh``
+— a ``git pull`` of the felix-deployer checkout does NOT refresh it. Any change to
+``audit.sh`` therefore needs an explicit sync of that deployed copy.
+
+This is the **canonical** audit.sh syncer: use it (via a deploys/queued manifest)
+for every change to ``audit.sh``, rather than minting a per-mission deploy script.
+It supersedes the mission-named ``deploy-openclaw-bin-seam.py`` (#811), the first
+instance of this same copy+verify operation, for future audit.sh syncs. The logic
+is identical: copy the checkout's ``audit.sh`` to the deployed path, force the
+executable bit (it is invoked directly), and verify byte-identity.
+
+Tier 3 (a file copy into a claude-owned dir — no sudo, no Tier 0/1/2 action).
+
+CLI contract (per docs/runbooks/deploy/discipline.md):
+
+* ``--dry-run`` — print the planned copy (source, target, exists/differs). NO
+  side effects on office2.
+* ``--apply``   — copy + force +x + verify byte-identical. Idempotent in effect.
+
+Exit codes
+----------
+* 0 — dry-run printed; OR apply succeeded (target byte-identical + executable).
+* 1 — apply failed (source missing, copy error, or post-copy mismatch).
+* 2 — usage error (missing / wrong-shaped mode argument).
+
+Invocation note: felix-deployer invokes entrypoints by file path
+(``subprocess.run([path, "--dry-run"], shell=False)``), NOT via ``python3 -m``.
+This script imports only stdlib, so no sys.path shim is required.
+"""
+from __future__ import annotations
+
+import argparse
+import filecmp
+import json
+import os
+import shutil
+import stat
+import sys
+from pathlib import Path
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+_SOURCE = _REPO_ROOT / "scripts" / "office2" / "security-monitor" / "audit.sh"
+_TARGET = Path("/data/services/security-monitor/scripts/audit.sh")
+
+
+def _emit(outcome: str, **fields: object) -> None:
+    """Print one structured line for the felix-deployer log."""
+    payload = {"entrypoint": "deploy-security-monitor-audit", "outcome": outcome, **fields}
+    sys.stdout.write(json.dumps(payload, sort_keys=True) + "\n")
+
+
+def _dry_run() -> int:
+    if not _SOURCE.is_file():
+        _emit("dry_run_error", error=f"source not found: {_SOURCE}")
+        return 1
+    target_exists = _TARGET.exists()
+    differs = not (target_exists and filecmp.cmp(_SOURCE, _TARGET, shallow=False))
+    _emit(
+        "dry_run",
+        source=str(_SOURCE),
+        target=str(_TARGET),
+        target_exists=target_exists,
+        would_copy=differs,
+    )
+    return 0
+
+
+def _apply() -> int:
+    if not _SOURCE.is_file():
+        _emit("apply_error", error=f"source not found: {_SOURCE}")
+        return 1
+    try:
+        _TARGET.parent.mkdir(parents=True, exist_ok=True)
+        shutil.copy2(_SOURCE, _TARGET)
+        # audit.sh is invoked directly (`sg docker -c .../audit.sh`), so it MUST
+        # stay executable. copy2 only preserves the *source* mode, so ensure +x
+        # on the target explicitly rather than trusting the checkout's bits.
+        current = _TARGET.stat().st_mode
+        _TARGET.chmod(current | stat.S_IXUSR | stat.S_IXGRP | stat.S_IXOTH)
+    except OSError as exc:
+        _emit("apply_error", error=f"copy failed: {exc}", target=str(_TARGET))
+        return 1
+    # Verify byte-identical + executable (the deterministic post-conditions).
+    if not filecmp.cmp(_SOURCE, _TARGET, shallow=False):
+        _emit("apply_error", error="post-copy mismatch", target=str(_TARGET))
+        return 1
+    if not os.access(_TARGET, os.X_OK):
+        _emit("apply_error", error="target not executable after copy", target=str(_TARGET))
+        return 1
+    _emit("applied", source=str(_SOURCE), target=str(_TARGET))
+    return 0
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    mode = parser.add_mutually_exclusive_group(required=True)
+    mode.add_argument("--dry-run", action="store_true", help="print planned copy; no side effects")
+    mode.add_argument("--apply", action="store_true", help="copy + verify audit.sh")
+    try:
+        args = parser.parse_args(argv)
+    except SystemExit:
+        return 2
+    return _apply() if args.apply else _dry_run()
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/office2/security-monitor/audit.sh
+++ b/scripts/office2/security-monitor/audit.sh
@@ -9,6 +9,7 @@
 #           known IOCs, listening ports, system systemd enabled services,
 #           SSH authorized_keys, /etc/hosts hash, system crontabs
 #   User:   systemd user-scope enabled units + unit-file/drop-in inventory
+#           + normalized unit-file CONTENTS (#818 — catches body/ExecStart drift)
 #   Felix:  OpenClaw cron-job normalized config, openclaw.json content hash
 #
 # Setup:
@@ -175,6 +176,38 @@ tmp=$(mktemp)
 find "$HOME/.config/systemd/user" \( -type f -o -type l \) -printf '%P %y\n' 2>/dev/null \
     | LC_ALL=C sort > "$tmp"
 check_baseline "systemd-user-dropins.txt" "$tmp"
+rm -f "$tmp"
+
+# 6d. Systemd user-scope unit-file CONTENTS (functional, normalized) (#818)
+# 6b/6c track enabled unit NAMES and the unit-file inventory (paths + type), but
+# NOT the file CONTENTS. A change to ExecStart/Environment/WorkingDirectory INSIDE
+# an existing, still-enabled unit — a stale or tampered unit body (the #816 class,
+# which hid a dead service for ~6 weeks) — is invisible to them. This baseline
+# captures the functional content of each user unit file so a body change trips
+# the daily audit. Normalization mirrors the #817 unit-drift canon (scripts/trust/
+# unit_drift_detector.py): drop full-line comments (a directive line never starts
+# with '#'/';') and blank lines, strip trailing whitespace — so a comment/
+# whitespace-only edit is NOT flagged, but any directive change always is.
+log "Scanning systemd user unit-file contents..."
+tmp=$(mktemp)
+if [ -d "$HOME/.config/systemd/user" ]; then
+    # Deterministic order: regular files only (find does not follow symlinks),
+    # sorted by relative path (LC_ALL=C). .wants/ symlinks are skipped here; a
+    # symlink to an in-dir unit file has that target captured as a file (our
+    # case — deployed units are real files under this dir), while a symlink to a
+    # root-owned system unit (/usr/lib/systemd/user) is not content-baselined —
+    # a bounded gap: 6c still records the symlink's existence, and those targets
+    # live outside the user-writable dir (lower tamper surface).
+    while IFS= read -r rel; do
+        [ -z "$rel" ] && continue
+        printf '=== %s ===\n' "$rel" >> "$tmp"
+        awk 'NF && $1 !~ /^[#;]/ { sub(/[ \t]+$/, ""); print }' \
+            "$HOME/.config/systemd/user/$rel" >> "$tmp"
+    done < <(cd "$HOME/.config/systemd/user" && find . -type f -printf '%P\n' 2>/dev/null | LC_ALL=C sort)
+else
+    echo "no-user-systemd" > "$tmp"
+fi
+check_baseline "systemd-user-unit-contents.txt" "$tmp"
 rm -f "$tmp"
 
 # 7. SSH authorized_keys

--- a/tests/deploy/test_audited_surfaces.py
+++ b/tests/deploy/test_audited_surfaces.py
@@ -139,7 +139,7 @@ def test_ci_script_imports_shared_matcher_not_a_copy():
 
 def test_real_registry_loads_and_matches():
     audited = audited_surfaces.load_audited_surfaces()
-    assert audited.get("expected_baseline_count") == 14
+    assert audited.get("expected_baseline_count") == 15
     assert any(s["id"] == "openclaw-config" for s in audited["audited_surfaces"])
     # A real openclaw.json change matches the real openclaw-config surface.
     matches = audited_surfaces.match_surfaces(["scripts/openclaw/openclaw.json"], audited)
@@ -156,7 +156,7 @@ def test_load_audited_surfaces_exits_2_when_missing(monkeypatch, tmp_path):
 
 # --- known_baselines guard (WP02 T012, Codex LOW) -------------------------
 
-# The documented 14-baseline inventory audit.sh emits (== expected_baseline_count).
+# The documented 15-baseline inventory audit.sh emits (== expected_baseline_count).
 # Pinning this set catches a stale registry name that audit.sh no longer emits
 # being silently accepted as a "known" declaration target.
 _KNOWN_BASELINES_INVENTORY = {
@@ -174,23 +174,24 @@ _KNOWN_BASELINES_INVENTORY = {
     "ssh-keys.txt",
     "systemd-user-dropins.txt",
     "systemd-user-units.txt",
+    "systemd-user-unit-contents.txt",
 }
 
 
-def test_known_baselines_equals_documented_14_inventory():
+def test_known_baselines_equals_documented_15_inventory():
     registry = audited_surfaces.load_audited_surfaces()
     names = audited_surfaces.known_baselines(registry)
-    assert len(names) == 14
+    assert len(names) == 15
     assert names == _KNOWN_BASELINES_INVENTORY
     # And the registry's own count field agrees.
-    assert registry.get("expected_baseline_count") == 14
+    assert registry.get("expected_baseline_count") == 15
 
 
 def test_load_audited_surfaces_or_error_success():
     registry, reason = audited_surfaces.load_audited_surfaces_or_error()
     assert reason is None
     assert registry is not None
-    assert registry.get("expected_baseline_count") == 14
+    assert registry.get("expected_baseline_count") == 15
 
 
 def test_load_audited_surfaces_or_error_missing_does_not_exit(monkeypatch, tmp_path):

--- a/tests/deploy/test_deploy_security_monitor_audit.py
+++ b/tests/deploy/test_deploy_security_monitor_audit.py
@@ -1,0 +1,141 @@
+"""Tests for scripts/deploy/deploy-security-monitor-audit.py + its manifest (#818).
+
+The entrypoint copies the checkout's security-monitor audit.sh to its standalone
+office2 copy and verifies byte-identity + the executable bit. These tests exercise
+the deterministic copy/verify + the CLI contract (dry-run / apply / usage error)
+against tmp paths, so they never touch the real /data path.
+"""
+from __future__ import annotations
+
+import importlib.util
+import json
+import pathlib
+import sys
+
+import pytest
+import yaml
+
+_REPO_ROOT = pathlib.Path(__file__).resolve().parents[2]
+_ENTRYPOINT_PATH = _REPO_ROOT / "scripts" / "deploy" / "deploy-security-monitor-audit.py"
+_MANIFEST_QUEUED = _REPO_ROOT / "deploys" / "queued" / "0022-systemd-unit-content-baseline.yaml"
+
+
+def _resolve_manifest_path() -> pathlib.Path:
+    """queued pre-deploy, applied/<NNNN>-... once felix-deployer relocates it."""
+    if _MANIFEST_QUEUED.exists():
+        return _MANIFEST_QUEUED
+    applied = sorted(
+        (_REPO_ROOT / "deploys" / "applied").glob("*-systemd-unit-content-baseline.yaml")
+    )
+    return applied[-1] if applied else _MANIFEST_QUEUED
+
+
+def _load_entrypoint():
+    if str(_REPO_ROOT) not in sys.path:
+        sys.path.insert(0, str(_REPO_ROOT))
+    spec = importlib.util.spec_from_file_location("deploy_security_monitor_audit", _ENTRYPOINT_PATH)
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+_mod = _load_entrypoint()
+
+
+def _capsys_json(capsys) -> dict:
+    out = capsys.readouterr().out.strip().splitlines()
+    return json.loads(out[-1])
+
+
+# --- CLI contract ----------------------------------------------------------
+
+
+def test_no_mode_is_usage_error():
+    assert _mod.main([]) == 2
+
+
+def test_both_modes_is_usage_error():
+    assert _mod.main(["--dry-run", "--apply"]) == 2
+
+
+# --- dry-run ---------------------------------------------------------------
+
+
+def test_dry_run_reports_copy_needed(monkeypatch, tmp_path, capsys):
+    src = tmp_path / "audit.sh"
+    src.write_text("echo hi\n")
+    monkeypatch.setattr(_mod, "_SOURCE", src)
+    monkeypatch.setattr(_mod, "_TARGET", tmp_path / "deployed" / "audit.sh")
+    assert _mod.main(["--dry-run"]) == 0
+    payload = _capsys_json(capsys)
+    assert payload["outcome"] == "dry_run"
+    assert payload["target_exists"] is False
+    assert payload["would_copy"] is True
+
+
+def test_dry_run_missing_source_fails(monkeypatch, tmp_path, capsys):
+    monkeypatch.setattr(_mod, "_SOURCE", tmp_path / "nope.sh")
+    assert _mod.main(["--dry-run"]) == 1
+    assert _capsys_json(capsys)["outcome"] == "dry_run_error"
+
+
+# --- apply -----------------------------------------------------------------
+
+
+def test_apply_copies_and_verifies(monkeypatch, tmp_path, capsys):
+    src = tmp_path / "audit.sh"
+    src.write_text("#!/usr/bin/env bash\necho audit\n")
+    src.chmod(0o755)
+    target = tmp_path / "deployed" / "audit.sh"  # parent does not exist yet
+    monkeypatch.setattr(_mod, "_SOURCE", src)
+    monkeypatch.setattr(_mod, "_TARGET", target)
+
+    assert _mod.main(["--apply"]) == 0
+    assert _capsys_json(capsys)["outcome"] == "applied"
+    assert target.read_text() == src.read_text()
+    assert target.stat().st_mode & 0o111  # executable preserved
+
+
+def test_apply_forces_executable_from_nonexec_source(monkeypatch, tmp_path, capsys):
+    """audit.sh is invoked directly, so the target must be +x even if the repo
+    source is not executable (copy2 preserves the source's non-exec mode)."""
+    src = tmp_path / "audit.sh"
+    src.write_text("echo hi\n")
+    src.chmod(0o644)  # deliberately NOT executable
+    target = tmp_path / "deployed" / "audit.sh"
+    monkeypatch.setattr(_mod, "_SOURCE", src)
+    monkeypatch.setattr(_mod, "_TARGET", target)
+
+    assert _mod.main(["--apply"]) == 0
+    assert _capsys_json(capsys)["outcome"] == "applied"
+    assert target.stat().st_mode & 0o111, "target must be executable after apply"
+
+
+def test_apply_is_idempotent(monkeypatch, tmp_path, capsys):
+    src = tmp_path / "audit.sh"
+    src.write_text("echo hi\n")
+    target = tmp_path / "deployed" / "audit.sh"
+    monkeypatch.setattr(_mod, "_SOURCE", src)
+    monkeypatch.setattr(_mod, "_TARGET", target)
+    assert _mod.main(["--apply"]) == 0
+    assert _mod.main(["--apply"]) == 0  # second run: still success
+    assert _capsys_json(capsys)["outcome"] == "applied"
+
+
+def test_apply_missing_source_fails(monkeypatch, tmp_path, capsys):
+    monkeypatch.setattr(_mod, "_SOURCE", tmp_path / "nope.sh")
+    monkeypatch.setattr(_mod, "_TARGET", tmp_path / "deployed" / "audit.sh")
+    assert _mod.main(["--apply"]) == 1
+    assert _capsys_json(capsys)["outcome"] == "apply_error"
+
+
+# --- manifest --------------------------------------------------------------
+
+
+def test_manifest_shape():
+    m = yaml.safe_load(_resolve_manifest_path().read_text())
+    assert m["schema_version"] == "v1"
+    assert m["tier"] == 3
+    assert m["audited_surface"] is False
+    assert m["entrypoint"] == "scripts/deploy/deploy-security-monitor-audit.py"
+    assert m["issue"] == "kentonium3/kg-automation#818"


### PR DESCRIPTION
## What

The daily 3AM security audit's systemd baselines track enabled unit **names** (`systemd-user-units.txt`) and the file **inventory** — paths + type (`systemd-user-dropins.txt`) — but **not** the file **contents**. A change to `ExecStart`/`Environment` *inside* an existing enabled unit (a stale or tampered body — the #816 class that hid a dead service ~6 weeks) was invisible to the audit.

This is the **tamper/integrity half** that complements the #817 deployed-vs-repo canary: #817 compares to the **repo**; this compares to the **last approved baseline**, so it also catches a malicious edit that *also* edits the repo, plus non-repo-managed units.

## How

`audit.sh` section **6d** builds `systemd-user-unit-contents.txt` — the functional content of each `~/.config/systemd/user` unit file, comment/blank/trailing-whitespace normalized (mirrors the #817 `unit_drift_detector` canon; a systemd directive never starts with `#`/`;`, so a directive change always trips it, a comment-only edit does not). Deterministic (`LC_ALL=C` sort + in-file awk order); drop-in `.d/*.conf` captured; `.wants/` symlinks skipped (targets captured as files; a symlink to a root-owned system unit is a bounded, documented gap).

**Additive + self-healing:** `check_baseline` auto-creates the new baseline on the first run after deploy (no alert, no destructive `rm baselines/*` reset); the 14 existing baselines are unchanged. `audit.sh` is not a hashed audited surface, so **no rebaseline of existing baselines is required**.

`expected_baseline_count` 14→15 (load-bearing: `rebaseline.py` verifies the regenerated on-disk count equals it). `systemd-user-unit-contents.txt` added to the `systemd-user-units` surface's `affected_baselines` so `known_baselines()` == expected == 15 and the manifest `expected_baselines` declaration path accepts it.

## Deploy

`audit.sh` runs from a standalone copy at `/data/services/security-monitor/scripts/audit.sh` (a git pull doesn't refresh it). New **canonical** syncer `scripts/deploy/deploy-security-monitor-audit.py` (generic copy+verify, supersedes the mission-named #811 `deploy-openclaw-bin-seam.py` for future audit.sh syncs) + **manifest 0022** (`audited_surface: false`).

## Adversarial review (reviewer-renata, security lens)

- **HIGH (fixed):** the count bump broke 3 assertions in `test_audited_surfaces.py` and left `known_baselines()` == 14 vs count 15 — self-inconsistent, and the `expected_baselines` declaration path would have rejected the new baseline. Resolved by adding it to `affected_baselines` + aligning the tests.
- **Confirmed sound:** the awk normalization cannot normalize away a real `ExecStart`/`Environment` change (no false-clean); deterministic (no security-channel noise); the additive claim verified; deploy script correct.

## Gate
- Full suite **5932 passed**, 0 failed; validators clean; `audit.sh` `bash -n` OK; `known_baselines()`==`expected_baseline_count`==15.

## Live-verify plan (post-merge)
Manifest 0022 syncs audit.sh; then run `audit.sh` once on office2 and confirm the 15th baseline (`systemd-user-unit-contents.txt`) auto-creates cleanly with no false drift on the existing 14.

**Rebaseline: not required** — no hashed baseline drifts; the 15th auto-creates on the next audit run.

Closes #818

🤖 Generated with [Claude Code](https://claude.com/claude-code)