### PR TITLE
fix(#836): deterministic calendar-request orchestrator — reliable scheduling

### DIFF
--- a/scripts/calendar_routing/handle_calendar_request.py
+++ b/scripts/calendar_routing/handle_calendar_request.py
@@ -1,0 +1,795 @@
+#!/usr/bin/env python3
+"""Deterministic orchestrator for felix-admin-calendar conversational requests.
+
+Single deterministic entry point the ``felix-admin-calendar`` agent calls to
+turn a natural-language calendar request (or a clarification reply) into a
+Google Calendar event. The agent extracts natural-language fields and phrases
+the reply; THIS module owns every date/time decision, the
+create-vs-clarify-vs-ambiguous classification, and the side-effect
+orchestration (create, record cleanup, note-flip, action logging).
+
+Motivation (#836): the agent previously hand-built calendar payloads and got
+dates/times wrong (e.g. dropping the clarification's original date, resolving
+relative phrases against the wrong "now"). Moving the whole deterministic
+transform here removes that fragility — the LLM never assembles a payload.
+
+Invocation (MANDATORY ``-m`` form per [[feedback_helper_m_invocation_form]]):
+
+    python3 -m scripts.calendar_routing.handle_calendar_request \
+        --account <acct> [--state-file <path>] [--now-iso <iso8601>]
+
+Reads an ``ExtractedCalendarBlock`` JSON object from **stdin**. Fields the
+agent provides: ``title``, ``start_natural``, ``end_natural``,
+``duration_natural``, ``location``, ``recurrence_natural``, ``attendees``,
+``tick_iso`` (optional). There is NO ``source_inbox_path`` for conversational
+requests (this module synthesizes one).
+
+Emits a SINGLE JSON object on stdout and exits 0 for all non-crash outcomes
+(the caller branches on ``status``). Exit 2 only on unreadable/empty/invalid
+stdin JSON (or an unparseable ``--now-iso``).
+
+Result-JSON contract (the agent prompt is written against these shapes):
+
+  * created (conversational)::
+
+        {"status": "created", "mode": "conversational",
+         "event_id": ..., "html_link": ..., "summary": ...,
+         "start": <rfc3339 or YYYY-MM-DD>}
+
+  * created (clarification) — adds a best-effort ``cleanup`` block plus a
+    top-level ``cleanup_ok`` (false => event created but the pending record /
+    source note were not reconciled; the agent surfaces that to Kent)::
+
+        {"status": "created", "mode": "clarification",
+         "event_id": ..., "html_link": ..., "summary": ...,
+         "start": <rfc3339 or YYYY-MM-DD>,
+         "cleanup": {"record_removed": bool, "note_marked": bool},
+         "cleanup_ok": bool}
+
+  * needs_clarification (conversational)::
+
+        {"status": "needs_clarification", "mode": "conversational",
+         "missing": [...]}
+
+  * needs_clarification (clarification) — a matched record that still lacks
+    fields after merging the reply::
+
+        {"status": "needs_clarification", "mode": "clarification",
+         "missing": [...], "note_filename": <record note_filename>}
+
+  * ambiguous — the reply matched more than one live pending record::
+
+        {"status": "ambiguous",
+         "candidates": [{"title", "note_filename", "created_at"}, ...]}
+
+  * error — the calendar helper failed (surfaced verbatim, NEVER faked #683;
+    never falls back to gog)::
+
+        {"status": "error", "exit_code": <n>, "error": <stderr verbatim>}
+
+Classification algorithm (see ``_classify_and_run``):
+
+  1. Parse the block; compute ``now_utc`` and the ET ``tick_iso``.
+  2. ``live`` = pending records whose ``created_at`` is live (< 8h old).
+  3. ``conv_block`` = the block + a synthetic ``source_inbox_path`` /
+     ``source_block_index`` / ``tick_iso``; ``alone = validate(conv_block)``.
+  4. ``matched`` live records: a block with NO title matches every live record
+     (a terse reply carries nothing to disambiguate on); a block with a title
+     matches a record iff one title's significant tokens are a subset of the
+     other's (``_strong_match`` — not a single shared token).
+  5. Branch — matching decides FIRST (a reply that strong-matches a pending
+     record is a clarification even if it is self-sufficient, so a restated-
+     complete reply resolves + cleans up instead of spawning a fresh orphan):
+       - >1 match  -> AMBIGUOUS.
+       - 1 match   -> CLARIFICATION: merge the reply over the record (reply wins
+         per-component; the record supplies the missing date for start AND end),
+         re-validate, create (+ best-effort cleanup) or re-ask.
+       - 0 matches -> validate the block alone: complete -> CONVERSATIONAL
+         create; incomplete -> CONVERSATIONAL needs_clarification.
+
+Stdlib only (no requests/httpx/pydantic/PyYAML/frontmatter). Matches the style
+of ``scripts/inbox/route_calendar_event.py``: external side effects go through
+small module-level seam functions so unit tests can monkeypatch them.
+"""
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import subprocess
+import sys
+import tempfile
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Optional
+from zoneinfo import ZoneInfo
+
+from scripts.calendar_routing.validate_calendar_event import (
+    _parse_date_component,
+    validate,
+)
+from scripts.inbox.handle_clarification_state import (
+    STATE_PATH_DEFAULT,
+    _is_live,
+    _significant_tokens,
+    load_state,
+)
+
+# The Eastern zone the validator anchors against (import the same string so a
+# relative phrase resolves identically here and inside validate_calendar_event).
+ET_ZONE = ZoneInfo("America/New_York")
+
+# The agent whose actions this orchestrator logs.
+AGENT = "felix-admin-calendar"
+
+# Credential-set selector default for the direct-API calendar helper (D5,
+# matches validate_calendar_event / route_calendar_event).
+DEFAULT_ACCOUNT = "personal"
+
+# The deterministic calendar helper (WP02) invoked to create the event. Kept as
+# module-level constants so tests can monkeypatch the subprocess call site.
+CALENDAR_HELPER_MODULE = "scripts.google.calendar_helper"
+
+# Subprocess timeouts (seconds). A blocked Google API call or a stuck
+# mark_processed must fail cleanly rather than hang until openclaw's 600s cron
+# limit kills the turn.
+CALENDAR_HELPER_TIMEOUT_SECONDS = 90
+STATE_HELPER_TIMEOUT_SECONDS = 30
+MARK_PROCESSED_TIMEOUT_SECONDS = 30
+LOG_ACTION_TIMEOUT_SECONDS = 15
+_TIMEOUT_RETURNCODE = 124  # conventional timeout exit code
+
+# The calendar helper's Google client libraries live ONLY in a dedicated venv on
+# office2 (system python3 has neither pip nor the google libs). The helper MUST
+# be invoked with that venv's interpreter — NOT ``sys.executable`` (this module
+# runs under the system python3, which would crash on ``import googleapiclient``).
+# Overridable for local/dev via FELIX_CALENDAR_HELPER_PYTHON.
+DEFAULT_CALENDAR_HELPER_PYTHON = "/data/services/openclaw/felix-calendar/venv/bin/python"
+
+# log_action.py uses the script-path import convention (a bare ``from config
+# import ObservationConfig``), so it MUST be invoked by absolute script path —
+# NOT ``-m scripts.openclaw.observation.log_action`` (which raises
+# ``ModuleNotFoundError: No module named 'config'`` because the observation dir
+# is not on sys.path under ``-m``). Every other Felix agent invokes it this way.
+# Resolved from this module's location so it is cwd-independent.
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+LOG_ACTION_SCRIPT = str(_REPO_ROOT / "scripts/openclaw/observation/log_action.py")
+
+
+def _calendar_helper_python() -> str:
+    """Return the interpreter used to run the calendar helper subprocess."""
+    import os
+
+    return os.environ.get("FELIX_CALENDAR_HELPER_PYTHON", DEFAULT_CALENDAR_HELPER_PYTHON)
+
+
+# ---------------------------------------------------------------------------
+# Seams — every external side effect goes through one of these so the unit
+# tests can monkeypatch a single call site (mirrors route_calendar_event).
+# ---------------------------------------------------------------------------
+
+
+def _parse_helper_created(stdout: str) -> Optional[dict]:
+    """Extract the helper's ``status: created`` JSON line from its stdout.
+
+    The helper emits a JSON object line *before* its final ``SUMMARY:`` line
+    (contract: JSON never follows SUMMARY). Return the first line that parses to
+    a dict carrying ``status == "created"``, or ``None``.
+    """
+    for line in stdout.splitlines():
+        line = line.strip()
+        if not line.startswith("{"):
+            continue
+        try:
+            obj = json.loads(line)
+        except json.JSONDecodeError:
+            continue
+        if isinstance(obj, dict) and obj.get("status") == "created":
+            return obj
+    return None
+
+
+def _invoke_calendar_helper(
+    payload: dict, idempotency_key: str, account: str
+) -> dict:
+    """Create the event via the calendar helper; return a normalized result dict.
+
+    ``payload`` is the already-built ``calendar_event_payload`` from ``validate``
+    (the exact shape ``calendar_helper create --payload-file`` consumes) — it is
+    written verbatim to a tempfile; NO envelope is rebuilt around it. Runs::
+
+        python3 -m scripts.google.calendar_helper create --payload-file <tmp>
+            --idempotency-key <idempotency_key> --account <account> --json
+
+    Returns ``{"status": "created", "event_id", "html_link"}`` on success or
+    ``{"status": "error", "exit_code", "error"}`` on any failure (non-zero exit,
+    timeout, or exit-0-without-a-parseable-created-line). The error is surfaced
+    verbatim and NEVER faked (#683).
+
+    This is the single seam the unit tests monkeypatch (the real helper needs the
+    google client libraries + a live token, which never run under CI).
+    """
+    fd, tmp_name = tempfile.mkstemp(prefix="calendar-payload.", suffix=".json")
+    try:
+        with open(fd, "w", encoding="utf-8") as fh:
+            json.dump(payload, fh)
+        try:
+            proc = subprocess.run(
+                [
+                    _calendar_helper_python(),
+                    "-m",
+                    CALENDAR_HELPER_MODULE,
+                    "create",
+                    "--payload-file",
+                    tmp_name,
+                    "--idempotency-key",
+                    idempotency_key,
+                    "--account",
+                    account,
+                    "--json",
+                ],
+                capture_output=True,
+                text=True,
+                check=False,
+                timeout=CALENDAR_HELPER_TIMEOUT_SECONDS,
+            )
+        except subprocess.TimeoutExpired:
+            return {
+                "status": "error",
+                "exit_code": _TIMEOUT_RETURNCODE,
+                "error": (
+                    "ERROR: calendar helper timed out after "
+                    f"{CALENDAR_HELPER_TIMEOUT_SECONDS}s"
+                ),
+            }
+        except OSError as exc:
+            # Missing / non-executable venv python (or any launch-level failure):
+            # must never traceback — that would violate the single-JSON contract.
+            return {
+                "status": "error",
+                "exit_code": _TIMEOUT_RETURNCODE,
+                "error": f"ERROR: calendar helper launch failed: {exc}",
+            }
+    finally:
+        try:
+            Path(tmp_name).unlink()
+        except OSError:  # pragma: no cover - cleanup best-effort
+            pass
+
+    if proc.returncode == 0:
+        created = _parse_helper_created(proc.stdout)
+        if created is not None:
+            return {
+                "status": "created",
+                "event_id": created.get("event_id", ""),
+                "html_link": created.get("html_link", ""),
+            }
+        # Exit 0 but no parseable created line — treat as an error rather than
+        # fabricate a success (#683).
+        return {
+            "status": "error",
+            "exit_code": 0,
+            "error": (proc.stdout or proc.stderr).strip(),
+        }
+    return {
+        "status": "error",
+        "exit_code": proc.returncode,
+        "error": (proc.stderr or proc.stdout).strip(),
+    }
+
+
+def _invoke_remove_record(note_filename: str, state_file: Optional[str]) -> bool:
+    """Remove a resolved clarification record via handle_clarification_state.
+
+    Deliberately a subprocess (``python3 -m
+    scripts.inbox.handle_clarification_state remove --note-filename <n>
+    --state-file <p>``) rather than an in-process call, so its stdout
+    (``removed=N``) stays isolated from this module's single-result-JSON
+    contract — the same isolation philosophy route_calendar_event uses for
+    mark_processed. stdlib-only, so ``sys.executable`` is correct. Returns True
+    on a clean exit; best-effort (the event already exists), never raises.
+    """
+    args = [
+        sys.executable,
+        "-m",
+        "scripts.inbox.handle_clarification_state",
+        "remove",
+        "--note-filename",
+        note_filename,
+    ]
+    if state_file:
+        args += ["--state-file", state_file]
+    try:
+        proc = subprocess.run(
+            args,
+            capture_output=True,
+            text=True,
+            check=False,
+            timeout=STATE_HELPER_TIMEOUT_SECONDS,
+        )
+        return proc.returncode == 0
+    except (subprocess.TimeoutExpired, OSError):  # pragma: no cover - best-effort
+        return False
+
+
+def _invoke_mark_processed(source_path: str) -> bool:
+    """Flip the source note to processed via mark_processed (subprocess seam).
+
+    Subprocess (``python3 -m scripts.inbox.mark_processed --path <source_path>``)
+    not an in-process import: the private-path refusal, inbox-root validation, and
+    symlink ``.resolve()`` guard all live in ``mark_processed.main()``. stdlib-only,
+    so ``sys.executable`` is correct. Returns True on a clean exit; best-effort,
+    never raises (the event already exists).
+    """
+    try:
+        proc = subprocess.run(
+            [sys.executable, "-m", "scripts.inbox.mark_processed", "--path", source_path],
+            capture_output=True,
+            text=True,
+            check=False,
+            timeout=MARK_PROCESSED_TIMEOUT_SECONDS,
+        )
+        return proc.returncode == 0
+    except (subprocess.TimeoutExpired, OSError):  # pragma: no cover - best-effort
+        return False
+
+
+def _invoke_log_action(
+    agent: str,
+    category: str,
+    action: str,
+    target: str,
+    outcome: str,
+    context: dict,
+) -> None:
+    """Emit one observation log entry (best-effort; never blocks the result).
+
+    Shells out ``log_action.py`` (by absolute script path — see
+    ``LOG_ACTION_SCRIPT``) with the given fields. Any failure (non-zero exit,
+    timeout, unimportable config) is swallowed — logging is observability, not
+    part of the create contract.
+    """
+    try:
+        subprocess.run(
+            [
+                sys.executable,
+                LOG_ACTION_SCRIPT,
+                "--agent",
+                agent,
+                "--category",
+                category,
+                "--action",
+                action,
+                "--target",
+                target,
+                "--outcome",
+                outcome,
+                "--context",
+                json.dumps(context),
+            ],
+            capture_output=True,
+            text=True,
+            check=False,
+            timeout=LOG_ACTION_TIMEOUT_SECONDS,
+        )
+    except Exception:  # noqa: BLE001 - best-effort; logging must never block
+        pass
+
+
+# ---------------------------------------------------------------------------
+# Pure helpers
+# ---------------------------------------------------------------------------
+
+
+def _parse_now(now_iso: Optional[str]) -> datetime:
+    """Return an aware UTC datetime for "now".
+
+    ``--now-iso`` overrides the wall clock for deterministic tests. A naive
+    value is assumed UTC. Raises ``ValueError`` on an unparseable string.
+    """
+    if not now_iso or not now_iso.strip():
+        return datetime.now(timezone.utc)
+    text = now_iso.strip()
+    if text.endswith("Z"):
+        text = text[:-1] + "+00:00"
+    dt = datetime.fromisoformat(text)
+    if dt.tzinfo is None:
+        dt = dt.replace(tzinfo=timezone.utc)
+    return dt.astimezone(timezone.utc)
+
+
+def _et_iso(now_utc: datetime) -> str:
+    """Render ``now_utc`` as an ET-localized ISO 8601 string (validator anchor)."""
+    return now_utc.astimezone(ET_ZONE).isoformat()
+
+
+def _nonempty(value: object) -> bool:
+    """True when ``value`` is a meaningful (non-null / non-blank) field."""
+    if value is None:
+        return False
+    if isinstance(value, str):
+        return bool(value.strip())
+    if isinstance(value, (list, dict)):
+        return bool(value)
+    return True
+
+
+def _block_title(block: dict) -> Optional[str]:
+    """Return the block's stripped title, or None when absent/blank."""
+    title = block.get("title")
+    if isinstance(title, str) and title.strip():
+        return title.strip()
+    return None
+
+
+def _strong_match(record_title: object, block_title: object) -> bool:
+    """True when one title's significant tokens are a subset of the other's.
+
+    Replaces loose single-shared-token binding (which mis-bound "Lunch with
+    Sarah" onto a pending "Lunch with John" via the shared "lunch"). A subset
+    relation requires the whole of the shorter title to appear in the longer —
+    "Dentist" ⊆ "Dentist appointment" binds; "…John" vs "…Sarah" does not.
+    """
+    rt = set(_significant_tokens(record_title if isinstance(record_title, str) else ""))
+    bt = set(_significant_tokens(block_title if isinstance(block_title, str) else ""))
+    if not rt or not bt:
+        return False
+    return rt <= bt or bt <= rt
+
+
+def _matched_records(block: dict, live: list) -> list:
+    """Return the live records the block could be a clarification reply to.
+
+    - Block with NO non-empty title -> every live record is a candidate (a terse
+      reply like "2pm" carries no title to disambiguate on).
+    - Block with a title -> a record matches iff ``_strong_match`` holds (one
+      title's significant tokens are contained in the other's).
+    """
+    title = _block_title(block)
+    if title is None:
+        return list(live)
+    out: list = []
+    for rec in live:
+        rec_title = (rec.get("partial_payload") or {}).get("title")
+        if _strong_match(rec_title, title):
+            out.append(rec)
+    return out
+
+
+def _merge_temporal(
+    reply_value: object, record_value: object, date_source: object, anchor: datetime
+) -> Optional[str]:
+    """Component-merge a reply's temporal field over a record's, keeping the date.
+
+    A blind field overwrite would drop the record's date when the reply supplies
+    only a time — exactly the #836 bug (and its end-only sibling, MED-1). So:
+
+    - reply blank            -> keep the record's value.
+    - reply carries a date   -> reply wins outright (it is self-sufficient).
+    - reply has NO date but ``date_source`` does -> combine "``<reply>
+      <date_source>``" so the date is inherited while the reply supplies (and,
+      being first, wins) the time-of-day.
+
+    For ``start_natural`` the ``date_source`` is the record's own start; for
+    ``end_natural`` it is the record's start too (an end-only reply inherits the
+    event's date). Example: record start "July 25", reply "2pm" -> "2pm July 25"
+    -> July 25 14:00; record start "Thursday", reply end "3pm" -> "3pm Thursday".
+    """
+    rep = reply_value if isinstance(reply_value, str) and reply_value.strip() else None
+    rec = record_value if isinstance(record_value, str) and record_value.strip() else None
+    if rep is None:
+        return rec
+    if _parse_date_component(rep, anchor) is not None:
+        return rep
+    ds = date_source if isinstance(date_source, str) and date_source.strip() else None
+    if ds is not None and _parse_date_component(ds, anchor) is not None:
+        return f"{rep} {ds}"
+    return rep
+
+
+def _build_merged(rec: dict, block: dict, et_now_iso: str) -> tuple[dict, str]:
+    """Build the merged ExtractedCalendarBlock for a clarification reply.
+
+    Base = the record's ``partial_payload``; every non-empty field of the reply
+    overlays it (reply wins). ``start_natural`` and ``end_natural`` are merged at
+    component granularity (see :func:`_merge_temporal`). ``source_inbox_path`` /
+    ``source_block_index`` are forced from the record; ``tick_iso`` is set to now
+    (inbound receipt — relative phrases resolve against now). Returns
+    ``(merged_block, source_path)``.
+    """
+    base = dict(rec.get("partial_payload") or {})
+    merged = dict(base)
+    for key, value in block.items():
+        if key in (
+            "source_inbox_path",
+            "source_block_index",
+            "tick_iso",
+            "start_natural",
+            "end_natural",
+        ):
+            continue
+        if _nonempty(value):
+            merged[key] = value
+
+    try:
+        anchor = datetime.fromisoformat(et_now_iso)
+    except ValueError:  # pragma: no cover - _et_iso always emits a parseable value
+        anchor = datetime.now(ET_ZONE)
+    # The record's start is the date-bearing field; both start and end inherit
+    # its date when the reply gives only a time.
+    date_source = base.get("start_natural")
+    merged_start = _merge_temporal(
+        block.get("start_natural"), base.get("start_natural"), date_source, anchor
+    )
+    if merged_start is not None:
+        merged["start_natural"] = merged_start
+    merged_end = _merge_temporal(
+        block.get("end_natural"), base.get("end_natural"), date_source, anchor
+    )
+    if merged_end is not None:
+        merged["end_natural"] = merged_end
+
+    source_path = base.get("source_inbox_path") or rec.get("note_filename") or ""
+    merged["source_inbox_path"] = source_path
+    merged["source_block_index"] = base.get("source_block_index", 0)
+    merged["tick_iso"] = et_now_iso
+    return merged, str(source_path)
+
+
+def _candidate(rec: dict) -> dict:
+    """Project a live record into the ambiguous-result candidate shape."""
+    return {
+        "title": (rec.get("partial_payload") or {}).get("title"),
+        "note_filename": rec.get("note_filename"),
+        "created_at": rec.get("created_at"),
+    }
+
+
+def _payload_start(payload: dict) -> str:
+    """Return the timed RFC3339 start, or the all-day date, for the result."""
+    return payload.get("start_rfc3339") or payload.get("start_date") or ""
+
+
+def _conversational_key(block: dict, tick_iso: str) -> str:
+    """Idempotency key for a conversational create: stable per request, distinct
+    across distinct requests.
+
+    ``conversational-{tick_iso}-{h}`` where ``h`` is the first 8 hex of the SHA-1
+    of the content-normalized block. Same content + same tick -> same key (a
+    retry never double-creates); different content in the same second -> a
+    different key (no collision between two distinct requests, MED-2).
+    """
+    digest = hashlib.sha1(
+        json.dumps(block, sort_keys=True, ensure_ascii=False).encode("utf-8")
+    ).hexdigest()[:8]
+    return f"conversational-{tick_iso}-{digest}"
+
+
+# ---------------------------------------------------------------------------
+# Create + orchestration
+# ---------------------------------------------------------------------------
+
+
+def _create_from_payload(
+    payload: dict,
+    idempotency_key: str,
+    account: str,
+    mode: str,
+    *,
+    record: Optional[dict] = None,
+    source_path: Optional[str] = None,
+    state_file: Optional[str] = None,
+) -> dict:
+    """Create the event and (for clarifications) run best-effort cleanup.
+
+    On helper failure: log ``calendar_event_failed`` and return the error dict
+    verbatim (never faked #683; no record removed, no note marked). On success:
+    log ``calendar_event_created`` and, for a clarification, remove the record +
+    mark the source note + log ``calendar_event_clarification_resolved`` (all
+    best-effort — the event already exists — with their outcome reported in the
+    ``cleanup`` block).
+    """
+    summary = payload.get("summary", "")
+    start = _payload_start(payload)
+
+    create_result = _invoke_calendar_helper(payload, idempotency_key, account)
+    if create_result.get("status") != "created":
+        _invoke_log_action(
+            AGENT,
+            "error",
+            "calendar_event_failed",
+            summary or idempotency_key,
+            "error",
+            {"mode": mode, "error": create_result.get("error", "")},
+        )
+        return {
+            "status": "error",
+            "exit_code": create_result.get("exit_code"),
+            "error": create_result.get("error", ""),
+        }
+
+    event_id = create_result.get("event_id", "")
+    html_link = create_result.get("html_link", "")
+    result: dict = {
+        "status": "created",
+        "mode": mode,
+        "event_id": event_id,
+        "html_link": html_link,
+        "summary": summary,
+        "start": start,
+    }
+    _invoke_log_action(
+        AGENT,
+        "routine",
+        "calendar_event_created",
+        summary or event_id,
+        "created",
+        {"mode": mode, "event_id": event_id},
+    )
+
+    if mode == "clarification":
+        note_filename = (record or {}).get("note_filename", "")
+        record_removed = _invoke_remove_record(note_filename, state_file)
+        if not record_removed:
+            # Retry the removal once — a transient state-file contention should
+            # not strand the record (and leave a resolved clarification re-asking).
+            record_removed = _invoke_remove_record(note_filename, state_file)
+        note_marked = _invoke_mark_processed(source_path) if source_path else False
+        cleanup_ok = record_removed and note_marked
+        _invoke_log_action(
+            AGENT,
+            "routine",
+            "calendar_event_clarification_resolved",
+            note_filename or event_id,
+            "resolved",
+            {"event_id": event_id, "clarification_id": note_filename},
+        )
+        result["cleanup"] = {
+            "record_removed": record_removed,
+            "note_marked": note_marked,
+        }
+        # Surfaced so the agent can tell Kent when cleanup silently failed (the
+        # event exists but the record/note weren't reconciled). Status stays
+        # "created" — the event DID get created.
+        result["cleanup_ok"] = cleanup_ok
+
+    return result
+
+
+def _classify_and_run(
+    block: dict, now_utc: datetime, state_path: Path, account: str
+) -> dict:
+    """Classify the request and run the matching branch. Returns the result dict."""
+    et_now_iso = _et_iso(now_utc)
+    block_tick = block.get("tick_iso")
+    tick_iso = (
+        block_tick
+        if isinstance(block_tick, str) and block_tick.strip()
+        else et_now_iso
+    )
+
+    live = [r for r in load_state(state_path) if _is_live(r.get("created_at"), now_utc)]
+
+    # Matching decides FIRST — a reply that strong-matches a pending record is a
+    # clarification even when it happens to be self-sufficient (a restated-complete
+    # reply must resolve + clean up the record, not spawn a fresh orphan). Only
+    # when NO record matches does alone-completeness pick conversational
+    # create-vs-clarify.
+    matched = _matched_records(block, live)
+
+    if len(matched) > 1:
+        return {
+            "status": "ambiguous",
+            "candidates": [_candidate(r) for r in matched],
+        }
+
+    if len(matched) == 1:
+        rec = matched[0]
+        merged, source_path = _build_merged(rec, block, et_now_iso)
+        mval = validate(merged)
+        if mval.get("complete"):
+            return _create_from_payload(
+                mval["calendar_event_payload"],
+                source_path,
+                account,
+                "clarification",
+                record=rec,
+                source_path=source_path,
+                state_file=str(state_path),
+            )
+        return {
+            "status": "needs_clarification",
+            "mode": "clarification",
+            "missing": mval.get("missing_fields", []),
+            "note_filename": rec.get("note_filename"),
+        }
+
+    # No pending record matched — a purely conversational request.
+    conv_block = dict(block)
+    conv_block["source_inbox_path"] = f"conversational-{tick_iso}"
+    conv_block["source_block_index"] = 0
+    conv_block["tick_iso"] = tick_iso
+    alone = validate(conv_block)
+
+    if alone.get("complete"):
+        return _create_from_payload(
+            alone["calendar_event_payload"],
+            _conversational_key(block, tick_iso),
+            account,
+            "conversational",
+        )
+
+    return {
+        "status": "needs_clarification",
+        "mode": "conversational",
+        "missing": alone.get("missing_fields", []),
+    }
+
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
+
+
+def main(argv: Optional[list[str]] = None) -> int:
+    parser = argparse.ArgumentParser(
+        prog="handle_calendar_request",
+        description=(
+            "Deterministic orchestrator: classify a conversational calendar "
+            "request (or clarification reply) read from stdin and create the "
+            "event / ask for clarification / report ambiguity."
+        ),
+    )
+    parser.add_argument(
+        "--account",
+        default=DEFAULT_ACCOUNT,
+        help=(
+            "Credential-set selector passed through to the calendar helper "
+            f"(default {DEFAULT_ACCOUNT!r})."
+        ),
+    )
+    parser.add_argument(
+        "--state-file",
+        default=str(STATE_PATH_DEFAULT),
+        help=(
+            "Path to the pending-clarification JSON state file. Defaults to "
+            f"{STATE_PATH_DEFAULT}."
+        ),
+    )
+    parser.add_argument(
+        "--now-iso",
+        default=None,
+        help=(
+            "Override 'now' (ISO 8601, aware or naive-UTC) for deterministic "
+            "tests. Defaults to the current UTC time."
+        ),
+    )
+    args = parser.parse_args(argv)
+
+    raw = sys.stdin.read()
+    if not raw.strip():
+        sys.stderr.write("INVALID_INPUT_JSON: empty stdin\n")
+        return 2
+    try:
+        block = json.loads(raw)
+    except json.JSONDecodeError as exc:
+        sys.stderr.write(f"INVALID_INPUT_JSON: {exc}\n")
+        return 2
+    if not isinstance(block, dict):
+        sys.stderr.write("INVALID_INPUT_JSON: top-level value is not a JSON object\n")
+        return 2
+
+    try:
+        now_utc = _parse_now(args.now_iso)
+    except ValueError as exc:
+        sys.stderr.write(f"INVALID_NOW_ISO: {exc}\n")
+        return 2
+
+    result = _classify_and_run(block, now_utc, Path(args.state_file), args.account)
+    sys.stdout.write(json.dumps(result) + "\n")
+    sys.stdout.flush()
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/openclaw/agents/felix-admin-calendar/AGENTS.md
+++ b/scripts/openclaw/agents/felix-admin-calendar/AGENTS.md
@@ -6,13 +6,13 @@
 
 ## Charter
 
-You are the calendar-substrate agent (judgment-only). Domain: the *conversational* Google Calendar surface that genuinely needs an LLM — (a) Kent's conversational calendar requests via main, (b) clarification round-trips when capture's extraction was incomplete. `felix-admin-capture` owns inbox classification and the deterministic inbox→calendar happy path (#679). The terminal create/update/delete is a deterministic **calendar helper** call (`scripts.google.calendar_helper`), not a skill — you have no `gog`. You own the pending-calendar-clarifications state file; main delegates, you don't re-dispatch back.
+You are the calendar-substrate agent (judgment-only). Domain: the *conversational* Google Calendar surface that genuinely needs an LLM — (a) Kent's conversational calendar requests via main, (b) clarification round-trips when capture's extraction was incomplete. `felix-admin-capture` owns inbox classification and the deterministic inbox→calendar happy path (#679). Your terminal action is a single deterministic **calendar-request orchestrator** (`scripts.calendar_routing.handle_calendar_request`) that owns matching, merging, validation, timezone math, event creation, state cleanup, and logging — you extract natural-language fields and phrase the result; you have no `gog` and you never invoke the calendar helper yourself.
 
 ## Memory / Red Lines / Verbatim
 
 - **Memory**: fresh each session. Use `MEMORY.md` (main sessions only) for durable context.
 - **Red lines**: never exfiltrate private data (see SOUL.md privacy boundary); no destructive commands without asking; when in doubt, file a P2-bug via main's `felix-file-issue.py`.
-- **Verbatim pass-through (ABSOLUTE)**: on self-dispatch into event creation (Resolve-and-create step 2), forward synthesized payload values VERBATIM — the helper payload and `log_action` depend on an unchanged payload between dispatch and execution.
+- **Verbatim reporting (ABSOLUTE)**: report the orchestrator's result faithfully — surface its `error` text VERBATIM and NEVER report an event as created unless its `status` was `created` (#683).
 
 ## Output discipline
 
@@ -22,14 +22,13 @@ Your final reply IS the message Kent receives — Felix's main session relays EV
 
 **Hard rule #2 — a turn that produces a user-facing message starts with the identity line, NO leading text.** First character is `S` in `Sent by felix-admin-calendar:<model>`. No "Perfect.", no "Here is the result:", no "Per AGENTS.md…". If you catch analysis text before the identity line, delete it.
 
-**Hard rule #3 — emit ZERO text between tool calls.** tool_use → tool_result → next tool_use, no intervening assistant text. The ONLY assistant text in the whole run is the `[felix-admin-calendar]: IDLE` token, the JSON response envelope returned to the caller, OR a final reply starting with the identity line.
+**Hard rule #3 — emit ZERO text between tool calls.** tool_use → tool_result → next tool_use, no intervening assistant text. The ONLY assistant text in the whole run is the `[felix-admin-calendar]: IDLE` token OR a final reply starting with the identity line.
 
-**Never narrate**: no step recaps or framing ("Validator returned complete:true", "Now invoking the calendar helper"), no status preamble around `[felix-admin-calendar]: IDLE`, no time/date narration, no delivery-status paragraphs, no meta-commentary about delivery.
+**Never narrate**: no step recaps or framing ("Validator returned complete:true", "Now invoking the orchestrator"), no status preamble around `[felix-admin-calendar]: IDLE`, no time/date narration, no delivery-status paragraphs, no meta-commentary about delivery.
 
 **Correct shape:**
 
-- **Capture-dispatch create**: tool_use chain → JSON response envelope on stdout, no user-facing reply (the envelope is for the caller, not Kent).
-- **Clarification reply**: chain → final text begins with `Sent by felix-admin-calendar:<model>` (or the helper error verbatim per the failure mode).
+- **Calendar request**: tool_use (orchestrator) → tool_result → final text begins with `Sent by felix-admin-calendar:<model>` confirming the event, asking for a missing field, disambiguating, or surfacing the error verbatim.
 - **No-op turn**: `[felix-admin-calendar]: IDLE`. End.
 
 Origin: `felix-admin-capture` smoke-tests (2026-05-20) — text before the identity line, in the final reply OR between tool calls, reaches Kent's WhatsApp verbatim.
@@ -42,96 +41,38 @@ Origin: `felix-admin-capture` smoke-tests (2026-05-20) — text before the ident
 
 ---
 
-## Calendar event creation (conversational / clarification only)
+## Calendar request handling
 
-With a fully-resolved `create_calendar_event` payload (conversational via main, or self-dispatched from the clarification handler below), **do not respond in chat** — perform the calendar-write workflow. Payload contract: `.../inbox-calendar-and-aspiration-routing-01KTHHXS/contracts/capture_to_main_calendar_payload.md`.
+Every calendar request reaching you — a conversational request from main OR a WhatsApp clarification reply — is handled the SAME way: extract the natural-language fields, hand them to ONE deterministic command, and phrase its result. **You never build a payload, a datetime, or an RFC3339 string; you never compute a timezone; you never invoke the calendar helper directly; you never decide whether a message is a clarification reply.** The orchestrator owns all of that — matching a reply to a pending clarification, merging, validation, timezone/RFC3339, creating the event, removing the resolved record, flipping the source note, and logging. Reliable calendar scheduling depends on you doing ONLY field extraction and wording.
 
-### Input payload
+### Step 1 — extract fields into an ExtractedCalendarBlock
 
-Parse JSON. **Required**: `action`, `calendar_id`, `account`, `summary`, `source_inbox_path`, and a start/end pair — **either** `start_rfc3339`+`end_rfc3339` (timed) **or** `start_date`+`end_date` (all-day, `YYYY-MM-DD`). **Optional**: `start_timezone`, `location`, `description`, `rrule`, `attendees` (emails or null), `clarification_id` (set on self-dispatch below). Pass whichever pair is present verbatim — defaults (`personal`, `primary`) already resolved upstream.
+Signal extraction is your judgment; the orchestrator does the deterministic parsing. Build a JSON object with whatever the text supplies:
 
-### Calendar helper invocation
+| Field | What it is | Example fragments |
+|---|---|---|
+| `title` | the event name / subject | "lunch with John", "dentist" |
+| `start_natural` | when it starts (date and/or time) | `Tuesday`, `next Tuesday`, `tomorrow`, `<Month> <day>`, `<n>am`/`<n>pm`, `noon`, combined "Thursday 2pm" |
+| `duration_natural` | how long | `for <n> hours/minutes`, `<n>h<m>m` |
+| `end_natural` | explicit end time | `to <n>pm`, `until <n>pm` |
+| `location` | where | `at <place>`, `@<place>` |
+| `recurrence_natural` | repeat pattern | `every <weekday>`, `weekly`, `biweekly`, `monthly`, `first`/`last <weekday>` |
+| `attendees` | who (emails or names, or null) | `with <name>(, <name>)*` |
+| `tick_iso` | **inbound receipt time** — set to NOW | so relative phrases ("next Tuesday") resolve against now, NOT any earlier timestamp |
 
-The terminal create is a deterministic **calendar helper** subprocess (you have no `gog`). Write the fully-resolved payload to a tempfile and invoke with `--payload-file` (never hand-build event bodies); template, flags, and exit codes in **TOOLS.md → calendar helper**. Key behaviors: `--idempotency-key "<source_inbox_path>"` makes a re-run a no-op; parse the `--json` line for `event_id`/`html_link`; a non-zero exit means the calendar was **not** mutated — surface the helper's `ERROR:` verbatim, NEVER report a create that did not happen (#683), never fall back to `gog`.
+Leave a field absent/null when the text doesn't supply it — do NOT invent a date, time, or default; the orchestrator asks for anything missing. For a terse clarification reply ("2pm", "for an hour"), extract only what's present — the orchestrator merges it onto the open clarification.
 
-### Response envelope
+### Step 2 — run the orchestrator
 
-Return one JSON object on stdout:
+Pipe the block to the single deterministic command (syntax + result contract in **TOOLS.md → calendar request orchestrator**). Default `<account>` is `personal` unless the request names another:
 
-- **Success** (exit 0): `{"status":"created","gcal_event_id":"<event_id>","html_link":"<html_link>","summary":"<summary>","start_rfc3339":"<start>","rrule":"<rrule|null>"}`
-- **Failure** (non-zero/malformed): `{"status":"error","error":"<helper stderr verbatim>","exit_code":<code>}` — do not paraphrase; the caller surfaces it verbatim to Kent.
+`cd /home/claude/kg-automation && echo '<ExtractedCalendarBlock JSON>' | python3 -m scripts.calendar_routing.handle_calendar_request --account <account>`
 
-### Logging
+It returns ONE JSON object carrying a `status`. It has already done any matching, merging, creating, record-removal, note-flip, and logging — you do none of those.
 
-Every calendar-create attempt emits a structured `log_action` event (success → `calendar_event_created`, failure → `calendar_event_failed`) before the response envelope returns. Exact commands and context payloads live in **TOOLS.md → log_action**. If `log_action.py` itself fails, note it to stderr and continue — don't block the response envelope on observability failure.
+### Step 3 — phrase the result (your ONLY user-facing output)
 
-## Calendar clarification reply handler
-
-When the inbox contained an incomplete calendar event, capture prompts Kent on WhatsApp and records the open prompt in a state file. His reply lands as an inbound WhatsApp message to you. State-file contract in **TOOLS.md → state file**.
-
-### Trigger
-
-On every inbound WhatsApp message, BEFORE any other intent classification, check `/data/services/openclaw/state/pending-calendar-clarifications.json` (a JSON **array** of PendingClarification records). If missing or empty, skip this handler.
-
-### Match the reply to an open record
-
-Use the deterministic matcher (`handle_clarification_state match --reply-content "<inbound body>"`; syntax in **TOOLS.md → state file**) — it reads the JSON-array store and returns the most-recent matching entry (or `null`):
-
-- **`null`** (no match) → skip this handler; proceed with normal handling.
-- **A single matched entry** → proceed with it. The reply naturally aligns to the most recent open prompt; proceed unless obviously unrelated (e.g., "log meditation done" — habit ping, not calendar reply).
-- **Genuine ambiguity** (reply could plausibly resolve two pending events) → send a turn-summary asking Kent to specify (e.g. `Got it. Was that for: "lunch with John next Tuesday" or "meeting with Y"?`), STOP without writing to any state file or calendar.
-
-### Field merge and re-validation
-
-Extract structured fields from the reply text using these patterns (LLM: signal extraction; helper: deterministic validation downstream):
-
-| Field | Patterns |
-|---|---|
-| Time-of-day | `<n>am`, `<n>pm`, `<n>:<m>am`, `<n>:<m>pm`, `noon`, `midnight`, `<n>:<m>` (24h) |
-| Duration | `for <n> (hour|minute|hr|min)(s)?`, `<n>h<m>m` |
-| End time | `to <n>am|pm`, `until <n>am|pm` |
-| Date | `Tuesday`, `next Tuesday`, `tomorrow`, `<n>/<m>`, `<Month> <day>`, `<Month> <day>, <year>` |
-| Location | `at <words>`, `@<words>` |
-| Recurrence | `every <weekday>`, `weekly`, `biweekly`, `monthly`, `first|second|third|fourth|last <weekday>` |
-| Attendees | `with <name>(, <name>)*` |
-
-Build a merged candidate block by applying extracted fields to the open record's `fields_so_far`. **Merge rule**: each extracted field replaces or fills its slot; if already non-null AND the reply extracts a different value, **the reply wins** (Kent's correction).
-
-Re-run the validator on stdin (`echo "<merged block JSON>" | … validate_calendar_event.py`; path in **TOOLS.md → validator**).
-
-Set `tick_iso` in the merged block to the **inbound message receipt time** — NOT the prompt's original `sent_at`. Relative phrases ("next Tuesday") must resolve against now.
-
-Validator output is JSON with `complete: true|false`:
-
-- `complete: true` → Resolve and create (below).
-- `complete: false`, `missing_fields` **same set** as existing → insufficient reply. Send `Still need: <missing>`. Record stays open; do NOT update `last_reprompt_at`.
-- `complete: false`, `missing_fields` **smaller set** → partial progress. Send a turn-summary asking what's missing, update `last_reprompt_at` to inbound receipt time, atomically rewrite the state file, keep the record open.
-
-### Resolve and create
-
-When re-validation returns `complete: true`, do the following in order:
-
-1. **Synthesize the CalendarEventPayload** from the validator's `calendar_event_payload` output; set `clarification_id` to the resolved record's id (correlates logging).
-
-2. **Apply the Calendar event creation handler above** with the synthesized payload (self-dispatch, not an `openclaw agent` round-trip). Its Logging auto-emits `calendar_event_created`/`calendar_event_failed`.
-
-3. **Remove the resolved record** — deterministic helper, not by hand (#763): `handle_clarification_state remove --note-filename "<matched note_filename>"` (prints `removed=N`; syntax in **TOOLS.md → state file**). (A *failed* resolution keeps its record — see Failure mode.)
-
-4. **Flip the source note's frontmatter** at `source_inbox_path`: locate the YAML block, set `status: processed` and `processed_at: "<tick_iso>"` (same as re-validation). Atomic write via .tmp + rename, matching capture's pattern.
-
-5. **Log the resolution** — emit `calendar_event_clarification_resolved` via `log_action` (command + context in **TOOLS.md → log_action**), targeting the `clarification_id`. (Step 2 also fires `calendar_event_created`.)
-
-6. **Send a turn-summary to Kent on WhatsApp** confirming the event (with gcal html_link if available). Standard end-of-turn output, not a channel-action call.
-
-### Failure mode (helper fails during resolution)
-
-If the calendar helper in step 2 exits non-zero (`status: "error"`):
-
-- `calendar_event_failed` is logged by the calendar-create handler.
-- **Do NOT remove the state-file record** — persist it so Kent can retry.
-- **Do NOT flip the source note status** — stays at `needs-review`.
-- Surface the failure verbatim in the turn-summary with the helper's `ERROR:` text so Kent can retry, correct the input, or fall back to manual creation. **Never fabricate a created event (#683); no `gog` fallback exists.**
-
-### Why this handler runs first
-
-Run it before main's intent-classification so a calendar clarification reply is never mis-routed — the check is cheap and the negative case costs nothing.
+- **`created`** → confirm to Kent: the `summary`, the start (date + time), and the `html_link` if present. If the result carries `"cleanup_ok": false` (a resolved clarification whose pending reminder couldn't be cleared), add one line saying the event is on the calendar but the pending reminder may re-ask — surface it, don't hide it.
+- **`needs_clarification`** → ask Kent for exactly the `missing` field(s), briefly (e.g. `What time on Thursday?`).
+- **`ambiguous`** → the reply could resolve more than one open event; ask which, listing the `candidates` titles (e.g. `Which one — "lunch with John" or "meeting with Y"?`). Create nothing.
+- **`error`** → surface the orchestrator's `error` text VERBATIM. NEVER report an event as created when `status` was not `created` (#683); there is no `gog` fallback.

--- a/scripts/openclaw/agents/felix-admin-calendar/TOOLS.md
+++ b/scripts/openclaw/agents/felix-admin-calendar/TOOLS.md
@@ -1,107 +1,23 @@
 # TOOLS.md
 
-## calendar helper (deterministic Google Calendar CLI)
+## calendar request orchestrator (your single calendar tool)
 
-- Sole calendar-write tool. This agent has **no `gog` skill** — the terminal
-  create/update/delete is the deterministic helper `scripts.google.calendar_helper`,
-  invoked via the standard `exec` tool. Write the fully-resolved
-  `create_calendar_event` payload to a tempfile and pass `--payload-file` (never
-  hand-build event bodies). Invocation template (deploy venv, run from
-  `/home/claude/kg-automation`):
+`scripts.calendar_routing.handle_calendar_request` is the ONE deterministic command you run for EVERY calendar request — a conversational request or a clarification reply. You have **no `gog`**, and you do **not** call the calendar helper, the validator, the clarification-state helper, or `log_action` directly — the orchestrator invokes all of them for you. This is what makes scheduling reliable: all date/time math and state changes are deterministic, never hand-built by you.
+
+- Invocation (pipe the ExtractedCalendarBlock JSON on stdin). The orchestrator is stdlib-only and resolves the deploy venv internally for the helper subprocess, so run it under system `python3` anchored to the checkout:
 
   ```bash
-  /data/services/openclaw/felix-calendar/venv/bin/python \
-    -m scripts.google.calendar_helper create \
-    --payload-file <tmp> --account <account> \
-    --idempotency-key "<source_inbox_path>" --json
+  cd /home/claude/kg-automation && echo '<ExtractedCalendarBlock JSON>' | python3 -m scripts.calendar_routing.handle_calendar_request --account <account>
   ```
 
-  The helper reads `summary`, the start/end pair (`start_rfc3339`/`end_rfc3339`,
-  or all-day `start_date`/`end_date`), and `start_timezone`/`location`/
-  `description`/`rrule` from the payload file; it refuses `attendees` unless
-  `--allow-attendees` (a note must not silently email people).
-- Authoritative flag/exit-code contract:
-  `kitty-specs/felix-calendar-helper-*/contracts/calendar-helper-cli.md`.
-  Payload (event-body) contract:
-  `kitty-specs/felix-calendar-subagent-extraction-01KTTA33/contracts/calendar-event-payload.md`.
-- `--json` is required for the response envelope: the helper emits a JSON line
-  (`{"status": "created", "event_id": …, "html_link": …}`) *before* its final
-  `SUMMARY:` line. Parse the JSON line.
-- `--idempotency-key "<source_inbox_path>"` de-dupes re-runs of the same source
-  note so a retry never double-creates.
-- Exit codes: `0` success · `1` operational/API error · `2` usage error ·
-  `3` auth failure. A non-zero exit writes `ERROR: …` to stderr and never
-  mutated the calendar — surface it verbatim (never fake a created event, #683;
-  there is no `gog` fallback).
-- OAuth is per-account (credential-set selector `--account`, default `personal`),
-  resolved inside the helper from `~/.config/felix/google/<account>/`. Do NOT
-  prompt for credentials or run any auth flow in-handler — that's an operator
-  surface. An expired/invalid token surfaces as exit `3`.
+- Default `--account` is `personal`. The block fields you assemble are listed in **AGENTS.md → Calendar request handling, Step 1**.
+- It returns ONE JSON object on stdout with a `status`; branch on it (AGENTS.md → Step 3):
+  - `{"status":"created","mode":"conversational"|"clarification","event_id":…,"html_link":…,"summary":…,"start":…}` — created at the correct ET date/time. A clarification result also carries `"cleanup_ok": <bool>` (and a `cleanup` block): the orchestrator best-effort removes the pending record, flips the source note, and logs — so `cleanup_ok: false` means the event exists but the reminder wasn't cleared (surface that to Kent).
+  - `{"status":"needs_clarification","mode":…,"missing":[…]}` — a required field is missing; ask Kent for exactly those.
+  - `{"status":"ambiguous","candidates":[{"title","note_filename","created_at"},…]}` — the reply could resolve more than one open clarification; ask Kent which.
+  - `{"status":"error","exit_code":<n>,"error":"<verbatim>"}` — the calendar helper failed and the calendar was NOT mutated; surface `error` VERBATIM (never fake a create, #683; no `gog` fallback).
 
-## State file: pending-calendar-clarifications.json
-
-- Path: `/data/services/openclaw/state/pending-calendar-clarifications.json`
-- Format: a JSON **array** of PendingClarification objects
-  (`{"note_filename", "partial_payload", "created_at"}`). Managed by
-  `scripts.inbox.handle_clarification_state` (`add` / `sweep` / `match`).
-  Schema context:
-  `kitty-specs/inbox-calendar-and-aspiration-routing-01KTHHXS/contracts/pending_clarification_record.md`.
-- Do NOT hand-roll parsing — use the `handle_clarification_state match` helper to
-  match a reply, and let the 24h `sweep` age out resolved/stale entries. The
-  helper writes atomically (temp + `os.replace`). Commands (run from
-  `/home/claude/kg-automation`):
-
-  ```bash
-  # Match an inbound reply to the most-recent open record (prints the entry, or null):
-  python3 -m scripts.inbox.handle_clarification_state match --reply-content "<inbound message body>"
-
-  # Remove a resolved record by note filename (prints removed=N):
-  python3 -m scripts.inbox.handle_clarification_state remove --note-filename "<matched note_filename>"
-  ```
-
-## Validator: validate_calendar_event.py
-
-- Path: `/home/claude/kg-automation/scripts/calendar_routing/validate_calendar_event.py`
-- Reads merged candidate block JSON from stdin; emits `complete: true|false`
-  plus `missing_fields` and (when complete) `calendar_event_payload`. Invoke
-  (from `/home/claude/kg-automation`):
-
-  ```bash
-  echo "<merged candidate block JSON>" | python3 scripts/calendar_routing/validate_calendar_event.py
-  ```
-- Owns deterministic field validation. The LLM job is signal extraction
-  from natural-language reply text; the validator does the math.
-
-## log_action
-
-- Path: `/home/claude/kg-automation/scripts/openclaw/observation/log_action.py`
-- Every calendar-create attempt emits a structured `log_action` event before the
-  response envelope returns (run from `/home/claude/kg-automation`):
-
-  ```bash
-  # On success:
-  python3 scripts/openclaw/observation/log_action.py \
-    --agent felix-admin-calendar --category routine \
-    --action calendar_event_created --target "<gcal_event_id>" --outcome success \
-    --context '{"source_inbox_path": "<from payload>", "account": "<from payload>", "calendar_id": "<from payload>", "rrule": "<from payload or null>", "clarification_id": "<from payload or null>"}'
-
-  # On failure:
-  python3 scripts/openclaw/observation/log_action.py \
-    --agent felix-admin-calendar --category error \
-    --action calendar_event_failed --target "<source_inbox_path>" --outcome error \
-    --context '{"error_detail": "<helper stderr>", "exit_code": <helper exit code>, "clarification_id": "<from payload or null>"}'
-  ```
-- Clarification resolution ALSO emits `calendar_event_clarification_resolved`:
-
-  ```bash
-  python3 scripts/openclaw/observation/log_action.py \
-    --agent felix-admin-calendar --category routine \
-    --action calendar_event_clarification_resolved \
-    --target "<clarification_id>" --outcome success \
-    --context '{"source_file": "<source_inbox_path>", "gcal_event_id": "<from helper response>"}'
-  ```
-- If `log_action.py` itself fails, write a short note to stderr and continue —
-  don't block the response envelope on observability failure.
+- What it owns internally (so you never do): matching a reply to a live pending clarification (`/data/services/openclaw/state/pending-calendar-clarifications.json`), merging the reply onto the record, deterministic date/time parsing + timezone (America/New_York) → RFC3339, all-day handling, the `calendar_helper create` call with an idempotency key, removing the resolved record, flipping the source note (`mark_processed`), and `log_action` (`calendar_event_created` / `calendar_event_failed` / `calendar_event_clarification_resolved`).
 
 ## Privacy
 

--- a/tests/calendar/test_handle_calendar_request.py
+++ b/tests/calendar/test_handle_calendar_request.py
@@ -1,0 +1,651 @@
+"""Tests for ``scripts.calendar_routing.handle_calendar_request``.
+
+The orchestrator reads an ``ExtractedCalendarBlock`` from stdin, classifies it
+(conversational create / conversational clarify / clarification / ambiguous),
+and drives the deterministic create + cleanup. Every external side effect is a
+module-level seam (``_invoke_calendar_helper``, ``_invoke_remove_record``,
+``_invoke_mark_processed``, ``_invoke_log_action``); these tests monkeypatch
+those so no subprocess, Google API, or filesystem note is ever touched.
+
+Tests drive ``main()`` in-process (stdin/stdout patched) — the existing
+``tests/calendar`` / ``tests/inbox`` convention — which also measures coverage
+of the CLI surface honestly.
+
+The #836 crux (test 3): a clarification reply supplies the TIME while the
+pending record supplies the DATE; the merge must yield the record's date at the
+reply's time. A blind field overwrite would drop the date — the exact bug.
+"""
+from __future__ import annotations
+
+import io
+import json
+import sys
+from datetime import datetime, timedelta, timezone
+
+import pytest
+
+from scripts.calendar_routing import handle_calendar_request as hcr
+
+
+# ---------------------------------------------------------------------------
+# Harness
+# ---------------------------------------------------------------------------
+
+
+def _run(monkeypatch, block, argv=None) -> tuple[int, dict, str]:
+    """Drive ``main`` with ``block`` on stdin; return (code, parsed_stdout, stderr)."""
+    stdin_text = block if isinstance(block, str) else json.dumps(block)
+    stdout_buf = io.StringIO()
+    stderr_buf = io.StringIO()
+    monkeypatch.setattr(sys, "stdin", io.StringIO(stdin_text))
+    monkeypatch.setattr(sys, "stdout", stdout_buf)
+    monkeypatch.setattr(sys, "stderr", stderr_buf)
+    code = hcr.main(argv or [])
+    out = stdout_buf.getvalue()
+    parsed = json.loads(out) if out.strip() else {}
+    return code, parsed, stderr_buf.getvalue()
+
+
+class _Seams:
+    """Records seam calls and returns canned successes."""
+
+    def __init__(self):
+        self.created_payloads: list = []
+        self.created_keys: list = []
+        self.removed: list = []
+        self.marked: list = []
+        self.log_calls: list = []
+        self.helper_result = {"status": "created", "event_id": "E1", "html_link": "L1"}
+
+    def install(self, monkeypatch):
+        def fake_helper(payload, idempotency_key, account):
+            self.created_payloads.append(payload)
+            self.created_keys.append(idempotency_key)
+            return self.helper_result
+
+        def fake_remove(note_filename, state_file):
+            self.removed.append(note_filename)
+            return True
+
+        def fake_mark(source_path):
+            self.marked.append(source_path)
+            return True
+
+        def fake_log(agent, category, action, target, outcome, context):
+            self.log_calls.append(
+                {
+                    "agent": agent,
+                    "category": category,
+                    "action": action,
+                    "target": target,
+                    "outcome": outcome,
+                    "context": context,
+                }
+            )
+
+        monkeypatch.setattr(hcr, "_invoke_calendar_helper", fake_helper)
+        monkeypatch.setattr(hcr, "_invoke_remove_record", fake_remove)
+        monkeypatch.setattr(hcr, "_invoke_mark_processed", fake_mark)
+        monkeypatch.setattr(hcr, "_invoke_log_action", fake_log)
+        return self
+
+    @property
+    def actions(self):
+        return [c["action"] for c in self.log_calls]
+
+
+@pytest.fixture
+def seams(monkeypatch):
+    return _Seams().install(monkeypatch)
+
+
+def _iso_z(dt: datetime) -> str:
+    return dt.astimezone(timezone.utc).replace(microsecond=0).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+def _record(title, start_natural, *, note_filename="felix-smoke.md",
+            source_inbox_path="/inbox/vault/felix-smoke.md", created_at=None):
+    partial = {
+        "title": title,
+        "start_natural": start_natural,
+        "source_inbox_path": source_inbox_path,
+        "source_block_index": 0,
+    }
+    return {
+        "note_filename": note_filename,
+        "partial_payload": partial,
+        "created_at": created_at or _iso_z(datetime(2026, 7, 20, 12, 0, tzinfo=timezone.utc)),
+    }
+
+
+def _seed_state(tmp_path, records):
+    state = tmp_path / "pending.json"
+    state.write_text(json.dumps(records), encoding="utf-8")
+    return state
+
+
+def _empty_state(tmp_path):
+    return _seed_state(tmp_path, [])
+
+
+# ---------------------------------------------------------------------------
+# 1. Conversational COMPLETE — summer + winter (no double offset)
+# ---------------------------------------------------------------------------
+
+
+def test_conversational_complete_summer(seams, monkeypatch, tmp_path):
+    state = _empty_state(tmp_path)
+    code, out, err = _run(
+        monkeypatch,
+        {"title": "meet Bob", "start_natural": "tomorrow at 2pm", "duration_natural": "1 hour"},
+        ["--state-file", str(state), "--now-iso", "2026-07-15T12:00:00-04:00"],
+    )
+    assert code == 0, err
+    assert out["status"] == "created"
+    assert out["mode"] == "conversational"
+    assert out["event_id"] == "E1"
+    # No cleanup block for conversational creates.
+    assert "cleanup" not in out
+    # ET summer offset is -04:00 (EDT) — proves no double offset.
+    payload = seams.created_payloads[0]
+    assert payload["start_rfc3339"] == "2026-07-16T14:00:00-04:00"
+    assert out["start"] == "2026-07-16T14:00:00-04:00"
+    # Synthetic conversational idempotency key, not a record path.
+    assert seams.created_keys[0].startswith("conversational-")
+    assert "calendar_event_created" in seams.actions
+
+
+def test_conversational_complete_winter(seams, monkeypatch, tmp_path):
+    state = _empty_state(tmp_path)
+    code, out, err = _run(
+        monkeypatch,
+        {"title": "meet Bob", "start_natural": "tomorrow at 2pm", "duration_natural": "1 hour"},
+        ["--state-file", str(state), "--now-iso", "2026-01-15T12:00:00-05:00"],
+    )
+    assert code == 0, err
+    payload = seams.created_payloads[0]
+    # ET winter offset is -05:00 (EST) — same wall time, correct offset.
+    assert payload["start_rfc3339"] == "2026-01-16T14:00:00-05:00"
+    assert out["start"] == "2026-01-16T14:00:00-05:00"
+
+
+# ---------------------------------------------------------------------------
+# 2. Conversational INCOMPLETE — no records
+# ---------------------------------------------------------------------------
+
+
+def test_conversational_incomplete_no_records(seams, monkeypatch, tmp_path):
+    state = _empty_state(tmp_path)
+    code, out, err = _run(
+        monkeypatch,
+        {"title": "lunch", "start_natural": "Thursday"},
+        ["--state-file", str(state), "--now-iso", "2026-07-15T12:00:00-04:00"],
+    )
+    assert code == 0, err
+    assert out["status"] == "needs_clarification"
+    assert out["mode"] == "conversational"
+    assert "start_time" in out["missing"]
+    # No create, no record cleanup.
+    assert seams.created_payloads == []
+    assert seams.removed == []
+    assert seams.marked == []
+
+
+# ---------------------------------------------------------------------------
+# 3. Clarification SOLE-MATCH — the #836 crux (record date + reply time)
+# ---------------------------------------------------------------------------
+
+
+def test_clarification_sole_match_combines_date_and_time(seams, monkeypatch, tmp_path):
+    state = _seed_state(
+        tmp_path,
+        [_record("Felix live smoke", "July 25",
+                 note_filename="felix-smoke.md",
+                 source_inbox_path="/inbox/vault/felix-smoke.md")],
+    )
+    code, out, err = _run(
+        monkeypatch,
+        {"title": "Felix live smoke", "start_natural": "2pm", "duration_natural": "1 hour"},
+        ["--state-file", str(state), "--now-iso", "2026-07-20T12:00:00-04:00"],
+    )
+    assert code == 0, err
+    assert out["status"] == "created"
+    assert out["mode"] == "clarification"
+    payload = seams.created_payloads[0]
+    # Date from the RECORD (July 25), time from the REPLY (2pm). The exact fix.
+    assert payload["start_rfc3339"] == "2026-07-25T14:00:00-04:00"
+    # Idempotency key is the record's source path (not a synthetic conversational one).
+    assert seams.created_keys[0] == "/inbox/vault/felix-smoke.md"
+    # Cleanup happened: record removed + note marked.
+    assert out["cleanup"] == {"record_removed": True, "note_marked": True}
+    assert seams.removed == ["felix-smoke.md"]
+    assert seams.marked == ["/inbox/vault/felix-smoke.md"]
+    # Both log actions emitted.
+    assert "calendar_event_created" in seams.actions
+    assert "calendar_event_clarification_resolved" in seams.actions
+    resolved = next(c for c in seams.log_calls if c["action"] == "calendar_event_clarification_resolved")
+    assert resolved["context"]["clarification_id"] == "felix-smoke.md"
+
+
+# ---------------------------------------------------------------------------
+# 4. Clarification TERSE reply (no title) — binds via no-title -> all-candidates
+# ---------------------------------------------------------------------------
+
+
+def test_clarification_terse_no_title_binds_sole_record(seams, monkeypatch, tmp_path):
+    state = _seed_state(
+        tmp_path,
+        [_record("Felix live smoke", "July 25",
+                 note_filename="felix-smoke.md",
+                 source_inbox_path="/inbox/vault/felix-smoke.md")],
+    )
+    code, out, err = _run(
+        monkeypatch,
+        {"start_natural": "2pm", "duration_natural": "1 hour"},
+        ["--state-file", str(state), "--now-iso", "2026-07-20T12:00:00-04:00"],
+    )
+    assert code == 0, err
+    assert out["status"] == "created"
+    assert out["mode"] == "clarification"
+    payload = seams.created_payloads[0]
+    # Title AND date came from the record; time from the reply.
+    assert payload["summary"] == "Felix live smoke"
+    assert payload["start_rfc3339"] == "2026-07-25T14:00:00-04:00"
+
+
+# ---------------------------------------------------------------------------
+# 5. AMBIGUOUS — terse no-title reply, two live records
+# ---------------------------------------------------------------------------
+
+
+def test_ambiguous_two_live_records(seams, monkeypatch, tmp_path):
+    state = _seed_state(
+        tmp_path,
+        [
+            _record("Felix live smoke", "July 25", note_filename="a.md",
+                    source_inbox_path="/inbox/a.md"),
+            _record("Dentist appointment", "July 26", note_filename="b.md",
+                    source_inbox_path="/inbox/b.md"),
+        ],
+    )
+    code, out, err = _run(
+        monkeypatch,
+        {"start_natural": "2pm", "duration_natural": "1 hour"},
+        ["--state-file", str(state), "--now-iso", "2026-07-20T12:00:00-04:00"],
+    )
+    assert code == 0, err
+    assert out["status"] == "ambiguous"
+    assert len(out["candidates"]) == 2
+    names = {c["note_filename"] for c in out["candidates"]}
+    assert names == {"a.md", "b.md"}
+    # Nothing created.
+    assert seams.created_payloads == []
+
+
+# ---------------------------------------------------------------------------
+# 6. Anti-mis-bind — complete conversational request while an UNRELATED record
+#    is pending: create conversationally, leave the record untouched.
+# ---------------------------------------------------------------------------
+
+
+def test_anti_misbind_complete_request_ignores_pending(seams, monkeypatch, tmp_path):
+    state = _seed_state(
+        tmp_path,
+        [_record("Dentist appointment", "July 26", note_filename="dentist.md",
+                 source_inbox_path="/inbox/dentist.md")],
+    )
+    code, out, err = _run(
+        monkeypatch,
+        {"title": "meet Bob", "start_natural": "tomorrow at 2pm", "duration_natural": "1 hour"},
+        ["--state-file", str(state), "--now-iso", "2026-07-15T12:00:00-04:00"],
+    )
+    assert code == 0, err
+    assert out["status"] == "created"
+    assert out["mode"] == "conversational"
+    # The unrelated pending record is NOT removed or marked.
+    assert seams.removed == []
+    assert seams.marked == []
+    assert "cleanup" not in out
+
+
+# ---------------------------------------------------------------------------
+# 7. ALL-DAY — whole-day duration -> start_date/end_date, no fabricated time
+# ---------------------------------------------------------------------------
+
+
+def test_all_day_event(seams, monkeypatch, tmp_path):
+    state = _empty_state(tmp_path)
+    code, out, err = _run(
+        monkeypatch,
+        {"title": "Kent's anniversary", "start_natural": "August 3", "duration_natural": "1 day"},
+        ["--state-file", str(state), "--now-iso", "2026-07-15T12:00:00-04:00"],
+    )
+    assert code == 0, err
+    assert out["status"] == "created"
+    payload = seams.created_payloads[0]
+    assert payload["start_date"] == "2026-08-03"
+    assert payload["end_date"] == "2026-08-04"
+    # No timed fields fabricated.
+    assert "start_rfc3339" not in payload
+    assert out["start"] == "2026-08-03"
+
+
+# ---------------------------------------------------------------------------
+# 8. Helper ERROR — surfaced verbatim, failed logged, no cleanup
+# ---------------------------------------------------------------------------
+
+
+def test_helper_error_surfaced_no_cleanup(seams, monkeypatch, tmp_path):
+    seams.helper_result = {
+        "status": "error",
+        "exit_code": 3,
+        "error": "ERROR: auth_failed invalid_grant",
+    }
+    state = _seed_state(
+        tmp_path,
+        [_record("Felix live smoke", "July 25", note_filename="felix-smoke.md",
+                 source_inbox_path="/inbox/vault/felix-smoke.md")],
+    )
+    code, out, err = _run(
+        monkeypatch,
+        {"title": "Felix live smoke", "start_natural": "2pm", "duration_natural": "1 hour"},
+        ["--state-file", str(state), "--now-iso", "2026-07-20T12:00:00-04:00"],
+    )
+    assert code == 0, err
+    assert out["status"] == "error"
+    assert out["exit_code"] == 3
+    assert out["error"] == "ERROR: auth_failed invalid_grant"
+    # No fabricated event id, no cleanup.
+    assert "event_id" not in out
+    assert seams.removed == []
+    assert seams.marked == []
+    assert "calendar_event_failed" in seams.actions
+    assert "calendar_event_created" not in seams.actions
+
+
+# ---------------------------------------------------------------------------
+# 9. Liveness — an aged-out record (9h old) is ignored
+# ---------------------------------------------------------------------------
+
+
+def test_aged_out_record_ignored(seams, monkeypatch, tmp_path):
+    now = datetime(2026, 7, 20, 12, 0, tzinfo=timezone.utc)
+    aged = _record("Felix live smoke", "July 25", note_filename="felix-smoke.md",
+                   source_inbox_path="/inbox/vault/felix-smoke.md",
+                   created_at=_iso_z(now - timedelta(hours=9)))
+    state = _seed_state(tmp_path, [aged])
+    code, out, err = _run(
+        monkeypatch,
+        {"start_natural": "2pm"},
+        ["--state-file", str(state), "--now-iso", _iso_z(now)],
+    )
+    assert code == 0, err
+    # Record is not live -> not matched -> falls through to conversational clarify,
+    # NOT a clarification create.
+    assert out["status"] == "needs_clarification"
+    assert out["mode"] == "conversational"
+    assert seams.created_payloads == []
+
+
+# ---------------------------------------------------------------------------
+# Clarification that stays incomplete after merge
+# ---------------------------------------------------------------------------
+
+
+def test_clarification_still_incomplete_leaves_record(seams, monkeypatch, tmp_path):
+    # Record has only a title (no date); reply adds a time but still no date.
+    rec = {
+        "note_filename": "felix-smoke.md",
+        "partial_payload": {
+            "title": "Felix live smoke",
+            "source_inbox_path": "/inbox/vault/felix-smoke.md",
+            "source_block_index": 0,
+        },
+        "created_at": _iso_z(datetime(2026, 7, 20, 12, 0, tzinfo=timezone.utc)),
+    }
+    state = _seed_state(tmp_path, [rec])
+    code, out, err = _run(
+        monkeypatch,
+        {"title": "Felix live smoke", "start_natural": "2pm"},
+        ["--state-file", str(state), "--now-iso", "2026-07-20T12:00:00-04:00"],
+    )
+    assert code == 0, err
+    assert out["status"] == "needs_clarification"
+    assert out["mode"] == "clarification"
+    assert out["note_filename"] == "felix-smoke.md"
+    # Record left in place (not removed), event not created.
+    assert seams.removed == []
+    assert seams.created_payloads == []
+
+
+# ---------------------------------------------------------------------------
+# CLI guards — bad stdin -> exit 2
+# ---------------------------------------------------------------------------
+
+
+def test_empty_stdin_exits_2(monkeypatch):
+    code, out, err = _run(monkeypatch, "", [])
+    assert code == 2
+    assert "INVALID_INPUT_JSON" in err
+
+
+def test_malformed_stdin_exits_2(monkeypatch):
+    code, out, err = _run(monkeypatch, "not json", [])
+    assert code == 2
+    assert "INVALID_INPUT_JSON" in err
+
+
+def test_non_object_stdin_exits_2(monkeypatch):
+    code, out, err = _run(monkeypatch, "[1, 2, 3]", [])
+    assert code == 2
+    assert "top-level" in err
+
+
+def test_bad_now_iso_exits_2(monkeypatch, tmp_path):
+    state = _empty_state(tmp_path)
+    code, out, err = _run(
+        monkeypatch,
+        {"title": "x", "start_natural": "tomorrow at 2pm", "duration_natural": "1 hour"},
+        ["--state-file", str(state), "--now-iso", "not-a-date"],
+    )
+    assert code == 2
+    assert "INVALID_NOW_ISO" in err
+
+
+# ---------------------------------------------------------------------------
+# _invoke_calendar_helper command construction (real seam, subprocess mocked)
+# ---------------------------------------------------------------------------
+
+
+# ---------------------------------------------------------------------------
+# Fix 2 — restated-complete reply that strong-matches the sole pending record
+# resolves as a CLARIFICATION (with cleanup), not a fresh conversational create.
+# ---------------------------------------------------------------------------
+
+
+def test_restated_complete_reply_resolves_as_clarification(seams, monkeypatch, tmp_path):
+    state = _seed_state(
+        tmp_path,
+        [_record("Dentist", "July 25", note_filename="dentist.md",
+                 source_inbox_path="/inbox/dentist.md")],
+    )
+    # Complete on its own (date + time + duration), and its title contains the
+    # pending record's title → strong match.
+    code, out, err = _run(
+        monkeypatch,
+        {"title": "Dentist appointment", "start_natural": "July 25 at 2pm",
+         "duration_natural": "1 hour"},
+        ["--state-file", str(state), "--now-iso", "2026-07-20T12:00:00-04:00"],
+    )
+    assert code == 0, err
+    assert out["status"] == "created"
+    assert out["mode"] == "clarification"
+    payload = seams.created_payloads[0]
+    assert payload["start_rfc3339"] == "2026-07-25T14:00:00-04:00"
+    # Resolved against the record: its idempotency key + cleanup, not an orphan.
+    assert seams.created_keys[0] == "/inbox/dentist.md"
+    assert out["cleanup"] == {"record_removed": True, "note_marked": True}
+    assert out["cleanup_ok"] is True
+    assert seams.removed == ["dentist.md"]
+    assert seams.marked == ["/inbox/dentist.md"]
+
+
+# ---------------------------------------------------------------------------
+# Fix 1/2 — an incomplete reply sharing only a GENERIC token ("Lunch") with a
+# pending record must NOT bind (subset rule); falls through to conversational.
+# ---------------------------------------------------------------------------
+
+
+def test_generic_token_does_not_misbind(seams, monkeypatch, tmp_path):
+    state = _seed_state(
+        tmp_path,
+        [_record("Lunch with John", "Thursday", note_filename="john.md",
+                 source_inbox_path="/inbox/john.md",
+                 created_at=_iso_z(datetime(2026, 7, 15, 12, 0, tzinfo=timezone.utc)))],
+    )
+    code, out, err = _run(
+        monkeypatch,
+        {"title": "Lunch with Sarah", "start_natural": "2pm", "duration_natural": "1 hour"},
+        ["--state-file", str(state), "--now-iso", "2026-07-15T12:00:00-04:00"],
+    )
+    assert code == 0, err
+    assert out["status"] == "needs_clarification"
+    assert out["mode"] == "conversational"
+    # John's record is untouched — no merge onto his Thursday, no create.
+    assert seams.created_payloads == []
+    assert seams.removed == []
+    assert seams.marked == []
+
+
+# ---------------------------------------------------------------------------
+# Fix 3 — an end-only reply inherits the record's date.
+# ---------------------------------------------------------------------------
+
+
+def test_end_only_reply_inherits_record_date(seams, monkeypatch, tmp_path):
+    state = _seed_state(
+        tmp_path,
+        [_record("Dentist", "Thursday", note_filename="dentist.md",
+                 source_inbox_path="/inbox/dentist.md",
+                 created_at=_iso_z(datetime(2026, 7, 15, 12, 0, tzinfo=timezone.utc)))],
+    )
+    # Terse (no title) reply carrying both a start-time and an end-time.
+    code, out, err = _run(
+        monkeypatch,
+        {"start_natural": "2pm", "end_natural": "3pm"},
+        ["--state-file", str(state), "--now-iso", "2026-07-15T12:00:00-04:00"],
+    )
+    assert code == 0, err
+    assert out["status"] == "created"
+    assert out["mode"] == "clarification"
+    payload = seams.created_payloads[0]
+    # Thursday after Wed 2026-07-15 is 2026-07-16; both endpoints on that date.
+    assert payload["start_rfc3339"] == "2026-07-16T14:00:00-04:00"
+    assert payload["end_rfc3339"] == "2026-07-16T15:00:00-04:00"
+
+
+# ---------------------------------------------------------------------------
+# Fix 4 — conversational idempotency key: distinct per request, stable per retry.
+# ---------------------------------------------------------------------------
+
+
+def test_conversational_idempotency_key_distinctness(seams, monkeypatch, tmp_path):
+    state = _empty_state(tmp_path)
+    now = "2026-07-15T12:00:00-04:00"
+    block_a = {"title": "meet Bob", "start_natural": "tomorrow at 2pm", "duration_natural": "1 hour"}
+    block_b = {"title": "meet Carol", "start_natural": "tomorrow at 2pm", "duration_natural": "1 hour"}
+
+    _run(monkeypatch, block_a, ["--state-file", str(state), "--now-iso", now])
+    _run(monkeypatch, block_b, ["--state-file", str(state), "--now-iso", now])
+    _run(monkeypatch, block_a, ["--state-file", str(state), "--now-iso", now])
+
+    key_a1, key_b, key_a2 = seams.created_keys
+    # Different content, same tick -> different keys (no same-second collision).
+    assert key_a1 != key_b
+    # Same content + same tick -> identical key (idempotent retry).
+    assert key_a1 == key_a2
+
+
+# ---------------------------------------------------------------------------
+# Fix 6 — cleanup failure: record removal retried once, cleanup_ok False,
+# status still "created".
+# ---------------------------------------------------------------------------
+
+
+def test_cleanup_failure_retries_and_flags(seams, monkeypatch, tmp_path):
+    calls = {"remove": 0}
+
+    def failing_remove(note_filename, state_file):
+        calls["remove"] += 1
+        return False
+
+    monkeypatch.setattr(hcr, "_invoke_remove_record", failing_remove)
+
+    state = _seed_state(
+        tmp_path,
+        [_record("Felix live smoke", "July 25", note_filename="felix-smoke.md",
+                 source_inbox_path="/inbox/vault/felix-smoke.md")],
+    )
+    code, out, err = _run(
+        monkeypatch,
+        {"title": "Felix live smoke", "start_natural": "2pm", "duration_natural": "1 hour"},
+        ["--state-file", str(state), "--now-iso", "2026-07-20T12:00:00-04:00"],
+    )
+    assert code == 0, err
+    # Event WAS created; cleanup failed and is surfaced.
+    assert out["status"] == "created"
+    assert out["mode"] == "clarification"
+    assert out["cleanup"]["record_removed"] is False
+    assert out["cleanup"]["note_marked"] is True
+    assert out["cleanup_ok"] is False
+    # Removal was retried exactly once (two attempts total).
+    assert calls["remove"] == 2
+
+
+# ---------------------------------------------------------------------------
+# Fix 5 — a launch-level OSError in the helper seam is caught, not raised.
+# ---------------------------------------------------------------------------
+
+
+def test_calendar_helper_oserror_is_caught(monkeypatch):
+    def boom(cmd, **kwargs):
+        raise OSError("No such file or directory: venv/bin/python")
+
+    monkeypatch.setattr(hcr.subprocess, "run", boom)
+    result = hcr._invoke_calendar_helper(
+        {"summary": "x", "start_rfc3339": "2026-07-25T14:00:00-04:00"},
+        "/inbox/vault/felix-smoke.md",
+        "personal",
+    )
+    assert result["status"] == "error"
+    assert "launch failed" in result["error"]
+
+
+def test_calendar_helper_command_shape(monkeypatch):
+    import subprocess
+
+    recorded: dict = {}
+
+    def fake_run(cmd, **kwargs):
+        recorded["cmd"] = cmd
+        return subprocess.CompletedProcess(
+            args=cmd,
+            returncode=0,
+            stdout='{"status": "created", "event_id": "e9", "html_link": "h9"}\n'
+            "SUMMARY: op=create status=created\n",
+            stderr="",
+        )
+
+    monkeypatch.setattr(hcr.subprocess, "run", fake_run)
+    result = hcr._invoke_calendar_helper(
+        {"summary": "x", "start_rfc3339": "2026-07-25T14:00:00-04:00"},
+        "/inbox/vault/felix-smoke.md",
+        "personal",
+    )
+    assert result == {"status": "created", "event_id": "e9", "html_link": "h9"}
+    cmd = recorded["cmd"]
+    assert cmd[0] == hcr.DEFAULT_CALENDAR_HELPER_PYTHON
+    assert cmd[0] != sys.executable
+    assert "-m" in cmd and hcr.CALENDAR_HELPER_MODULE in cmd
+    assert cmd[cmd.index("--idempotency-key") + 1] == "/inbox/vault/felix-smoke.md"
+    assert cmd[cmd.index("--account") + 1] == "personal"


### PR DESCRIPTION
Closes kentonium3/kg-automation#836.

## Problem
felix-admin-calendar (haiku) hand-built Google Calendar payloads → a "2pm" request created a **6 PM event on the wrong day**, and clarification replies never resolved. Root cause: the *inbox* path (`route_calendar_event --create`) is fully deterministic, but the *agent* paths trusted the LLM to do datetime math and decide clarification-vs-create.

## Fix
One new deterministic orchestrator — `scripts/calendar_routing/handle_calendar_request.py` — is the agent's sole calendar entry. It **composes existing, unmodified** helpers (`validate_calendar_event` for NL→validate→ET/RFC3339/all-day, `calendar_helper` for create, `handle_clarification_state` match/remove, `mark_processed` note-flip, `log_action`). The agent now only extracts NL fields and phrases the returned status (`created | needs_clarification | ambiguous | error`).

## Reliability design (both Codex checkpoints, fixed)
- **Matching decides first, deterministically** — subset title-match (one title's significant tokens ⊆ the other's): "Lunch with Sarah" no longer mis-binds onto pending "Lunch with John"; a restated-complete reply resolves + cleans up; terse replies bind sole-live; >1 → ambiguous.
- **Component-level temporal merge** — a time-only reply inherits the record's date for start **and** end: record "July 25" + reply "2pm" → `2026-07-25T14:00:00-04:00` (the exact bug, asserted).
- Idempotency key = `conversational-<tick>-<hash>` / record source path (no same-second collision).
- Helper `OSError`/timeout return JSON, never crash the single-JSON contract.
- Cleanup retried once; `cleanup_ok` surfaced when the event was created but the reminder couldn't be cleared.
- `log_action` invoked by absolute script path (its bare `from config import` breaks under `-m`) — observability restored.

## Prompt
The dual conversational/clarification workflow (~95 lines) collapses to one "Calendar request handling" flow. The raw `calendar_helper create` template is removed from the agent's reach (no bypass). AGENTS.md 11,846 → ~7,700 B.

## Gates
- 22 orchestrator tests (complete/incomplete, sole-match/terse/restated-complete, anti-mis-bind, ambiguous, all-day, DST, end-only merge, idempotency, cleanup-failure, OSError, liveness)
- Full suite **5954 passed**; `validate_workspace` 6/6
- No changes to `validate_calendar_event` / `handle_clarification_state` / `route_calendar_event` / capture (zero #699/#740 regression)

## Deploy
Code lands on office2 via checkout self-pull; prompt via agent-prompt-sync — both post-merge. **Rebaseline: not required — agent prompt files (#621)**; openclaw.json unchanged (model stays haiku). **Live acceptance** (conversational correct-time create + clarification resolve) run post-deploy before closing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)