### PR TITLE
fix(#515): persist correlated_checkin_date_et through record_completion

### DIFF
--- a/scripts/habits/record_completion.py
+++ b/scripts/habits/record_completion.py
@@ -200,6 +200,7 @@ def record(
     *,
     api_base_url: str,
     token: str,
+    correlated_checkin_date_et: str | None = None,
 ) -> None:
     """Three-write atomic completion record per ADR Q3-D.
 
@@ -227,6 +228,12 @@ def record(
             body if non-empty.
         api_base_url: Vikunja API base URL.
         token: Vikunja bearer token (felix-bot per Phase 1).
+        correlated_checkin_date_et: Optional instrumentation field (#515) —
+            the ``correlated_checkin_date_et`` the parser emitted (mission
+            #408 / WP-02): which morning-list check-in date this completion
+            was correlated to via the 48hr reply-correlation chain. Persisted
+            to the JSONL row when non-empty so mis-correlations are observable
+            (#509 trigger 2). Empty/absent → omitted (harmless).
 
     Raises:
         ValueError: On invalid state, missing field, or other schema
@@ -247,6 +254,10 @@ def record(
     }
     if note is not None:
         record_dict["note"] = note
+    # #515: instrumentation metadata, not part of the dedup key. Stored only
+    # when non-empty so the common no-correlation case leaves row shape stable.
+    if correlated_checkin_date_et:
+        record_dict["correlated_checkin_date_et"] = correlated_checkin_date_et
 
     # Step 0: validate. Raises ValueError before any I/O.
     state_log.validate_record(record_dict, "habits")
@@ -372,6 +383,15 @@ def build_parser() -> argparse.ArgumentParser:
         help="Optional free-form note appended to the Felix comment body.",
     )
     parser.add_argument(
+        "--correlated-checkin-date-et", default=None,
+        help=(
+            "Optional instrumentation field (#515): the parser's top-level "
+            "correlated_checkin_date_et (which check-in date this completion "
+            "was correlated to). Persisted to the JSONL row when non-empty; "
+            "empty/absent is harmless."
+        ),
+    )
+    parser.add_argument(
         "--token-file",
         type=Path,
         default=Path(DEFAULT_TOKEN_PATH),
@@ -424,6 +444,7 @@ def _build_args_from_flags(args: argparse.Namespace) -> dict:
         "state": args.state,
         "source": args.source,
         "note": args.note,
+        "correlated_checkin_date_et": args.correlated_checkin_date_et,
     }
 
 
@@ -448,6 +469,9 @@ def main(argv: list[str] | None = None) -> int:
             "state": stdin_record.get("state"),
             "source": stdin_record.get("source"),
             "note": stdin_record.get("note"),
+            "correlated_checkin_date_et": stdin_record.get(
+                "correlated_checkin_date_et"
+            ),
         }
     else:
         try:
@@ -474,6 +498,7 @@ def main(argv: list[str] | None = None) -> int:
             note=kwargs.get("note"),
             api_base_url=args.base_url,
             token=token,
+            correlated_checkin_date_et=kwargs.get("correlated_checkin_date_et"),
         )
     except ValueError as e:
         print(f"ERROR: validation failed: {e}", file=sys.stderr)

--- a/scripts/openclaw/agents/felix-admin-habits/AGENTS.md
+++ b/scripts/openclaw/agents/felix-admin-habits/AGENTS.md
@@ -164,10 +164,13 @@ cd /home/claude/kg-automation && python3 -m scripts.habits.record_completion \
     --title "<title from the morning-list artifact>" \
     --date $(TZ=America/New_York date +%Y-%m-%d) \
     --state <complete|incomplete|skipped> \
-    --source whatsapp
+    --source whatsapp \
+    --correlated-checkin-date-et "<parser top-level correlated_checkin_date_et>"
 ```
 
 `--state` accepts only `complete`, `incomplete`, or `skipped` (Phase 2 strict enum). Pass the value the parser put in `tuples[i].state`.
+
+Pass the parser's **top-level** `correlated_checkin_date_et` (the same value on every call this reply produces — it is per-reply, not per-tuple) to `--correlated-checkin-date-et`. It is instrumentation (#515): when non-empty it records which check-in date this completion was correlated to, so mis-correlations are observable. When the parser emits `""` (the common case), pass the empty string — `record_completion` drops it and the row is unchanged.
 
 Exit codes: `0` = success or idempotent no-op; `1` = Vikunja write failure; `2` = state-log write failure (Vikunja already committed — surface in the action log); `3` = validation/usage error.
 

--- a/tests/habits/test_record_completion.py
+++ b/tests/habits/test_record_completion.py
@@ -743,3 +743,114 @@ class TestCli:
         assert exit_code == 3
         err = capsys.readouterr().err
         assert "Token file not found" in err
+
+
+# ===========================================================================
+# Group 11 — correlated_checkin_date_et instrumentation (#515)
+# ===========================================================================
+
+
+class TestCorrelatedCheckinDateEt:
+    """The parser's top-level ``correlated_checkin_date_et`` (mission #408 /
+    WP-02) must round-trip through ``record()`` and both CLI surfaces into the
+    persisted JSONL row so mis-correlations are observable (#509 trigger 2)."""
+
+    def _three_ok(self, mock_urlopen):
+        mock_urlopen.side_effect = [
+            _resp({"id": 14, "repeat_after": 86400, "repeat_mode": 0}),
+            _resp({"id": 14, "done": True}),
+            _resp({"id": 999}),
+        ]
+
+    def test_record_persists_field_when_non_empty(
+        self, mock_urlopen, mock_state_log_dir
+    ):
+        self._three_ok(mock_urlopen)
+        rc.record(**VALID_KWARGS, correlated_checkin_date_et="2026-05-19")
+
+        rows = state_log.read("habits", task_id=14, date="2026-05-20")
+        assert len(rows) == 1
+        assert rows[0]["correlated_checkin_date_et"] == "2026-05-19"
+
+    def test_record_omits_field_when_empty(
+        self, mock_urlopen, mock_state_log_dir
+    ):
+        self._three_ok(mock_urlopen)
+        rc.record(**VALID_KWARGS, correlated_checkin_date_et="")
+
+        rows = state_log.read("habits", task_id=14, date="2026-05-20")
+        assert len(rows) == 1
+        assert "correlated_checkin_date_et" not in rows[0]
+
+    def test_record_omits_field_when_absent(
+        self, mock_urlopen, mock_state_log_dir
+    ):
+        # Default (None) — the field never appears; row shape unchanged.
+        self._three_ok(mock_urlopen)
+        rc.record(**VALID_KWARGS)
+
+        rows = state_log.read("habits", task_id=14, date="2026-05-20")
+        assert len(rows) == 1
+        assert "correlated_checkin_date_et" not in rows[0]
+
+    def test_cli_persists_field_via_flag(
+        self, mock_urlopen, mock_state_log_dir, tmp_token_file, monkeypatch
+    ):
+        self._three_ok(mock_urlopen)
+        _patch_stdin(monkeypatch, None)  # no stdin -> flags path
+        exit_code = rc.main([
+            "--task-id", "14",
+            "--title", "Wake at 5:00 AM",
+            "--date", "2026-05-20",
+            "--state", "complete",
+            "--source", "whatsapp",
+            "--correlated-checkin-date-et", "2026-05-19",
+            "--token-file", str(tmp_token_file),
+            "--base-url", "http://test/api/v1/",
+        ])
+        assert exit_code == 0
+        rows = state_log.read("habits", task_id=14, date="2026-05-20")
+        assert len(rows) == 1
+        assert rows[0]["correlated_checkin_date_et"] == "2026-05-19"
+
+    def test_cli_persists_field_via_stdin(
+        self, mock_urlopen, mock_state_log_dir, tmp_token_file, monkeypatch
+    ):
+        self._three_ok(mock_urlopen)
+        payload = json.dumps({
+            "task_id": 14,
+            "title": "Wake at 5:00 AM",
+            "date": "2026-05-20",
+            "state": "complete",
+            "source": "whatsapp",
+            "correlated_checkin_date_et": "2026-05-19",
+        })
+        _patch_stdin(monkeypatch, payload)
+        exit_code = rc.main([
+            "--token-file", str(tmp_token_file),
+            "--base-url", "http://test/api/v1/",
+        ])
+        assert exit_code == 0
+        rows = state_log.read("habits", task_id=14, date="2026-05-20")
+        assert len(rows) == 1
+        assert rows[0]["correlated_checkin_date_et"] == "2026-05-19"
+
+    def test_field_is_not_part_of_dedup_key(
+        self, mock_urlopen, mock_state_log_dir
+    ):
+        """A second call for the same (task_id, date, state) is still an
+        idempotent no-op even if the correlation value differs — the field is
+        metadata, not part of the dedup key."""
+        self._three_ok(mock_urlopen)
+        rc.record(**VALID_KWARGS, correlated_checkin_date_et="2026-05-19")
+
+        # Second call: no Vikunja traffic allowed (idempotent short-circuit).
+        mock_urlopen.side_effect = AssertionError(
+            "urlopen must not be called on idempotent re-record"
+        )
+        rc.record(**VALID_KWARGS, correlated_checkin_date_et="2026-05-18")
+
+        rows = state_log.read("habits", task_id=14, date="2026-05-20")
+        assert len(rows) == 1
+        # First write wins; no duplicate row.
+        assert rows[0]["correlated_checkin_date_et"] == "2026-05-19"


### PR DESCRIPTION
## Summary
Closes #515. The habits reply parser (`parse_morning_reply.py`) computes a top-level `correlated_checkin_date_et` (the 48h reply-correlation-chain result, mission #408/WP-02) but `record_completion.py` never read or persisted it — every correlation result was computed then **dropped** before the JSONL write. **0 of 391 live rows** carried it. This converts #509 trigger 2 ("a real mis-correlation surfaces") from invisible to observable.

## Changes
- **`scripts/habits/record_completion.py`** — add `--correlated-checkin-date-et`; thread through `record()`, the flags path, and the stdin-JSON path. Persisted to the `habits-history.jsonl` row **only when non-empty** (mirrors `note`), so the common no-correlation case leaves row shape stable. It is metadata, **not** part of the `(task_id, date, state)` dedup key.
- **`scripts/openclaw/agents/felix-admin-habits/AGENTS.md`** Step 2 — pass the parser's top-level `correlated_checkin_date_et` on each `record_completion` call.
- **`tests/habits/test_record_completion.py`** — 6 tests: round-trip via `record()`/flags/stdin; omitted when empty/absent; confirmed not part of the dedup key.

## Why no schema change
`state_log.validate_record` is permissive about extra keys, and `append`/`read` pass dicts through (`StateLogRecord` is a doc-only mirror, never reconstructed from rows). The field rides as an allowed extra and round-trips cleanly.

## Scope discipline
Kept tight per the #515 body — did **not** migrate `record_completion`'s own HTTP wrapper (that's #543's opportunistic job), and did **not** touch the still-#509-blocked quote-reply extraction.

## Gates
- Full suite green: **5960 passed, 42 skipped, 1 xfailed**.
- Codex review (spec-kitty-review profile): **SHIP, no findings** — independently verified dedup isolation, empty-omission, both CLI paths, and the state_log round-trip.

## Rebaseline
Not required — `openclaw-agent-prompts` maps to `affected_baselines: []` (#621); `scripts/habits` is not a hashed audited surface.

🤖 Generated with [Claude Code](https://claude.com/claude-code)