### PR TITLE
fix(gitignore): ignore repo-relative runtime state dirs (#855)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -74,3 +74,10 @@ kitty-ops/ops-index.jsonl
 
 # spec-kitty 3.2.6 plugin-projection artifact (emitted by 'doctor tool-surfaces --fix'); see spec-kitty tracking issue
 /dist/
+
+# Repo-relative runtime state/output dirs (#855). Canonical runtime state lives
+# in /data/services/openclaw/state/ on office2, never in the checkout. A stray
+# relative write under scripts/<domain>/state/ must not dirty the working tree
+# or erode felix-deployer's clean-tree invariant. No scripts/**/state/ dir is
+# intentionally tracked (audited 2026-07-22).
+scripts/**/state/


### PR DESCRIPTION
## Summary

Adds `scripts/**/state/` to `.gitignore` so a stray relative runtime write into the office2 checkout (canonical runtime state lives in `/data/services/openclaw/state/`, never in the checkout) cannot dirty the working tree or erode felix-deployer's clean-tree invariant.

## Context

office2's checkout had carried an untracked `scripts/habits/state/habits-history.jsonl` (removed manually 2026-07-22) — a one-off stray write with nothing preventing recurrence. This ignore rule makes such accidental writes invisible to `git status`.

## Verification

- Audited the tree: **no** `scripts/**/state/` dir is intentionally tracked (`git ls-files` empty; none on disk).
- Confirmed a probe write `scripts/habits/state/probe.jsonl` is now matched by `git check-ignore`.
- Full gate green locally: `make test` (5978 passed, 42 skipped), `validate_docs`, `validate_architecture_data`.

Rebaseline: not required — `.gitignore` is not an audited surface.

Closes #855

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DLvcqgYayz41EYZFsDj5xz