### PR TITLE
fix(security): whatsapp missing-in false-positive + expires_at-aware boundary (#854, #852 part 1)

### DIFF
--- a/scripts/security/credential_health_check/cadence.py
+++ b/scripts/security/credential_health_check/cadence.py
@@ -44,6 +44,32 @@ def compute_boundary(credential: Credential) -> Optional[date]:
     return anchor + CADENCE_INTERVALS[credential.review_cadence]
 
 
+def compute_effective_boundary(credential: Credential) -> Optional[date]:
+    """Return the EARLIER of the review-cadence boundary and the hard `expires_at`.
+
+    This is the boundary the warning window should be measured against (#852). A
+    credential whose real expiry (`expires_at`) is sooner than its review-cadence
+    boundary must be warned ahead of the *expiry* — otherwise it silently lapses
+    while the cadence-only boundary still sits far in the future (e.g. an annual
+    review boundary a year out while the key actually dies next month).
+
+    Behaviour:
+    - cadence boundary AND expires_at present  → the earlier of the two.
+    - only a cadence boundary (no expires_at)  → the cadence boundary (unchanged
+      pre-#852 behaviour).
+    - only expires_at (non-fixed-interval cred) → expires_at.
+    - neither                                   → None.
+    """
+    candidates = [
+        d
+        for d in (compute_boundary(credential), credential.expires_at)
+        if d is not None
+    ]
+    if not candidates:
+        return None
+    return min(candidates)
+
+
 def is_within_warning_window(
     boundary: date,
     today: date,

--- a/scripts/security/credential_health_check/github_writer.py
+++ b/scripts/security/credential_health_check/github_writer.py
@@ -67,6 +67,14 @@ def cadence_alert_body(
     cycle_date: date,
 ) -> str:
     days_remaining = (boundary - cycle_date).days
+    # #852: when the credential declares a hard `expires_at`, surface it so the
+    # reader can see WHY the warning boundary is where it is — the boundary is
+    # the earlier of the review-cadence date and this hard expiry.
+    expiry_line = (
+        f"**Hard expiry (`expires_at`)**: **{credential.expires_at.isoformat()}**\n"
+        if credential.expires_at is not None
+        else ""
+    )
     return (
         f"**Credential**: `{credential.name}` (`{credential.type or 'unspecified'}`)\n"
         f"**Scope**: {credential.scope or '—'}\n"
@@ -74,7 +82,9 @@ def cadence_alert_body(
         f"**Used by**: {_used_by_str(credential)}\n\n"
         f"**Review cadence**: `{credential.review_cadence}` — last reviewed "
         f"**{credential.last_reviewed.isoformat() if credential.last_reviewed else '—'}**\n"
-        f"**Cadence boundary**: **{boundary.isoformat()}** (in {days_remaining} days)\n"
+        f"{expiry_line}"
+        f"**Warning boundary** (earlier of review cadence + hard expiry): "
+        f"**{boundary.isoformat()}** (in {days_remaining} days)\n"
         f"**Vikunja task**: #{vikunja_task_id} (due {(boundary - _timedelta_days(7)).isoformat()})\n\n"
         "---\n\n"
         "### Rotation procedure\n\n"

--- a/scripts/security/credential_health_check/listing.py
+++ b/scripts/security/credential_health_check/listing.py
@@ -13,7 +13,11 @@ from dataclasses import dataclass
 from datetime import date
 from typing import IO, Iterable, Optional
 
-from .cadence import WARNING_WINDOW_DAYS, compute_boundary, is_fixed_interval_cadence
+from .cadence import (
+    WARNING_WINDOW_DAYS,
+    compute_effective_boundary,
+    is_fixed_interval_cadence,
+)
 from .manifest import Credential, ManifestQualityIssue, read_manifest
 
 
@@ -30,19 +34,26 @@ class CredentialListing:
 
 
 def _status_for(cred: Credential, boundary: Optional[date], today: date) -> str:
-    """Classify a credential's current state for the Status column."""
-    if not is_fixed_interval_cadence(cred.review_cadence):
-        if cred.review_cadence == "monitor-activity":
-            return "activity-tracked"
-        return f"skip ({cred.review_cadence})"
-    if boundary is None:
+    """Classify a credential's current state for the Status column.
+
+    Keyed off the (effective) boundary first (#852): any credential with a
+    boundary — cadence-driven or `expires_at`-driven — is classified by its
+    days-to-boundary, so the --list view agrees with what the alerter fires on.
+    Only when there is no boundary do we fall back to a cadence-type label.
+    """
+    if boundary is not None:
+        delta = (boundary - today).days
+        if delta < 0:
+            return f"OVERDUE ({-delta}d ago)"
+        if delta <= WARNING_WINDOW_DAYS:
+            return f"WARNING ({delta}d)"
+        return f"within ({delta}d)"
+    # No boundary: classify by cadence type.
+    if cred.review_cadence == "monitor-activity":
+        return "activity-tracked"
+    if is_fixed_interval_cadence(cred.review_cadence):
         return "skip (no anchor)"
-    delta = (boundary - today).days
-    if delta < 0:
-        return f"OVERDUE ({-delta}d ago)"
-    if delta <= WARNING_WINDOW_DAYS:
-        return f"WARNING ({delta}d)"
-    return f"within ({delta}d)"
+    return f"skip ({cred.review_cadence})"
 
 
 def build_listings(
@@ -51,7 +62,7 @@ def build_listings(
     """Build CredentialListing entries from well-formed credentials."""
     rows: list[CredentialListing] = []
     for cred in credentials:
-        boundary = compute_boundary(cred)
+        boundary = compute_effective_boundary(cred)
         rows.append(
             CredentialListing(
                 name=cred.name,

--- a/scripts/security/credential_health_check/manifest.py
+++ b/scripts/security/credential_health_check/manifest.py
@@ -83,6 +83,7 @@ class Credential:
     host: Optional[str] = None
     last_reviewed: Optional[date] = None
     created_date: Optional[date] = None
+    expires_at: Optional[date] = None
     liveness_probe: Optional[LivenessProbeConfig] = None
 
 
@@ -136,6 +137,18 @@ def _validate_and_construct(
         )
 
     created_date = _parse_iso_date(entry.get("created_date"))
+
+    # expires_at is the credential's REAL hard-expiry date (#852). It is
+    # optional; when present it must be a parseable ISO-8601 date. Unlike
+    # last_reviewed it drives no anchor requirement — it only tightens the
+    # warning boundary (see cadence.compute_effective_boundary).
+    expires_at_raw = entry.get("expires_at")
+    expires_at = _parse_iso_date(expires_at_raw)
+    if expires_at_raw is not None and expires_at is None:
+        return None, ManifestQualityIssue(
+            credential_name=name,
+            reason=f"expires_at is not a parseable ISO-8601 date: {expires_at_raw!r}",
+        )
 
     if cadence in FIXED_INTERVAL_CADENCES:
         # Need an anchor for boundary computation.
@@ -273,6 +286,7 @@ def _validate_and_construct(
         host=entry.get("host") if isinstance(entry.get("host"), str) else None,
         last_reviewed=last_reviewed,
         created_date=created_date,
+        expires_at=expires_at,
         liveness_probe=liveness_probe,
     )
     return cred, None

--- a/scripts/security/credential_health_check/orchestrator.py
+++ b/scripts/security/credential_health_check/orchestrator.py
@@ -13,7 +13,11 @@ from typing import Optional
 
 from scripts.common import vikunja_refs
 
-from .cadence import compute_boundary, is_fixed_interval_cadence, is_within_warning_window
+from .cadence import (
+    compute_effective_boundary,
+    is_fixed_interval_cadence,
+    is_within_warning_window,
+)
 from .github_writer import (
     GitHubWriteError,
     MANIFEST_QUALITY_TITLE_PREFIX,
@@ -111,9 +115,20 @@ def run_cycle(
         result.credentials_evaluated += 1
 
         if not liveness_only:
-            # Branch A: fixed-interval cadence.
-            if is_fixed_interval_cadence(cred.review_cadence):
-                boundary = compute_boundary(cred)
+            # Branch A: cadence- or expiry-driven boundary. The warning boundary
+            # is the EARLIER of the review-cadence boundary and the credential's
+            # hard `expires_at` (#852) — so a key whose real expiry precedes its
+            # cadence review date is warned ahead of the expiry, not silently
+            # left to lapse. Entered for any fixed-interval cadence, AND for any
+            # credential that carries `expires_at` even under a non-fixed cadence
+            # (so a future on-revocation/n-a cred with a hard expiry is still
+            # warned). Monitor-activity creds are excluded — they are handled by
+            # their signal reader (Branch B), never here.
+            if is_fixed_interval_cadence(cred.review_cadence) or (
+                cred.expires_at is not None
+                and cred.name not in MONITOR_ACTIVITY_READERS
+            ):
+                boundary = compute_effective_boundary(cred)
                 if boundary is None:
                     _log(
                         logger,

--- a/scripts/security/credential_health_check/signals.py
+++ b/scripts/security/credential_health_check/signals.py
@@ -188,19 +188,50 @@ def whatsapp_session_signal(
                 summary=f"whatsapp: flag `{required_flag}` missing",
             )
 
-    # Check in:/out: durations.
-    for direction in ("in", "out"):
-        prefix = f"{direction}:"
-        token = next((p for p in parts if p.startswith(prefix)), None)
-        if token is None:
+    # health:<state> — when openclaw emits it, the session self-reports its
+    # health. Anything other than `healthy` is a real liveness failure (#854).
+    health_token = next((p for p in parts if p.startswith("health:")), None)
+    if health_token is not None:
+        health_state = health_token[len("health:"):].strip()
+        if health_state != "healthy":
             return ActivitySignalFailure(
                 credential_name=credential.name,
                 reason=(
-                    f"WhatsApp default channel `{prefix}<duration>` token missing in "
-                    f"openclaw status output. Full line: {channel_line!r}"
+                    f"WhatsApp default channel reports `health:{health_state}`, "
+                    f"expected `health:healthy`. Full line: {channel_line!r}"
                 ),
-                summary=f"whatsapp: {prefix} token missing",
+                summary=f"whatsapp: health={health_state}",
             )
+
+    # Freshness of the directional + transport activity timestamps.
+    #
+    # openclaw OMITS the `in:` token whenever there has been no recent *inbound*
+    # message (and likewise `out:` with no recent outbound). A MISSING token
+    # therefore means "no activity in that direction", NOT staleness — a
+    # healthy-but-quiet session (linked+running+connected, health:healthy,
+    # fresh transport:) must not trip a false expiry alert (#854, closes the
+    # #851 class). So evaluate ONLY tokens that are present; a present duration
+    # beyond the 14-day threshold is a genuine expiry signal.
+    #
+    # `transport:` is the transport-layer heartbeat — the most reliable liveness
+    # timestamp because it is independent of message traffic — so it is parsed
+    # and checked the same way when present.
+    #
+    # Design note (renata MED-2): a MISSING `transport:` is deliberately NOT a
+    # failure. openclaw only began emitting the token in a newer status format
+    # (the older healthy fixtures omit it entirely), so enforcing its presence
+    # would false-positive on any session reporting the older shape. For a quiet
+    # session the hard liveness gate is therefore the bare flags
+    # (linked/running/connected) plus `health:` — openclaw drops `connected` /
+    # flips `health` when a session actually dies. This matches the expected
+    # behavior in #854: "healthy if linked+connected present and transport/out
+    # fresh; flag only on a present stale duration, a missing liveness flag, or
+    # health != healthy."
+    for direction in ("in", "out", "transport"):
+        prefix = f"{direction}:"
+        token = next((p for p in parts if p.startswith(prefix)), None)
+        if token is None:
+            continue  # non-fatal: an absent timestamp is not staleness (#854)
         duration_str = token[len(prefix):].strip()
         duration = parse_duration(duration_str)
         if duration is None:

--- a/tests/security/fixtures/openclaw-channels-status-quiet-no-inbound.txt
+++ b/tests/security/fixtures/openclaw-channels-status-quiet-no-inbound.txt
@@ -1,0 +1,5 @@
+Checking channel status…
+Gateway reachable.
+- WhatsApp default: enabled, configured, linked, running, connected, out:2h ago, transport:1m ago, dm:allowlist, allow:+16179300916, health:healthy
+
+Tip: https://docs.openclaw.ai/cli#status adds gateway health probes to status output (requires a reachable gateway).

--- a/tests/security/test_cadence.py
+++ b/tests/security/test_cadence.py
@@ -8,6 +8,7 @@ import pytest
 from credential_health_check.cadence import (
     WARNING_WINDOW_DAYS,
     compute_boundary,
+    compute_effective_boundary,
     is_fixed_interval_cadence,
     is_within_warning_window,
 )
@@ -84,6 +85,58 @@ def test_compute_boundary_returns_none_for_on_revocation():
 def test_compute_boundary_returns_none_when_anchor_missing():
     cred = _make_credential(last_reviewed=None, created_date=None)
     assert compute_boundary(cred) is None
+
+
+# ---------- compute_effective_boundary (#852) ----------
+
+
+def test_effective_boundary_expiry_earlier_than_cadence_wins():
+    """#852 core bug: expires_at sooner than the annual cadence boundary must win.
+
+    anthropic-test scenario: last_reviewed 2026-07-22 (annual → cadence 2027-07-22),
+    expires_at 2026-08-21 → effective boundary is the expiry, ~11 months earlier.
+    """
+    cred = _make_credential(
+        last_reviewed=date(2026, 7, 22), expires_at=date(2026, 8, 21)
+    )
+    assert compute_boundary(cred) == date(2027, 7, 22)  # cadence-only (the old bug)
+    assert compute_effective_boundary(cred) == date(2026, 8, 21)
+
+
+def test_effective_boundary_cadence_earlier_than_expiry_wins():
+    cred = _make_credential(
+        last_reviewed=date(2026, 5, 11), expires_at=date(2029, 5, 17)
+    )
+    # cadence boundary 2027-05-11 is earlier than the 2029 expiry.
+    assert compute_effective_boundary(cred) == date(2027, 5, 11)
+
+
+def test_effective_boundary_no_expires_at_falls_back_to_cadence():
+    cred = _make_credential(last_reviewed=date(2025, 5, 11), expires_at=None)
+    assert compute_effective_boundary(cred) == date(2026, 5, 11)
+
+
+def test_effective_boundary_expiry_only_non_fixed_interval():
+    """A non-fixed-interval cred with only an expires_at warns off the expiry."""
+    cred = _make_credential(
+        review_cadence="on-revocation", last_reviewed=None, expires_at=date(2026, 9, 1)
+    )
+    assert compute_boundary(cred) is None
+    assert compute_effective_boundary(cred) == date(2026, 9, 1)
+
+
+def test_effective_boundary_none_when_neither_present():
+    cred = _make_credential(
+        review_cadence="on-revocation", last_reviewed=None, expires_at=None
+    )
+    assert compute_effective_boundary(cred) is None
+
+
+def test_effective_boundary_tie_returns_that_date():
+    cred = _make_credential(
+        last_reviewed=date(2026, 7, 22), expires_at=date(2027, 7, 22)
+    )
+    assert compute_effective_boundary(cred) == date(2027, 7, 22)
 
 
 # ---------- is_within_warning_window ----------

--- a/tests/security/test_github_writer.py
+++ b/tests/security/test_github_writer.py
@@ -118,6 +118,35 @@ def test_cadence_body_renders_due_date_one_week_before_boundary():
     assert "due 2026-05-29" in body  # boundary 2026-06-05 minus 7 days
 
 
+def test_cadence_body_surfaces_hard_expiry_when_present():
+    """#852: when the credential declares expires_at, the body shows it and
+    labels the boundary as the earlier of the cadence + hard expiry."""
+    cred = Credential(
+        name="anthropic-test",
+        review_cadence="annual",
+        storage="~/.config/anthropic/test-key",
+        expiry_notes="Rotate the test key.",
+        type="api-token",
+        last_reviewed=date(2026, 7, 22),
+        expires_at=date(2026, 8, 21),
+    )
+    body = cadence_alert_body(
+        cred, date(2026, 8, 21), vikunja_task_id=7, cycle_date=date(2026, 8, 1)
+    )
+    assert "Hard expiry" in body
+    assert "2026-08-21" in body
+    assert "Warning boundary" in body
+    assert "in 20 days" in body
+
+
+def test_cadence_body_omits_hard_expiry_line_when_absent():
+    """A credential with no expires_at renders no Hard expiry line."""
+    body = cadence_alert_body(
+        _credential(), date(2026, 6, 5), vikunja_task_id=42, cycle_date=date(2026, 5, 11)
+    )
+    assert "Hard expiry" not in body
+
+
 def test_cadence_body_includes_rotation_procedure():
     body = cadence_alert_body(
         _credential(),

--- a/tests/security/test_listing.py
+++ b/tests/security/test_listing.py
@@ -130,6 +130,29 @@ def test_build_listings_no_boundary_for_monitor_activity():
     assert listings[0].boundary is None
 
 
+def test_build_listings_uses_effective_boundary_for_expiry():
+    """#852 (renata MED-1): --list must key off the EFFECTIVE boundary so it
+    agrees with the alerter. anthropic-test: annual cadence boundary 2027-07-22
+    but expires_at 2026-08-21 → the row shows the expiry boundary + WARNING."""
+    cred = _cred(
+        name="anthropic-test",
+        last_reviewed=date(2026, 7, 22),  # annual → cadence boundary 2027-07-22
+        expires_at=date(2026, 8, 21),
+    )
+    listings = build_listings([cred], today=date(2026, 8, 1))
+    assert listings[0].boundary == date(2026, 8, 21)  # the earlier (expiry), not 2027
+    assert listings[0].status == "WARNING (20d)"
+
+
+def test_status_for_non_fixed_cadence_with_expiry_uses_boundary():
+    """A non-fixed cadence credential that carries an effective boundary
+    (expires_at) is classified by days-to-boundary, not 'skip'."""
+    cred = _cred(review_cadence="on-revocation", last_reviewed=None,
+                 expires_at=date(2026, 9, 1))
+    status = _status_for(cred, boundary=date(2026, 9, 1), today=date(2026, 8, 20))
+    assert status == "WARNING (12d)"
+
+
 # ---------- render_table ----------
 
 

--- a/tests/security/test_manifest.py
+++ b/tests/security/test_manifest.py
@@ -289,3 +289,32 @@ def test_liveness_probe_non_object_raises(tmp_path, bad):
     cred_dict = {**_BASE_CRED, "liveness_probe": bad}
     with pytest.raises(ManifestQualityError, match="must be an object"):
         read_manifest(_write_manifest(tmp_path, cred_dict))
+
+
+# ---------------------------------------------------------------------------
+# expires_at parsing (#852)
+# ---------------------------------------------------------------------------
+
+
+def test_expires_at_parsed_when_valid(tmp_path):
+    cred_dict = {**_BASE_CRED, "expires_at": "2026-08-21"}
+    well_formed, malformed = read_manifest(_write_manifest(tmp_path, cred_dict))
+    assert malformed == []
+    assert len(well_formed) == 1
+    assert well_formed[0].expires_at is not None
+    assert well_formed[0].expires_at.isoformat() == "2026-08-21"
+
+
+def test_expires_at_absent_is_none(tmp_path):
+    cred_dict = {**_BASE_CRED}  # no expires_at
+    well_formed, _ = read_manifest(_write_manifest(tmp_path, cred_dict))
+    assert well_formed[0].expires_at is None
+
+
+def test_expires_at_unparseable_is_malformed(tmp_path):
+    cred_dict = {**_BASE_CRED, "expires_at": "not-a-date"}
+    well_formed, malformed = read_manifest(_write_manifest(tmp_path, cred_dict))
+    assert well_formed == []
+    assert len(malformed) == 1
+    assert malformed[0].credential_name == _BASE_CRED["name"]
+    assert "expires_at" in malformed[0].reason

--- a/tests/security/test_orchestrator.py
+++ b/tests/security/test_orchestrator.py
@@ -93,6 +93,67 @@ def test_cycle_near_expiry_files_paired_alert():
     assert call_order[1] == "issue"
 
 
+# ---------- expires_at-driven boundary (#852) ----------
+
+
+def _annual_cred_with_expiry(expires_at: date) -> Credential:
+    """Annual cred whose cadence boundary is ~1yr out but has a nearer hard expiry."""
+    return Credential(
+        name="anthropic-test",
+        review_cadence="annual",
+        storage="~/.config/anthropic/test-key",
+        expiry_notes="Rotate the test key in the Anthropic console.",
+        type="api-token",
+        last_reviewed=date(2026, 7, 22),  # annual cadence boundary → 2027-07-22
+        expires_at=expires_at,
+    )
+
+
+def test_cycle_expires_at_within_window_fires_when_cadence_is_far():
+    """#852: a key whose cadence boundary is a year out but whose real expiry is
+    within 30 days MUST fire a cadence alert (it previously passed unwarned)."""
+    cred = _annual_cred_with_expiry(date(2026, 8, 21))
+    p = _patch_paths()
+    with (
+        patch(p["dedup_check"], return_value=[]),
+        patch(p["create_task"], return_value=88) as mock_task,
+        patch(p["create_issue"], return_value=77) as mock_issue,
+        patch(p["load_token"], return_value="t"),
+        patch(p["project_id"], return_value=1),
+        patch(p["MONITOR_ACTIVITY_READERS"], new={}),
+        patch("credential_health_check.orchestrator.read_manifest", return_value=([cred], [])),
+    ):
+        # today = 2026-08-01: 20 days before the 2026-08-21 expiry (inside the
+        # 30-day window) but ~11 months before the 2027-07-22 cadence boundary.
+        result = run_cycle("/fake/manifest.json", today=date(2026, 8, 1))
+    assert result.cadence_alerts_filed == 1
+    mock_task.assert_called_once()
+    mock_issue.assert_called_once()
+    # The alert must be keyed off the EXPIRY boundary, not the cadence boundary.
+    task_boundary = mock_task.call_args.args[1]
+    assert task_boundary == date(2026, 8, 21)
+
+
+def test_cycle_same_cred_without_expiry_does_not_fire():
+    """Negative control: identical cred without expires_at → cadence boundary is
+    far out → no alert. Proves the alert above is driven by expires_at."""
+    cred = _annual_cred_with_expiry(None)  # type: ignore[arg-type]
+    p = _patch_paths()
+    with (
+        patch(p["dedup_check"], return_value=[]),
+        patch(p["create_task"]) as mock_task,
+        patch(p["create_issue"]) as mock_issue,
+        patch(p["load_token"], return_value="t"),
+        patch(p["project_id"], return_value=1),
+        patch(p["MONITOR_ACTIVITY_READERS"], new={}),
+        patch("credential_health_check.orchestrator.read_manifest", return_value=([cred], [])),
+    ):
+        result = run_cycle("/fake/manifest.json", today=date(2026, 8, 1))
+    assert result.cadence_alerts_filed == 0
+    mock_task.assert_not_called()
+    mock_issue.assert_not_called()
+
+
 # ---------- Dedup ----------
 
 

--- a/tests/security/test_whatsapp_signal.py
+++ b/tests/security/test_whatsapp_signal.py
@@ -109,6 +109,85 @@ def test_stale_in_activity_alerts():
     )
 
 
+def test_quiet_no_inbound_returns_none():
+    """#854: a healthy-but-quiet session omits the `in:` token (no recent
+    inbound). That is NOT staleness — with linked+running+connected,
+    health:healthy, and a fresh transport:, the signal must be healthy."""
+    stdout = (FIXTURES / "openclaw-channels-status-quiet-no-inbound.txt").read_text()
+    assert "in:" not in stdout.split("WhatsApp default:", 1)[1]  # fixture really omits in:
+    with patch(
+        "credential_health_check.signals.subprocess.run",
+        return_value=_fake_completed(stdout),
+    ):
+        assert whatsapp_session_signal(_credential()) is None
+
+
+def test_stale_transport_alerts():
+    """#854: when the transport heartbeat itself is stale beyond the 14-day
+    threshold, that IS a genuine liveness failure (even with no in:/out)."""
+    stdout = (
+        "Checking channel status…\nGateway reachable.\n"
+        "- WhatsApp default: enabled, configured, linked, running, connected, "
+        "transport:15d ago, dm:allowlist, allow:+16179300916, health:healthy\n"
+    )
+    with patch(
+        "credential_health_check.signals.subprocess.run",
+        return_value=_fake_completed(stdout),
+    ):
+        failure = whatsapp_session_signal(_credential())
+    assert isinstance(failure, ActivitySignalFailure)
+    assert "transport" in failure.summary.lower()
+    assert "14" in failure.reason
+
+
+def test_health_not_healthy_alerts():
+    """#854: an explicit non-healthy `health:` value is a real failure."""
+    stdout = (
+        "Checking channel status…\nGateway reachable.\n"
+        "- WhatsApp default: enabled, configured, linked, running, connected, "
+        "out:2h ago, transport:1m ago, dm:allowlist, allow:+16179300916, health:degraded\n"
+    )
+    with patch(
+        "credential_health_check.signals.subprocess.run",
+        return_value=_fake_completed(stdout),
+    ):
+        failure = whatsapp_session_signal(_credential())
+    assert isinstance(failure, ActivitySignalFailure)
+    assert "health" in failure.summary.lower()
+    assert "degraded" in failure.reason.lower()
+
+
+def test_healthy_with_health_token_returns_none():
+    """A present `health:healthy` token must not itself cause a failure."""
+    stdout = (
+        "Checking channel status…\nGateway reachable.\n"
+        "- WhatsApp default: enabled, configured, linked, running, connected, "
+        "in:5m ago, out:2h ago, transport:1m ago, dm:allowlist, allow:+16179300916, health:healthy\n"
+    )
+    with patch(
+        "credential_health_check.signals.subprocess.run",
+        return_value=_fake_completed(stdout),
+    ):
+        assert whatsapp_session_signal(_credential()) is None
+
+
+def test_connected_no_timestamps_no_health_is_healthy():
+    """#854 (renata MED-2): the intended behavior for a session that reports
+    linked+running+connected but omits ALL of in:/out:/transport: and any
+    health: token — liveness rests on the bare flags (openclaw drops `connected`
+    when a session truly dies), so this returns None (no false staleness)."""
+    stdout = (
+        "Checking channel status…\nGateway reachable.\n"
+        "- WhatsApp default: enabled, configured, linked, running, connected, "
+        "dm:allowlist, allow:+16179300916\n"
+    )
+    with patch(
+        "credential_health_check.signals.subprocess.run",
+        return_value=_fake_completed(stdout),
+    ):
+        assert whatsapp_session_signal(_credential()) is None
+
+
 def test_subprocess_nonzero_exit_alerts():
     with patch(
         "credential_health_check.signals.subprocess.run",


### PR DESCRIPTION
Two related fixes in `scripts/security/credential_health_check/` (paired per the autopilot queue).

## #854 — WhatsApp false-positive on a missing `in:` token — **Closes #854**

openclaw omits the `in:` token when there's been no recent *inbound* message, but the signal reader treated an absent `in:`/`out:` token as staleness → recurring false "whatsapp-session stale" issues (e.g. #851) on a healthy-but-quiet session.

- A missing directional token is now **non-fatal**; only **present** tokens are checked against the 14-day threshold.
- Parse `transport:` (the traffic-independent liveness heartbeat; checked when present) and `health:<state>` (present + not `healthy` → failure).
- A missing `transport:` is **deliberately not enforced** — older openclaw status output omits it (the existing healthy fixture proves this), so quiet-session liveness rests on `linked`/`running`/`connected` + `health`. Matches #854's stated expected behavior.

## #852 (Part 1 — the boundary bug) — `expires_at` was ignored

The warning boundary was computed purely from `review_cadence`, so a key whose real expiry precedes its cadence review date passed unwarned (`anthropic-test`: expires 2026-08-21 but cadence boundary 2027-07-22 → ~11 months late).

- Added `expires_at` to the `Credential` model + manifest parser (ISO parse + malformed path).
- New `cadence.compute_effective_boundary()` = **the earlier of** the cadence boundary and `expires_at`.
- Orchestrator **and** the `--list` view both key off the effective boundary now (they no longer disagree — renata MED-1). Gate also admits a non-fixed cadence that carries `expires_at` (renata LOW-1).
- Alert body surfaces the hard expiry. The existing Vikunja-task + deduped-GitHub-issue mechanism is reused unchanged.

### ⚠️ #852 is NOT fully closed by this PR

#852's broadened scope (a Kent comment) also asks for a **new ntfy ramping-reminder ladder** (30/14/7/3/1d + daily-overdue, per-rung dedup, new `ntfy_writer` module). That half is **deliberately not in this PR** — it introduces a new push channel + a new persistent per-rung state surface with genuine design latitude (felix-alert-bus vs raw ntfy; where per-rung state lives; overdue-daily dedup keying) that I'm **surfacing to Kent as a follow-up** rather than deciding unattended. **#852 stays open** for that.

## Verification

- Full gate green locally: `make test` (**5998 passed**, 42 skipped), `validate_docs`, `validate_architecture_data`. +20 targeted tests.
- Adversarial review (reviewer-renata): no HIGH findings; MED-1 (`--list` divergence) fixed, MED-2 (`transport` optional) documented + edge test added, LOW-1 (non-fixed + expires_at) closed.

Rebaseline: not required — `scripts/security/**` + `tests/**` are not audited surfaces.

Refs #852 (part 1). Closes #854

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DLvcqgYayz41EYZFsDj5xz