### PR TITLE
feat(security): ramping ntfy expiry-reminder ladder for credential-health-check (#852 Part 2)

### DIFF
--- a/deploys/queued/credential-health-check-alert-bus-env.yaml
+++ b/deploys/queued/credential-health-check-alert-bus-env.yaml
@@ -1,0 +1,43 @@
+schema_version: v1
+name: credential-health-check-alert-bus-env
+issue: kentonium3/kg-automation#852
+tier: 3
+entrypoint: scripts/deploy/deploy-credential-health-check-alert-bus-env.sh
+audited_surface: true
+verification:
+  pre:
+  - test -f scripts/office2/credential-health-check.service
+  - grep -qE "^EnvironmentFile=-/home/claude/[.]config/felix/alert-bus/env" scripts/office2/credential-health-check.service
+  post:
+  - grep -qE "^EnvironmentFile=-/home/claude/[.]config/felix/alert-bus/env" /home/claude/.config/systemd/user/credential-health-check.service
+  - systemctl --user is-active credential-health-check.timer
+  - grep -qE "^FELIX_ALERT_NTFY_TOPIC=.+" /home/claude/.config/felix/alert-bus/env
+created_at: '2026-07-23T10:10:00Z'
+created_by: claude-code-852-part2
+notes: |
+  #852 Part 2 (ramping ntfy expiry-reminder ladder). The new reminder ladder
+  in scripts/security/credential_health_check/reminders.py pushes escalating
+  ntfy alerts (30/14/7/3/1d then daily-once-overdue) through the unified
+  felix-alert bus (#701). The bus only delivers when FELIX_ALERT_NTFY_TOPIC is
+  set; credential-health-check.service previously loaded no alert-bus env-file,
+  so emit() would resolve NTFY_MISSING_TOPIC and the ladder would never fire.
+
+  This re-installs credential-health-check.service (+ .timer, unchanged) into
+  ~/.config/systemd/user/ with the added
+  `EnvironmentFile=-/home/claude/.config/felix/alert-bus/env` line (leading "-"
+  = non-fatal if absent), matching every sibling bus-using service
+  (felix-health-check, felix-canary, agent-prompt-sync, ...). The env-file is
+  already provisioned on office2 by the unified-alert-bus deploy (#701).
+
+  The Python reminder code itself rides the shared checkout self-pull (no copy
+  step); only the systemd unit-content change needs this manifest. The reminder
+  ladder writes its firing ledger to
+  /data/services/openclaw/state/credential-health-check/rungs.jsonl (created at
+  runtime, parents=True; claude owns the state tree).
+
+  Tier 3 (systemd user unit content edit; no Tier 0/1/2 action). oneshot fired
+  by a daily timer, so daemon-reload + enable --now is non-disruptive.
+  audited_surface: true — the unit-content change drifts
+  systemd-user-unit-contents; felix-deployer's deferred-confirm auto-rebaseline
+  fires off the repo-file signal (scripts/office2/*.service), no manual reset.
+  Rollback: remove the EnvironmentFile line and re-run this entrypoint.

--- a/scripts/deploy/deploy-credential-health-check-alert-bus-env.sh
+++ b/scripts/deploy/deploy-credential-health-check-alert-bus-env.sh
@@ -1,0 +1,93 @@
+#!/usr/bin/env bash
+# Deploy entrypoint for credential-health-check alert-bus env wiring (#852 Part 2).
+#
+# The felix-deployer manifest applier (scripts/deploy/lib/apply.py) invokes this
+# entrypoint TWICE: `<entrypoint> --dry-run` (must be non-mutating) then
+# `<entrypoint> --apply` (does the work). It runs the apply inside the shared
+# checkout deploylock, so the unit in the checkout is already at the merged
+# commit before apply.
+#
+# What it deploys: re-installs credential-health-check.service (and .timer,
+# unchanged, for idempotency) into ~/.config/systemd/user/ and reloads the user
+# manager so the running unit gains the EnvironmentFile that loads
+# FELIX_ALERT_NTFY_TOPIC for the unified felix-alert bus (#701). Without it, the
+# #852 ramping expiry-reminder ladder's emit() resolves NTFY_MISSING_TOPIC and
+# never delivers. The service is a oneshot fired by its daily timer; daemon-reload
+# + enable --now is non-disruptive. No sudo (Tier-0 discipline).
+#
+# audited_surface: the systemd unit content change -> the systemd-user-unit-contents
+# baseline drifts. felix-deployer's deferred-confirm auto-rebaseline detects the
+# repo-file signal (scripts/office2/*.service changed) and rebaselines automatically.
+set -euo pipefail
+
+export XDG_RUNTIME_DIR="${XDG_RUNTIME_DIR:-/run/user/$(id -u)}"
+
+REPO_ROOT="$(git rev-parse --show-toplevel 2>/dev/null || echo /home/claude/kg-automation)"
+UNIT_SRC="${REPO_ROOT}/scripts/office2"
+UNIT_DST="${HOME}/.config/systemd/user"
+SERVICE_UNIT="credential-health-check.service"
+TIMER_UNIT="credential-health-check.timer"
+ENV_LINE_RE='^EnvironmentFile=-/home/claude/[.]config/felix/alert-bus/env'
+
+MODE="${1:-}"
+
+fail() { echo "DEPLOY FAILED: $*" >&2; exit 1; }
+
+preflight() {
+  [ -f "${UNIT_SRC}/${SERVICE_UNIT}" ] || fail "unit missing in checkout: ${UNIT_SRC}/${SERVICE_UNIT}"
+  [ -f "${UNIT_SRC}/${TIMER_UNIT}" ] || fail "unit missing in checkout: ${UNIT_SRC}/${TIMER_UNIT}"
+  # Guard: the checkout unit MUST carry the alert-bus EnvironmentFile line, else
+  # deploying it would be a no-op that leaves the ladder inert.
+  grep -qE "${ENV_LINE_RE}" "${UNIT_SRC}/${SERVICE_UNIT}" \
+    || fail "checkout ${SERVICE_UNIT} is missing the alert-bus EnvironmentFile line"
+}
+
+case "${MODE}" in
+  --dry-run)
+    preflight
+    echo "[cred-health alert-bus env] DRY-RUN ok — would: cp ${SERVICE_UNIT}+${TIMER_UNIT} from ${UNIT_SRC} to ${UNIT_DST}; systemctl --user daemon-reload; enable --now ${TIMER_UNIT}; assert deployed ${SERVICE_UNIT} carries the alert-bus EnvironmentFile + timer active."
+    exit 0
+    ;;
+  --apply)
+    : # fall through
+    ;;
+  *)
+    echo "usage: $0 --dry-run | --apply" >&2
+    exit 2
+    ;;
+esac
+
+# ----- --apply -----
+echo "[cred-health alert-bus env] apply: repo_root=${REPO_ROOT}"
+preflight
+
+# 1. Place the unit files.
+mkdir -p "${UNIT_DST}"
+cp "${UNIT_SRC}/${SERVICE_UNIT}" "${UNIT_DST}/"
+cp "${UNIT_SRC}/${TIMER_UNIT}" "${UNIT_DST}/"
+echo "[cred-health alert-bus env] units placed in ${UNIT_DST}"
+
+# 2. Reload the user manager so the new unit definition takes effect.
+systemctl --user daemon-reload || fail "daemon-reload failed (XDG_RUNTIME_DIR=${XDG_RUNTIME_DIR}?)"
+
+# 3. Re-enable the timer (idempotent; non-disruptive to the oneshot service).
+systemctl --user enable --now "${TIMER_UNIT}" || fail "enable --now ${TIMER_UNIT} failed"
+
+# 4. Assert the deployed unit now carries the alert-bus EnvironmentFile line.
+grep -qE "${ENV_LINE_RE}" "${UNIT_DST}/${SERVICE_UNIT}" \
+  || fail "deployed ${SERVICE_UNIT} is missing the alert-bus EnvironmentFile after copy"
+
+# 5. Assert the timer is enabled AND scheduled.
+systemctl --user is-enabled "${TIMER_UNIT}" | grep -q enabled || fail "${TIMER_UNIT} not enabled after enable --now"
+systemctl --user list-timers "${TIMER_UNIT}" --no-pager | grep -q "${TIMER_UNIT}" || fail "${TIMER_UNIT} not in list-timers"
+
+# 6. Deliverability guard: the whole point of this deploy is that the ladder can
+# actually push. Assert the alert-bus env-file exists AND carries a non-empty
+# FELIX_ALERT_NTFY_TOPIC (provisioned by the unified-alert-bus deploy, #701) —
+# otherwise emit() would silently resolve NTFY_MISSING_TOPIC and never deliver,
+# and this deploy would falsely report success.
+ALERT_BUS_ENV="/home/claude/.config/felix/alert-bus/env"
+grep -qE '^FELIX_ALERT_NTFY_TOPIC=.+' "${ALERT_BUS_ENV}" \
+  || fail "alert-bus topic not provisioned: ${ALERT_BUS_ENV} missing a non-empty FELIX_ALERT_NTFY_TOPIC (deploy #701 should have set it)"
+
+echo "[cred-health alert-bus env] OK — deployed unit carries the alert-bus EnvironmentFile; ${TIMER_UNIT} enabled + scheduled; ntfy topic provisioned."

--- a/scripts/office2/credential-health-check.service
+++ b/scripts/office2/credential-health-check.service
@@ -10,3 +10,8 @@ ExecStart=/usr/bin/python3 -m scripts.security.credential_health_check --manifes
 Environment=HOME=/home/claude
 Environment=PYTHONPATH=/home/claude/kg-automation
 WorkingDirectory=/home/claude/kg-automation
+# Load FELIX_ALERT_NTFY_TOPIC for the unified felix-alert bus (#701) so the
+# #852 ramping expiry-reminder ladder can push ntfy. Leading "-" keeps startup
+# non-fatal if the topic env-file is absent (the bus returns NTFY_MISSING_TOPIC
+# instead of failing the run, and the reminder simply retries next cycle).
+EnvironmentFile=-/home/claude/.config/felix/alert-bus/env

--- a/scripts/security/credential_health_check/orchestrator.py
+++ b/scripts/security/credential_health_check/orchestrator.py
@@ -38,6 +38,7 @@ from .manifest import (
     ManifestUnreadableError,
     read_manifest,
 )
+from .reminders import process_expiry_reminder
 from .signals import MONITOR_ACTIVITY_READERS
 from .vikunja_writer import VikunjaWriteError, create_task, load_token
 
@@ -50,6 +51,7 @@ class CycleResult:
     cadence_alerts_filed: int = 0
     staleness_alerts_filed: int = 0
     liveness_alerts_filed: int = 0
+    expiry_reminders_pushed: int = 0
     alerts_deduped: int = 0
     manifest_quality_issue_filed: bool = False
     errors: list[str] = field(default_factory=list)
@@ -172,6 +174,15 @@ def run_cycle(
                             # _process_cadence_alert already logged. The cached state
                             # will remain None and subsequent credentials will retry.
                             pass
+                    # Ramping ntfy reminder ladder (#852 Part 2). Independent of the
+                    # once-filed Vikunja/GitHub artefact above: it re-rings at
+                    # 30/14/7/3/1d then daily-once-overdue via the felix-alert bus,
+                    # deduped per-rung / per-day by its own JSONL ledger. Runs even
+                    # when the GitHub issue already exists (that path deduped).
+                    if process_expiry_reminder(
+                        cred, boundary, today, dry_run=dry_run, logger=logger
+                    ):
+                        result.expiry_reminders_pushed += 1
 
             # Branch B: monitor-activity credentials.
             elif cred.name in MONITOR_ACTIVITY_READERS:
@@ -227,6 +238,7 @@ def run_cycle(
         cadence_filed=result.cadence_alerts_filed,
         staleness_filed=result.staleness_alerts_filed,
         liveness_filed=result.liveness_alerts_filed,
+        expiry_reminders_pushed=result.expiry_reminders_pushed,
         deduped=result.alerts_deduped,
         manifest_quality_filed=result.manifest_quality_issue_filed,
         errors=len(result.errors),

--- a/scripts/security/credential_health_check/reminders.py
+++ b/scripts/security/credential_health_check/reminders.py
@@ -1,0 +1,374 @@
+"""Ramping ntfy reminder ladder for credential expiry (#852 Part 2).
+
+As a credential's *effective boundary* — the earlier of its review-cadence
+boundary and its hard ``expires_at`` (see
+:func:`cadence.compute_effective_boundary`, #852 Part 1) — approaches, this
+fires escalating ntfy pushes through the unified felix-alert bus (#701) at fixed
+rungs (30 / 14 / 7 / 3 / 1 days before), then one push per calendar day once the
+boundary is reached or crossed ("overdue").
+
+Dedup / persistence (both locked design decisions on #852):
+
+- Each rung fires **at most once per ``(credential, boundary)``**. Firing history
+  is persisted to an append-only JSONL ledger so a rung crossed while the service
+  was down is still fired on the next run and never re-fired. If several rungs are
+  crossed in one cycle (e.g. the first run after a long outage), only the *most
+  urgent* crossed rung is pushed and the superseded (less-urgent) rungs are marked
+  consumed so they never back-fire.
+- Once overdue, at most **one push per ``(credential, date)``** (calendar day).
+
+A record is only persisted once the push is actually *delivered* (``result.ok``),
+so a transient ntfy outage retries the same rung on the next daily cycle rather
+than silently swallowing it. When the boundary itself moves (e.g. the credential
+is rotated and ``expires_at`` jumps a year out), the new boundary keys a fresh
+ladder — old rung records no longer match.
+
+The push is DELIBERATELY not linked to the Vikunja task or GitHub issue (#852
+design decision 4): it is a standalone urgency nudge; the durable, trackable work
+item lives in Vikunja + GitHub via the existing cadence-alert path
+(``orchestrator._process_cadence_alert``). This module never files issues/tasks.
+"""
+from __future__ import annotations
+
+import fcntl
+import json
+import logging
+import os
+from datetime import date, datetime, timezone
+from pathlib import Path
+from typing import NamedTuple, Optional
+
+from scripts.common.alert_bus import Alert, Severity, emit
+
+from .manifest import Credential
+
+
+#: Days-before-boundary rungs. Selection (:func:`select`) is order-independent
+#: (filter + ``min``), so this is written descending only for readability.
+REMINDER_RUNGS: tuple[int, ...] = (30, 14, 7, 3, 1)
+
+#: Sentinel rung value for the overdue (boundary reached/crossed) regime.
+OVERDUE_RUNG = "overdue"
+
+#: Where the firing ledger lives on office2. Runtime state — never in the
+#: checkout (gitignored ``scripts/**/state/`` is a *different*, repo-relative
+#: guard; the canonical runtime home is under /data, #855). Overridable via env
+#: for tests / relocation, mirroring the alert-bus ledger (#706).
+DEFAULT_STATE_DIR = "/data/services/openclaw/state/credential-health-check"
+STATE_DIR_ENV = "CREDENTIAL_HEALTH_STATE_DIR"
+RUNGS_FILENAME = "rungs.jsonl"
+
+#: Alert source tag (shows up in the felix-alert ledger + ntfy body).
+ALERT_SOURCE = "credential-health-check/expiry-reminder"
+
+
+def state_dir() -> Path:
+    """Resolve the ledger directory (``CREDENTIAL_HEALTH_STATE_DIR`` or default)."""
+    override = os.environ.get(STATE_DIR_ENV, "").strip()
+    return Path(override) if override else Path(DEFAULT_STATE_DIR)
+
+
+def rungs_path() -> Path:
+    return state_dir() / RUNGS_FILENAME
+
+
+# --------------------------------------------------------------------------- #
+# Persistence (append-only JSONL, torn-write-safe — mirrors alert_bus.ledger)  #
+# --------------------------------------------------------------------------- #
+
+
+class FiredState(NamedTuple):
+    """The set of already-fired dedup keys loaded from the ledger."""
+
+    #: {(credential, boundary_iso, rung_int)}
+    rungs: frozenset[tuple[str, str, int]]
+    #: {(credential, date_iso)}  — note: boundary-independent, per design decision 3
+    overdue_days: frozenset[tuple[str, str]]
+
+    def rung_fired(self, credential: str, boundary: date, rung: int) -> bool:
+        return (credential, boundary.isoformat(), rung) in self.rungs
+
+    def overdue_fired(self, credential: str, day: date) -> bool:
+        return (credential, day.isoformat()) in self.overdue_days
+
+
+def load_fired(path: Optional[Path] = None) -> FiredState:
+    """Read the ledger and build the fired-key sets. Missing file → empty state.
+
+    Malformed lines are skipped defensively (a truncated/partial JSONL line must
+    never crash the daily cycle). A rung record's ``rungs_consumed`` list (all
+    rungs superseded by that fire) is expanded so superseded rungs count as fired.
+    """
+    if path is None:
+        path = rungs_path()
+    rungs: set[tuple[str, str, int]] = set()
+    overdue: set[tuple[str, str]] = set()
+    try:
+        raw = path.read_text(encoding="utf-8")
+    except FileNotFoundError:
+        return FiredState(frozenset(), frozenset())
+    except OSError:
+        # Unreadable ledger: treat as empty (fail toward re-notifying, not silent).
+        return FiredState(frozenset(), frozenset())
+    for line in raw.splitlines():
+        line = line.strip()
+        if not line:
+            continue
+        try:
+            rec = json.loads(line)
+        except json.JSONDecodeError:
+            continue
+        if not isinstance(rec, dict):
+            continue
+        cred = rec.get("credential")
+        if not isinstance(cred, str) or not cred:
+            continue
+        kind = rec.get("kind")
+        if kind == "rung":
+            boundary = rec.get("boundary")
+            if not isinstance(boundary, str):
+                continue
+            consumed = rec.get("rungs_consumed")
+            if not isinstance(consumed, list):
+                fired = rec.get("rung_fired")
+                consumed = [fired] if isinstance(fired, int) else []
+            for r in consumed:
+                if isinstance(r, int) and not isinstance(r, bool):
+                    rungs.add((cred, boundary, r))
+        elif kind == "overdue":
+            day = rec.get("date")
+            if isinstance(day, str):
+                overdue.add((cred, day))
+    return FiredState(frozenset(rungs), frozenset(overdue))
+
+
+def _append_record(record: dict, path: Optional[Path] = None) -> None:
+    """Append one JSON record under an exclusive lock (torn-write-safe)."""
+    if path is None:
+        path = rungs_path()
+    path.parent.mkdir(parents=True, exist_ok=True)
+    line = json.dumps(record, separators=(",", ":")) + "\n"
+    fd = os.open(str(path), os.O_WRONLY | os.O_CREAT | os.O_APPEND, 0o600)
+    try:
+        fcntl.flock(fd, fcntl.LOCK_EX)
+        os.write(fd, line.encode("utf-8"))
+    finally:
+        fcntl.flock(fd, fcntl.LOCK_UN)
+        os.close(fd)
+
+
+# --------------------------------------------------------------------------- #
+# Pure decision + rendering                                                    #
+# --------------------------------------------------------------------------- #
+
+
+class Reminder(NamedTuple):
+    """The single reminder to fire this cycle (or None from :func:`select`)."""
+
+    rung: object  # int rung, or OVERDUE_RUNG
+    days_until: int
+    boundary: date
+    #: For a rung fire: every crossed-and-unfired rung this fire supersedes.
+    rungs_consumed: tuple[int, ...]
+
+
+def select(
+    credential_name: str,
+    boundary: date,
+    today: date,
+    fired: FiredState,
+) -> Optional[Reminder]:
+    """Decide which single reminder (if any) to fire for *credential_name*.
+
+    Pure function — no I/O. Returns None when nothing is due this cycle.
+
+    * ``days_until <= 0`` (boundary reached/crossed) → overdue regime: fire once
+      per calendar day (dedup ``(credential, date)``).
+    * otherwise → fire the most-urgent crossed-and-unfired rung, consuming (and
+      thus silencing) every less-urgent rung also crossed this cycle.
+    """
+    days_until = (boundary - today).days
+    if days_until <= 0:
+        if fired.overdue_fired(credential_name, today):
+            return None
+        return Reminder(OVERDUE_RUNG, days_until, boundary, ())
+
+    crossed = [r for r in REMINDER_RUNGS if days_until <= r]
+    unfired = [r for r in crossed if not fired.rung_fired(credential_name, boundary, r)]
+    if not unfired:
+        return None
+    # Most urgent crossed rung = smallest number of days. Consume all crossed
+    # unfired rungs so the less-urgent ones never back-fire on a later cycle.
+    target = min(unfired)
+    return Reminder(target, days_until, boundary, tuple(sorted(unfired, reverse=True)))
+
+
+def _severity_for(days_until: int) -> Severity:
+    """Map real proximity to the boundary onto ntfy priority.
+
+    Keyed off ``days_until`` (true remaining time) rather than the rung so a
+    *late* first observation after an outage — e.g. fires rung 3 when actually
+    2 days out — still gets the CRITICAL priority its proximity warrants, not
+    the rung's nominal (ERROR) level.
+    """
+    if days_until <= 1:  # boundary day, overdue, or the last day before
+        return Severity.CRITICAL
+    if days_until <= 7:
+        return Severity.ERROR
+    return Severity.WARN  # 8..30 days out
+
+
+def build_alert(credential: Credential, reminder: Reminder) -> Alert:
+    """Render the felix-alert for *reminder*. No Vikunja/GitHub links (decision 4)."""
+    boundary_iso = reminder.boundary.isoformat()
+    if reminder.rung == OVERDUE_RUNG:
+        overdue_by = abs(reminder.days_until)
+        title = f"Credential rotation OVERDUE: {credential.name}"
+        window = (
+            f"Boundary {boundary_iso} reached "
+            + ("today" if overdue_by == 0 else f"{overdue_by} day(s) ago")
+            + "."
+        )
+    else:
+        title = f"Credential rotation due in {reminder.days_until}d: {credential.name}"
+        window = f"Boundary {boundary_iso} — {reminder.days_until} day(s) out."
+    description = (
+        f"Credential '{credential.name}' is due for rotation/review.\n"
+        f"{window}\n"
+        f"Stored at: {credential.storage}"
+    )
+    action = f"Rotate '{credential.name}' before {boundary_iso}."
+    details = {
+        "credential": credential.name,
+        "boundary": boundary_iso,
+        "days_until": str(reminder.days_until),
+        "rung": str(reminder.rung),
+        "storage": credential.storage,
+    }
+    return Alert(
+        source=ALERT_SOURCE,
+        severity=_severity_for(reminder.days_until),
+        title=title,
+        description=description,
+        action=action,
+        details=details,
+    )
+
+
+# --------------------------------------------------------------------------- #
+# Orchestration                                                                #
+# --------------------------------------------------------------------------- #
+
+
+def _build_record(
+    credential: Credential, reminder: Reminder, severity: Severity, today: date
+) -> dict:
+    now = datetime.now(timezone.utc).isoformat()
+    base = {
+        "credential": credential.name,
+        "boundary": reminder.boundary.isoformat(),
+        "days_until": reminder.days_until,
+        "severity": severity.value,
+        "emitted": True,
+        "fired_at": now,
+    }
+    if reminder.rung == OVERDUE_RUNG:
+        # Overdue dedup key is (credential, date) — boundary-independent.
+        base.update({"kind": "overdue", "date": today.isoformat()})
+    else:
+        base.update(
+            {
+                "kind": "rung",
+                "rung_fired": reminder.rung,
+                "rungs_consumed": list(reminder.rungs_consumed),
+            }
+        )
+    return base
+
+
+def process_expiry_reminder(
+    credential: Credential,
+    boundary: date,
+    today: date,
+    *,
+    dry_run: bool,
+    logger: Optional[logging.Logger] = None,
+) -> bool:
+    """Evaluate + (maybe) fire the reminder ladder for one credential.
+
+    Returns True iff a push was delivered (and recorded). Never raises — the
+    alert bus is fail-safe and any ledger error is swallowed so the daily cycle
+    is never crashed by a reminder.
+    """
+    try:
+        fired = load_fired()
+        reminder = select(credential.name, boundary, today, fired)
+        if reminder is None:
+            return False
+
+        severity = _severity_for(reminder.days_until)
+        if dry_run:
+            _log(
+                logger,
+                logging.INFO,
+                "expiry_reminder_would_fire",
+                name=credential.name,
+                rung=reminder.rung,
+                days_until=reminder.days_until,
+                boundary=boundary.isoformat(),
+                severity=severity.value,
+            )
+            return False
+
+        result = emit(build_alert(credential, reminder))
+        if not result.ok:
+            # Not delivered → do NOT persist, so the next daily cycle retries this
+            # rung rather than silently swallowing it.
+            _log(
+                logger,
+                logging.WARNING,
+                "expiry_reminder_delivery_failed",
+                name=credential.name,
+                rung=reminder.rung,
+                days_until=reminder.days_until,
+                reason=result.reason,
+                topic_configured=result.topic_configured,
+            )
+            return False
+
+        # Persist only after a confirmed delivery. If the ledger write itself
+        # fails (disk/permission) this raises, is swallowed below, and the rung
+        # re-fires next cycle → at worst one duplicate ntfy. That is the
+        # deliberate bias: re-notify rather than silently drop.
+        _append_record(_build_record(credential, reminder, severity, today))
+        _log(
+            logger,
+            logging.INFO,
+            "expiry_reminder_fired",
+            name=credential.name,
+            rung=reminder.rung,
+            rungs_consumed=list(reminder.rungs_consumed),
+            days_until=reminder.days_until,
+            boundary=boundary.isoformat(),
+            severity=severity.value,
+        )
+        return True
+    except Exception as e:  # noqa: BLE001 — a reminder must never crash the cycle
+        _log(
+            logger,
+            logging.ERROR,
+            "expiry_reminder_error",
+            name=credential.name,
+            error=str(e),
+        )
+        return False
+
+
+def _log(logger: Optional[logging.Logger], level: int, msg: str, /, **kwargs) -> None:
+    if logger is None:
+        return
+    if kwargs:
+        kv = " ".join(f"{k}={v}" for k, v in kwargs.items())
+        logger.log(level, "%s %s", msg, kv)
+    else:
+        logger.log(level, msg)

--- a/tests/security/conftest.py
+++ b/tests/security/conftest.py
@@ -57,6 +57,23 @@ _SECURITY_MODULES = [
 
 
 @pytest.fixture(autouse=True)
+def isolate_reminder_state(tmp_path, monkeypatch):
+    """Keep the #852 expiry-reminder ladder hermetic in every security test.
+
+    - Redirects its JSONL firing ledger (``CREDENTIAL_HEALTH_STATE_DIR``) to a
+      per-test tmp dir so no test ever reads/writes /data.
+    - Ensures ``FELIX_ALERT_NTFY_TOPIC`` is unset so ``alert_bus.emit`` never
+      attempts a real ntfy POST (it short-circuits to ok=False, no network).
+
+    Returns the state dir so reminder tests can inspect the ledger.
+    """
+    state_dir = tmp_path / "cred-health-state"
+    monkeypatch.setenv("CREDENTIAL_HEALTH_STATE_DIR", str(state_dir))
+    monkeypatch.delenv("FELIX_ALERT_NTFY_TOPIC", raising=False)
+    return state_dir
+
+
+@pytest.fixture(autouse=True)
 def mock_vikunja_base_url(monkeypatch):
     """Prevent get_vikunja_base_url() from reading the config file in tests.
 

--- a/tests/security/test_orchestrator.py
+++ b/tests/security/test_orchestrator.py
@@ -93,6 +93,58 @@ def test_cycle_near_expiry_files_paired_alert():
     assert call_order[1] == "issue"
 
 
+# ---------- expiry reminder ladder wiring (#852 Part 2) ----------
+
+
+def test_cycle_pushes_expiry_reminder_within_window():
+    """The ramping ntfy ladder fires (and is counted) alongside the once-filed
+    Vikunja/GitHub artefact when a credential is inside the warning window."""
+    from credential_health_check import reminders
+    from scripts.common.alert_bus import AlertResult
+
+    p = _patch_paths()
+    with (
+        patch(p["dedup_check"], return_value=[]),
+        patch(p["create_task"], return_value=88),
+        patch(p["create_issue"], return_value=77),
+        patch(p["load_token"], return_value="t"),
+        patch(p["project_id"], return_value=1),
+        patch(p["MONITOR_ACTIVITY_READERS"], new={}),
+        patch.object(
+            reminders, "emit",
+            return_value=AlertResult(ok=True, reason=None, topic_configured=True),
+        ) as mock_emit,
+    ):
+        result = run_cycle(
+            str(FIXTURES / "manifest-near-expiry.json"),
+            today=date(2026, 5, 11),
+        )
+    assert result.expiry_reminders_pushed == 1
+    mock_emit.assert_called_once()
+
+
+def test_cycle_dry_run_does_not_push_reminder():
+    from credential_health_check import reminders
+
+    p = _patch_paths()
+    with (
+        patch(p["dedup_check"], return_value=[]),
+        patch(p["create_task"], return_value=88),
+        patch(p["create_issue"], return_value=77),
+        patch(p["load_token"], return_value="t"),
+        patch(p["project_id"], return_value=1),
+        patch(p["MONITOR_ACTIVITY_READERS"], new={}),
+        patch.object(reminders, "emit") as mock_emit,
+    ):
+        result = run_cycle(
+            str(FIXTURES / "manifest-near-expiry.json"),
+            today=date(2026, 5, 11),
+            dry_run=True,
+        )
+    assert result.expiry_reminders_pushed == 0
+    mock_emit.assert_not_called()
+
+
 # ---------- expires_at-driven boundary (#852) ----------
 
 
@@ -158,6 +210,9 @@ def test_cycle_same_cred_without_expiry_does_not_fire():
 
 
 def test_cycle_dedup_skips_already_open():
+    from credential_health_check import reminders
+    from scripts.common.alert_bus import AlertResult
+
     p = _patch_paths()
     with (
         patch(p["dedup_check"], return_value=[42]),  # any prefix returns an existing issue
@@ -166,6 +221,10 @@ def test_cycle_dedup_skips_already_open():
         patch(p["load_token"], return_value="t"),
         patch(p["project_id"], return_value=1),
         patch(p["MONITOR_ACTIVITY_READERS"], new={}),
+        patch.object(
+            reminders, "emit",
+            return_value=AlertResult(ok=True, reason=None, topic_configured=True),
+        ) as mock_emit,
     ):
         result = run_cycle(
             str(FIXTURES / "manifest-near-expiry.json"),
@@ -175,6 +234,12 @@ def test_cycle_dedup_skips_already_open():
     assert result.alerts_deduped >= 1
     mock_task.assert_not_called()
     mock_issue.assert_not_called()
+    # The ntfy ladder is INDEPENDENT of the once-filed GitHub/Vikunja dedup: it
+    # still rings even when the cadence alert was deduped (design decision — the
+    # push keeps escalating while the durable issue sits open). Locks the
+    # property against a refactor that moves the ladder into the not-deduped path.
+    assert result.expiry_reminders_pushed == 1
+    mock_emit.assert_called_once()
 
 
 # ---------- Vikunja failure ----------

--- a/tests/security/test_reminders.py
+++ b/tests/security/test_reminders.py
@@ -1,0 +1,300 @@
+"""Tests for credential_health_check.reminders — the #852 Part 2 ntfy ladder."""
+from __future__ import annotations
+
+import json
+from datetime import date
+from unittest.mock import patch
+
+import pytest
+
+from credential_health_check.manifest import Credential
+from credential_health_check import reminders
+from credential_health_check.reminders import (
+    OVERDUE_RUNG,
+    FiredState,
+    Reminder,
+    build_alert,
+    load_fired,
+    process_expiry_reminder,
+    select,
+)
+from scripts.common.alert_bus import AlertResult, Severity
+
+
+def _cred(name: str = "anthropic-test") -> Credential:
+    return Credential(
+        name=name,
+        review_cadence="annual",
+        storage="~/.config/anthropic/test-key",
+        expiry_notes="Rotate the test key in the Anthropic console.",
+        type="api-token",
+        last_reviewed=date(2026, 7, 22),
+        expires_at=date(2026, 8, 21),
+    )
+
+
+EMPTY = FiredState(frozenset(), frozenset())
+
+
+# --------------------------------------------------------------------------- #
+# select() — pure decision                                                     #
+# --------------------------------------------------------------------------- #
+
+
+@pytest.mark.parametrize(
+    "days_until,expected_rung",
+    [
+        (31, None),   # outside first rung → nothing
+        (30, 30),     # exactly first rung
+        (29, 30),     # between 30 and 14 → still the 30 rung (crossed, unfired)
+        (14, 14),
+        (7, 7),
+        (3, 3),
+        (1, 1),
+        (0, OVERDUE_RUNG),   # boundary day = overdue regime
+        (-5, OVERDUE_RUNG),  # past boundary
+    ],
+)
+def test_select_rung_boundaries(days_until, expected_rung):
+    boundary = date(2026, 8, 21)
+    today = boundary.fromordinal(boundary.toordinal() - days_until)
+    r = select("anthropic-test", boundary, today, EMPTY)
+    if expected_rung is None:
+        assert r is None
+    else:
+        assert r is not None
+        assert r.rung == expected_rung
+        assert r.days_until == days_until
+
+
+def test_select_dedups_a_fired_rung():
+    boundary = date(2026, 8, 21)
+    today = boundary.fromordinal(boundary.toordinal() - 30)  # days_until == 30
+    fired = FiredState(frozenset({("anthropic-test", boundary.isoformat(), 30)}), frozenset())
+    assert select("anthropic-test", boundary, today, fired) is None
+
+
+def test_select_advances_to_next_rung_after_earlier_fired():
+    boundary = date(2026, 8, 21)
+    today = boundary.fromordinal(boundary.toordinal() - 14)  # days_until == 14
+    fired = FiredState(frozenset({("anthropic-test", boundary.isoformat(), 30)}), frozenset())
+    r = select("anthropic-test", boundary, today, fired)
+    assert r is not None and r.rung == 14
+
+
+def test_select_consumes_all_crossed_rungs_on_first_late_observation():
+    """First run at days_until=5 (e.g. after an outage) fires the most-urgent
+    crossed rung (7) and consumes the superseded 30/14 so they never back-fire."""
+    boundary = date(2026, 8, 21)
+    today = boundary.fromordinal(boundary.toordinal() - 5)  # days_until == 5
+    r = select("anthropic-test", boundary, today, EMPTY)
+    assert r is not None
+    assert r.rung == 7  # most urgent crossed (days_until 5 <= 7)
+    assert set(r.rungs_consumed) == {30, 14, 7}
+
+
+def test_select_overdue_dedups_per_calendar_day():
+    boundary = date(2026, 8, 21)
+    today = date(2026, 8, 25)  # 4 days overdue
+    fired = FiredState(frozenset(), frozenset({("anthropic-test", today.isoformat())}))
+    assert select("anthropic-test", boundary, today, fired) is None
+    # A new day is not deduped.
+    r = select("anthropic-test", boundary, date(2026, 8, 26), fired)
+    assert r is not None and r.rung == OVERDUE_RUNG
+
+
+def test_select_boundary_change_resets_ladder():
+    """After rotation, expires_at jumps out → a new boundary keys a fresh ladder."""
+    old_boundary = date(2026, 8, 21)
+    fired = FiredState(
+        frozenset({("anthropic-test", old_boundary.isoformat(), r) for r in (30, 14, 7, 3, 1)}),
+        frozenset(),
+    )
+    new_boundary = date(2027, 8, 21)
+    today = new_boundary.fromordinal(new_boundary.toordinal() - 30)
+    r = select("anthropic-test", new_boundary, today, fired)
+    assert r is not None and r.rung == 30
+
+
+# --------------------------------------------------------------------------- #
+# Ledger round-trip                                                            #
+# --------------------------------------------------------------------------- #
+
+
+def test_ledger_roundtrip_rung(isolate_reminder_state):
+    reminders._append_record(
+        {
+            "credential": "anthropic-test",
+            "boundary": "2026-08-21",
+            "kind": "rung",
+            "rung_fired": 7,
+            "rungs_consumed": [30, 14, 7],
+            "days_until": 5,
+            "severity": "error",
+            "emitted": True,
+            "fired_at": "2026-08-16T00:00:00+00:00",
+        }
+    )
+    fired = load_fired()
+    b = date(2026, 8, 21)
+    assert fired.rung_fired("anthropic-test", b, 30)
+    assert fired.rung_fired("anthropic-test", b, 14)
+    assert fired.rung_fired("anthropic-test", b, 7)
+    assert not fired.rung_fired("anthropic-test", b, 3)
+
+
+def test_ledger_roundtrip_overdue(isolate_reminder_state):
+    reminders._append_record(
+        {
+            "credential": "anthropic-test",
+            "boundary": "2026-08-21",
+            "kind": "overdue",
+            "date": "2026-08-25",
+            "days_until": -4,
+            "severity": "critical",
+            "emitted": True,
+            "fired_at": "2026-08-25T00:00:00+00:00",
+        }
+    )
+    fired = load_fired()
+    assert fired.overdue_fired("anthropic-test", date(2026, 8, 25))
+    assert not fired.overdue_fired("anthropic-test", date(2026, 8, 26))
+
+
+def test_load_fired_missing_file_is_empty(isolate_reminder_state):
+    assert load_fired() == EMPTY
+
+
+def test_load_fired_skips_malformed_lines(isolate_reminder_state):
+    path = reminders.rungs_path()
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+        "not json\n"
+        + json.dumps({"credential": "x", "boundary": "2026-08-21", "kind": "rung", "rungs_consumed": [7]})
+        + "\n"
+        + json.dumps({"no": "credential"})
+        + "\n",
+        encoding="utf-8",
+    )
+    fired = load_fired()
+    assert fired.rung_fired("x", date(2026, 8, 21), 7)
+
+
+# --------------------------------------------------------------------------- #
+# build_alert()                                                                #
+# --------------------------------------------------------------------------- #
+
+
+def test_build_alert_has_no_vikunja_or_github_link():
+    r = Reminder(7, 5, date(2026, 8, 21), (30, 14, 7))
+    alert = build_alert(_cred(), r)
+    blob = " ".join([alert.title, alert.description, alert.action or "", *alert.details.values()])
+    assert "github.com" not in blob
+    assert "vikunja" not in blob.lower()
+    assert "/tasks/" not in blob
+    assert "issues/" not in blob
+
+
+def test_build_alert_severity_gradient():
+    b = date(2026, 8, 21)
+    assert build_alert(_cred(), Reminder(30, 30, b, (30,))).severity == Severity.WARN
+    assert build_alert(_cred(), Reminder(14, 14, b, (14,))).severity == Severity.WARN
+    assert build_alert(_cred(), Reminder(7, 7, b, (7,))).severity == Severity.ERROR
+    assert build_alert(_cred(), Reminder(3, 3, b, (3,))).severity == Severity.ERROR
+    assert build_alert(_cred(), Reminder(1, 1, b, (1,))).severity == Severity.CRITICAL
+    assert build_alert(_cred(), Reminder(OVERDUE_RUNG, -2, b, ())).severity == Severity.CRITICAL
+
+
+def test_build_alert_severity_tracks_true_proximity_not_rung():
+    """A late first observation fires a distant rung but must carry the priority
+    its real proximity warrants: rung 7 fired at 1 day out → CRITICAL (keying off
+    the rung would wrongly give ERROR)."""
+    b = date(2026, 8, 21)
+    late = Reminder(7, 1, b, (30, 14, 7))  # fired rung 7, but only 1 day out
+    assert build_alert(_cred(), late).severity == Severity.CRITICAL
+
+
+def test_build_alert_overdue_wording():
+    alert = build_alert(_cred(), Reminder(OVERDUE_RUNG, -4, date(2026, 8, 21), ()))
+    assert "OVERDUE" in alert.title
+    assert "4 day(s) ago" in alert.description
+
+
+# --------------------------------------------------------------------------- #
+# process_expiry_reminder() — orchestration                                    #
+# --------------------------------------------------------------------------- #
+
+
+def _ok():
+    return AlertResult(ok=True, reason=None, topic_configured=True)
+
+
+def _fail():
+    return AlertResult(ok=False, reason="NTFY_MISSING_TOPIC", topic_configured=False)
+
+
+def test_process_fires_and_persists_on_delivery(isolate_reminder_state):
+    boundary = date(2026, 8, 21)
+    today = boundary.fromordinal(boundary.toordinal() - 30)
+    with patch.object(reminders, "emit", return_value=_ok()) as mock_emit:
+        pushed = process_expiry_reminder(_cred(), boundary, today, dry_run=False)
+    assert pushed is True
+    mock_emit.assert_called_once()
+    # Persisted → a second call the same cycle is deduped.
+    with patch.object(reminders, "emit", return_value=_ok()) as mock_emit2:
+        again = process_expiry_reminder(_cred(), boundary, today, dry_run=False)
+    assert again is False
+    mock_emit2.assert_not_called()
+
+
+def test_process_does_not_persist_on_delivery_failure(isolate_reminder_state):
+    boundary = date(2026, 8, 21)
+    today = boundary.fromordinal(boundary.toordinal() - 30)
+    with patch.object(reminders, "emit", return_value=_fail()):
+        pushed = process_expiry_reminder(_cred(), boundary, today, dry_run=False)
+    assert pushed is False
+    # Nothing persisted → next cycle retries (emit called again).
+    with patch.object(reminders, "emit", return_value=_ok()) as mock_emit:
+        retry = process_expiry_reminder(_cred(), boundary, today, dry_run=False)
+    assert retry is True
+    mock_emit.assert_called_once()
+
+
+def test_process_dry_run_never_emits_or_persists(isolate_reminder_state):
+    boundary = date(2026, 8, 21)
+    today = boundary.fromordinal(boundary.toordinal() - 30)
+    with patch.object(reminders, "emit") as mock_emit:
+        pushed = process_expiry_reminder(_cred(), boundary, today, dry_run=True)
+    assert pushed is False
+    mock_emit.assert_not_called()
+    assert load_fired() == EMPTY
+
+
+def test_process_nothing_due_returns_false(isolate_reminder_state):
+    boundary = date(2026, 8, 21)
+    today = boundary.fromordinal(boundary.toordinal() - 31)  # outside window
+    with patch.object(reminders, "emit") as mock_emit:
+        pushed = process_expiry_reminder(_cred(), boundary, today, dry_run=False)
+    assert pushed is False
+    mock_emit.assert_not_called()
+
+
+def test_process_swallows_bus_exceptions(isolate_reminder_state):
+    boundary = date(2026, 8, 21)
+    today = boundary.fromordinal(boundary.toordinal() - 30)
+    with patch.object(reminders, "emit", side_effect=RuntimeError("boom")):
+        # Must not raise — a reminder can never crash the daily cycle.
+        pushed = process_expiry_reminder(_cred(), boundary, today, dry_run=False)
+    assert pushed is False
+
+
+def test_process_overdue_fires_daily(isolate_reminder_state):
+    boundary = date(2026, 8, 21)
+    with patch.object(reminders, "emit", return_value=_ok()) as mock_emit:
+        d1 = process_expiry_reminder(_cred(), boundary, date(2026, 8, 22), dry_run=False)
+        d1_again = process_expiry_reminder(_cred(), boundary, date(2026, 8, 22), dry_run=False)
+        d2 = process_expiry_reminder(_cred(), boundary, date(2026, 8, 23), dry_run=False)
+    assert d1 is True
+    assert d1_again is False  # same calendar day deduped
+    assert d2 is True         # next day fires again
+    assert mock_emit.call_count == 2


### PR DESCRIPTION
Implements **#852 Part 2** — the ramping ntfy expiry-reminder ladder. (Part 1, the `expires_at`-aware boundary, already shipped.)

## What
As a credential's **effective boundary** (earlier of the review-cadence boundary and hard `expires_at`, per `cadence.compute_effective_boundary`) approaches, push escalating ntfy reminders through the unified **felix-alert bus (#701)** at **30/14/7/3/1 days** before, then **one push per calendar day once overdue**.

All four locked design decisions are honored:
1. Routes through `alert_bus.emit()` — never raw ntfy.
2. Persistence keyed by `(credential, boundary, rung)` for rungs; `(credential, date)` for overdue days. Ledger: `/data/services/openclaw/state/credential-health-check/rungs.jsonl`.
3. Rungs 30/14/7/3/1 then daily-once-overdue.
4. The ntfy is **not** linked to the Vikunja task / GitHub issue.

## How
- **`reminders.py`** (new): pure rung-selection state machine + torn-write-safe append-only JSONL ledger. A rung crossed during an outage still fires next run and consumes superseded rungs (no back-fire). Records persist **only after a confirmed delivery**, so a transient ntfy outage retries rather than silently dropping. Severity tracks true proximity (`days_until`), not the nominal rung.
- **`orchestrator.py`**: runs the ladder in the within-warning-window branch (skipped in `--liveness-only`), **independent** of the once-filed Vikunja/GitHub dedup — the push keeps escalating while the durable issue sits open.
- **`credential-health-check.service`**: adds `EnvironmentFile=-.../alert-bus/env` so the bus can actually deliver (it previously loaded none → `NTFY_MISSING_TOPIC` → inert).
- **Deploy**: `deploys/queued/credential-health-check-alert-bus-env.yaml` + entrypoint reinstall the unit (Tier 3, audited_surface) with a deliverability post-check that asserts a non-empty `FELIX_ALERT_NTFY_TOPIC`.

## Note for review
The ladder ramps toward the **effective boundary**, so an annual-review-only credential (no hard `expires_at`) also gets ntfy ramping toward its review date — consistent with the Vikunja task the cadence path already files in the same window. Intentional; flag if you'd rather restrict pushes to hard-expiry credentials only.

## Tests
25 new tests (rung math, ledger round-trip, delivery-gated persist, dry-run, fail-safety, overdue daily, orchestrator wiring + ladder-independence). Full security suite: **284 passed**.

Adversarially reviewed (reviewer-renata): no material correctness bug; low/info findings folded.

**Rebaseline:** automatic — felix-deployer deferred-confirm off the `scripts/office2/*.service` repo-file signal when the manifest applies.

🤖 Generated with [Claude Code](https://claude.com/claude-code)