### PR TITLE
fix(#882,#883): retire anthropic-test, record console workspaces

### DIFF
--- a/docs/design/architecture/data/credential-manifest.json
+++ b/docs/design/architecture/data/credential-manifest.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.1",
-  "last_updated": "2026-07-26",
-  "updated_by": "#868 (vikunja-api dormant cadence 'n/a-dormant' → 'n/a' — invalid enum value flagged by credential-health-check) + vikunja-token-seam-kent-cutover-01KY8XQ0 (#860 phase 2, ADR-0007 — vikunja-api/felix-bot retired to dormant/non-runtime; vikunja-api-kent is now the sole runtime Vikunja credential) + anthropic-key-rotation-2026-07-22",
+  "last_updated": "2026-08-09",
+  "updated_by": "#882/#883 (anthropic-test retired after console disable; workspace + console_key_name recorded on both Anthropic entries; two rules added - no Anthropic credentials on the laptop, and record the console workspace) + #868 (vikunja-api dormant cadence 'n/a-dormant' → 'n/a' — invalid enum value flagged by credential-health-check) + vikunja-token-seam-kent-cutover-01KY8XQ0 (#860 phase 2, ADR-0007 — vikunja-api/felix-bot retired to dormant/non-runtime; vikunja-api-kent is now the sole runtime Vikunja credential) + anthropic-key-rotation-2026-07-22",
   "credentials": [
     {
       "name": "vikunja-admin",
@@ -55,6 +55,8 @@
       "scope": "Claude API direct access for OpenClaw agents, the felix-doc-auditor scripts-first driver, and the felix-heartbeat-gate (#490)",
       "storage": "/home/claude/.openclaw/agents/main/agent/openclaw-agent.sqlite (OpenClaw 2026.6+ per-agent SQLite auth store, openclaw-gateway; sub-agents inherit via read-through), /data/services/openclaw/secrets/anthropic (file, 0600 \u2014 primary source for the felix-doc-auditor driver and felix-heartbeat-gate; also the openclaw-gateway backup)",
       "host": "office2",
+      "workspace": "Default",
+      "console_key_name": "kg-felix-openclaw-key-2",
       "used_by": [
         "openclaw-gateway",
         "felix-doc-auditor-driver",
@@ -75,21 +77,23 @@
       "name": "anthropic-test",
       "type": "api-key",
       "scope": "Dedicated test/dev Anthropic API key for spikes and experiments, isolated from production (billing, rate limits, rotation). Console key: felix-test-key-1.",
-      "storage": "/home/claude/.config/felix/anthropic-test.env (file, 0600, claude:claude; sourceable ANTHROPIC_API_KEY=... env format)",
+      "storage": "/home/claude/.config/felix/anthropic-test.env (file, 0600, claude:claude; sourceable ANTHROPIC_API_KEY=... env format). RETIRED: the console key is disabled, so this file holds a dead value - delete it on office2.",
       "host": "office2",
+      "workspace": "Felix-test",
+      "console_key_name": "Felix-test-key-1",
+      "status": "retired",
       "used_by": [
         "spikes-and-tests"
       ],
       "deployed_by": "anthropic-test-key-2026-07-22",
-      "updated_by": "anthropic-test-key-provision-2026-07-22",
-      "last_updated": "2026-07-22",
-      "notes": "Standing test/dev key so spikes never use the production 'anthropic' key. Provisioned per docs/runbooks/security-baseline-ops.md 'Secrets provisioning' (read -rs; never echoed/here-stringed). Verified live HTTP 200 on 2026-07-22. Short-lived by design; extend the expiry at console.anthropic.com or re-mint before the next spike. No production consumer reads this key; spikes source it ad-hoc (e.g. #849 Life Lattice decisive test).",
-      "expiry_policy": "rotate-before-expiry",
-      "expires_at": "2026-08-21",
-      "review_cadence": "annual",
-      "expiry_notes": "felix-test-key-1 created 2026-07-22, expires 2026-08-21 (~30 days). credential-health-check.service warns 30 days ahead — i.e. ~immediately given the short horizon; expected for a short-lived test key. Bump the console expiry to reduce churn, or let it lapse and re-mint before the next spike.",
+      "updated_by": "#882/#883 - console key disabled 2026-08-09; manifest reconciled to console and alert boundary neutralized",
+      "last_updated": "2026-08-09",
+      "notes": "Standing test/dev key so spikes never use the production 'anthropic' key. Provisioned per docs/runbooks/security-baseline-ops.md 'Secrets provisioning' (read -rs; never echoed/here-stringed). Verified live HTTP 200 on 2026-07-22. Short-lived by design; extend the expiry at console.anthropic.com or re-mint before the next spike. No production consumer reads this key; spikes source it ad-hoc (e.g. #849 Life Lattice decisive test). RETIRED 2026-08-09 (#882): the console showed last-used 2026-07-22 - its own provisioning verification - and zero spend, so it was never used after the day it was minted. Disabled in the console rather than deleted, so the row and its dates stay auditable; the #882 investigation was only necessary because a DELETED key leaves no trace. The Felix-test workspace is deliberately kept as the isolation boundary that keeps spike traffic off the production key's billing and rate limits - re-mint into it when a spike actually needs a key.",
+      "expiry_policy": "none",
+      "review_cadence": "n/a",
+      "expiry_notes": "RETIRED 2026-08-09 - no expiry because no live credential. felix-test-key-1 was created 2026-07-22 with a 2026-08-21 expiry and was disabled in the console on 2026-08-09 (#882). expires_at was REMOVED deliberately, not left to lapse: compute_effective_boundary takes the earlier of the cadence boundary and expires_at, and nothing in credential-health-check filters on status, so a retired credential that still carries expires_at keeps climbing the ntfy ladder (#852: 30/14/7/3/1 days, then one push per day once overdue). With review_cadence 'n/a' and no expires_at there is no boundary and the ladder stops. Re-minting a spike key means restoring expires_at and a fixed-interval cadence at the same time.",
       "created_date": "2026-07-22",
-      "last_reviewed": "2026-07-22"
+      "last_reviewed": "2026-08-09"
     },
     {
       "name": "vikunja-api",
@@ -435,6 +439,8 @@
     "No credentials in committed files \u2014 ever",
     "Interactive auth for manual scripts (setup_vikunja.py pattern)",
     "Stored tokens for agent/automated use in office2 scoped secrets store",
-    "Credential names are stable identifiers used across documentation and code"
+    "Credential names are stable identifiers used across documentation and code",
+    "No Anthropic API credentials on the laptop - live tests and spikes run on office2, or source a key ad-hoc for the run. A globally exported key buys nothing (the one live-test consumer, tests/inbox/test_classifier_regression.py, is gated on CLASSIFIER_REGRESSION_LIVE=1 as well as the key) and it prompts every Claude Code session. See #882.",
+    "Record the console workspace for any credential whose provider scopes keys by workspace - a credential that cannot be located in the console cannot be revoked under pressure. See #883."
   ]
 }


### PR DESCRIPTION
Closes the manifest side of #882 and #883. #864 already closed.

Kent disabled `Felix-test-key-1` in the Anthropic console on 2026-08-09. This reconciles the manifest to the console and stops the alert ladder.

### `anthropic-test` -> retired
`status: retired`, `review_cadence: n/a`, `expiry_policy: none`, and **`expires_at` removed**.

That removal is the load-bearing part. `compute_effective_boundary` takes the earlier of the cadence boundary and `expires_at`, and **nothing in credential-health-check filters on `status`** — so retiring the credential while leaving `expires_at: 2026-08-21` would have kept climbing the ntfy ladder (7-day rung 8/14, 3-day 8/18, 1-day 8/20, then one push per calendar day indefinitely) for a key that no longer exists. `vikunja-api` looks quiet only because its expiry is 2029, not because it is retired.

Verified after the change: `compute_effective_boundary(anthropic-test)` returns `None`; `anthropic` unchanged at 2027-07-22.

### Workspaces recorded (#883)
Both Anthropic entries gain `workspace` and `console_key_name`. Tracing one untracked key required opening each workspace by hand and surfaced a `Felix-test` workspace documented nowhere.

No validator change was needed — the only unknown-key rejection is scoped to the `liveness_probe` sub-object, and `STATUS_ENUM` is gated to service-inventory entries.

### Rules
Two added: no Anthropic credentials on the laptop (#882), and record the console workspace for workspace-scoped providers (#883).

### Verification
- `validate_architecture_data`: OK, 0 findings
- `read_manifest`: 19 credentials, 0 quality issues
- `tests/security`: 289 passed
- pre-commit doc validation: passed

⚠ Takes effect on office2 only after it pulls — the checker runs from its own checkout there.